### PR TITLE
Drop the requirement that base64 payloads be URL-safe across the session channel

### DIFF
--- a/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
+++ b/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
@@ -419,7 +419,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
             }
         }
 
-        final JSONArray payloadArr = JsonPack.packByteArraysToBase64UrlArray(payloads);
+        final JSONArray payloadArr = JsonPack.packByteArraysToBase64PayloadsArray(payloads);
         final JSONObject signPayloads = new JSONObject();
         try {
             signPayloads.put(ProtocolContract.PARAMETER_AUTH_TOKEN, authToken);
@@ -453,7 +453,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
 
         final byte[][] payloads;
         try {
-            payloads = JsonPack.unpackBase64UrlArrayToByteArrays(arr);
+            payloads = JsonPack.unpackBase64PayloadsArrayToByteArrays(arr);
         } catch (JSONException e) {
             throw new JsonRpc20InvalidResponseException(paramName + " must be an array of base64url-encoded Strings");
         }
@@ -655,7 +655,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
             }
         }
 
-        final JSONArray payloadArr = JsonPack.packByteArraysToBase64UrlArray(transactions);
+        final JSONArray payloadArr = JsonPack.packByteArraysToBase64PayloadsArray(transactions);
         final JSONObject signAndSendTransaction = new JSONObject();
         try {
             signAndSendTransaction.put(ProtocolContract.PARAMETER_AUTH_TOKEN, authToken);

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/util/JsonPack.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/util/JsonPack.java
@@ -9,24 +9,24 @@ import org.json.JSONException;
 
 public class JsonPack {
     @NonNull
-    public static JSONArray packByteArraysToBase64UrlArray(@NonNull byte[][] byteArrays) {
+    public static JSONArray packByteArraysToBase64PayloadsArray(@NonNull byte[][] byteArrays) {
         final JSONArray arr = new JSONArray();
         for (byte[] byteArray : byteArrays) {
-            final String b64 = Base64.encodeToString(byteArray,
-                    Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+            final String b64 =
+                Base64.encodeToString(byteArray,Base64.NO_WRAP | Base64.NO_PADDING);
             arr.put(b64);
         }
         return arr;
     }
 
     @NonNull
-    public static byte[][] unpackBase64UrlArrayToByteArrays(@NonNull JSONArray arr)
+    public static byte[][] unpackBase64PayloadsArrayToByteArrays(@NonNull JSONArray arr)
             throws JSONException {
         final int numEntries = arr.length();
         final byte[][] byteArrays = new byte[numEntries][];
         for (int i = 0; i < numEntries; i++) {
             final String b64 = arr.getString(i);
-            byteArrays[i] = Base64.decode(b64, Base64.URL_SAFE);
+            byteArrays[i] = Base64.decode(b64, Base64.DEFAULT);
         }
         return byteArrays;
     }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepository.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepository.java
@@ -145,7 +145,7 @@ public class AuthRepository {
     public synchronized AuthRecord fromAuthToken(@NonNull String authToken) {
         final SQLiteDatabase db = ensureStarted();
 
-        final byte[] payload = Base64.decode(authToken, Base64.URL_SAFE);
+        final byte[] payload = Base64.decode(authToken, Base64.DEFAULT);
         if (payload.length < AUTH_TOKEN_HMAC_LENGTH_BYTES) {
             Log.w(TAG, "Invalid auth token");
             return null;
@@ -306,7 +306,7 @@ public class AuthRepository {
 
         Log.v(TAG, "Returning auth token for AuthRecord: " + authRecord);
 
-        return Base64.encodeToString(authToken, Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP);
+        return Base64.encodeToString(authToken,Base64.NO_PADDING | Base64.NO_WRAP);
     }
 
     @NonNull

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -600,7 +600,7 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
 
         final byte[][] payloads;
         try {
-            payloads = JsonPack.unpackBase64UrlArrayToByteArrays(payloadsArray);
+            payloads = JsonPack.unpackBase64PayloadsArrayToByteArrays(payloadsArray);
         } catch (JSONException e) {
             throw new IllegalArgumentException("payloads must be an array of base64url-encoded Strings");
         }
@@ -671,7 +671,7 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             assert(result != null); // checked in SignPayloadRequest.complete()
             assert(result.signedPayloads.length == request.payloads.length); // checked in SignPayloadRequest.complete()
 
-            final JSONArray signedPayloads = JsonPack.packByteArraysToBase64UrlArray(result.signedPayloads);
+            final JSONArray signedPayloads = JsonPack.packByteArraysToBase64PayloadsArray(result.signedPayloads);
             final JSONObject o = new JSONObject();
             try {
                 o.put(ProtocolContract.RESULT_SIGNED_PAYLOADS, signedPayloads);
@@ -834,7 +834,7 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             assert(result != null); // checked in SignPayloadRequest.complete()
             assert(result.signatures.length == request.payloads.length); // checked in SignPayloadRequest.complete()
 
-            final JSONArray signatures = JsonPack.packByteArraysToBase64UrlArray(result.signatures);
+            final JSONArray signatures = JsonPack.packByteArraysToBase64PayloadsArray(result.signatures);
             final JSONObject o = new JSONObject();
             try {
                 o.put(ProtocolContract.RESULT_SIGNATURES, signatures);
@@ -851,7 +851,7 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
     @NonNull
     private String createNotCommittedData(@NonNull @Size(min = 1) byte[][] signatures,
                                           @NonNull @Size(min = 1) boolean[] committed) {
-        final JSONArray signaturesArr = JsonPack.packByteArraysToBase64UrlArray(signatures);
+        final JSONArray signaturesArr = JsonPack.packByteArraysToBase64PayloadsArray(signatures);
         final JSONArray committedArr = JsonPack.packBooleans(committed);
         final JSONObject o = new JSONObject();
         try {


### PR DESCRIPTION
The association token with which we craft the `solana-wallet` intent URL should be URL-safe, but data we transmit over the session channel need not be. Removing this requirement will make it more ergonomic to deal with base64 encoded data in-browser, where the default behavior of `Buffer.toString('base64')` and `btoa()` is to produce non-url-safe base64 strings.