### PR TITLE
Throw correct error when token not found during reauthorize

### DIFF
--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -332,7 +332,10 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
                 result = request.get();
             } catch (ExecutionException e) {
                 final Throwable cause = e.getCause();
-                if (cause instanceof RequestDeclinedException) {
+                if (
+                    cause instanceof AuthTokenNotValidException ||
+                    cause instanceof RequestDeclinedException
+                ) {
                     handleRpcError(request.id, ProtocolContract.ERROR_AUTHORIZATION_FAILED, "reauthorize request failed", null);
                 } else {
                     handleRpcError(request.id, ERROR_INTERNAL, "Error while processing reauthorize request", null);


### PR DESCRIPTION
The spec says that `reauthorize` should throw `ERROR_AUTHORIZATION_FAILED` “if the wallet endpoint declined to renew auth_token for any reason.” When encountering `AuthTokenNotValidException` this code was mistakenly treating that as an internal error.