### PR TITLE
Refactor the clientlib Scenario API

### DIFF
--- a/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
+++ b/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
@@ -36,17 +36,6 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
         mClientTimeoutMs = clientTimeoutMs;
     }
 
-    public static RuntimeException unpackExecutionException(@NonNull ExecutionException e)
-            throws JsonRpc20Exception, TimeoutException {
-        final Throwable cause = e.getCause();
-        if (cause instanceof JsonRpc20Exception) {
-            throw (JsonRpc20Exception) cause;
-        } else if (cause instanceof TimeoutException) {
-            throw (TimeoutException) cause;
-        }
-        return new RuntimeException("Unknown exception while waiting for a JSON-RPC 2.0 response", cause);
-    }
-
     private static abstract class JsonRpc20MethodResultFuture<T> implements Future<T> {
         @NonNull
         protected final NotifyOnCompleteFuture<Object> mMethodCallFuture;
@@ -136,9 +125,9 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     // =============================================================================================
 
     @NonNull
-    public AuthorizeFuture authorizeAsync(@Nullable Uri identityUri,
-                                          @Nullable Uri iconUri,
-                                          @Nullable String identityName)
+    public AuthorizeFuture authorize(@Nullable Uri identityUri,
+                                     @Nullable Uri iconUri,
+                                     @Nullable String identityName)
             throws IOException {
         if (identityUri != null && (!identityUri.isAbsolute() || !identityUri.isHierarchical())) {
             throw new IllegalArgumentException("If non-null, identityUri must be an absolute, hierarchical Uri");
@@ -159,21 +148,6 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
         }
 
         return new AuthorizeFuture(methodCall(ProtocolContract.METHOD_AUTHORIZE, authorize, mClientTimeoutMs));
-    }
-
-    @NonNull
-    public AuthorizeResult authorize(@Nullable Uri identityUri,
-                                     @Nullable Uri iconUri,
-                                     @Nullable String identityName)
-            throws IOException, JsonRpc20Exception, TimeoutException, CancellationException {
-        final AuthorizeFuture future = authorizeAsync(identityUri, iconUri, identityName);
-        try {
-            return future.get();
-        } catch (ExecutionException e) {
-            throw unpackExecutionException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while waiting for authorize response", e);
-        }
     }
 
     public static class AuthorizeResult {
@@ -252,10 +226,10 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     // =============================================================================================
 
     @NonNull
-    public ReauthorizeFuture reauthorizeAsync(@Nullable Uri identityUri,
-                                              @Nullable Uri iconUri,
-                                              @Nullable String identityName,
-                                              @NonNull String authToken)
+    public ReauthorizeFuture reauthorize(@Nullable Uri identityUri,
+                                         @Nullable Uri iconUri,
+                                         @Nullable String identityName,
+                                         @NonNull String authToken)
             throws IOException {
         if (identityUri != null && (!identityUri.isAbsolute() || !identityUri.isHierarchical())) {
             throw new IllegalArgumentException("If non-null, identityUri must be an absolute, hierarchical Uri");
@@ -277,22 +251,6 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
         }
 
         return new ReauthorizeFuture(methodCall(ProtocolContract.METHOD_REAUTHORIZE, reauthorize, mClientTimeoutMs));
-    }
-
-    @NonNull
-    public ReauthorizeResult reauthorize(@Nullable Uri identityUri,
-                                         @Nullable Uri iconUri,
-                                         @Nullable String identityName,
-                                         @NonNull String authToken)
-            throws IOException, JsonRpc20Exception, TimeoutException, CancellationException {
-        final ReauthorizeFuture future = reauthorizeAsync(identityUri, iconUri, identityName, authToken);
-        try {
-            return future.get();
-        } catch (ExecutionException e) {
-            throw unpackExecutionException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while waiting for reauthorize response", e);
-        }
     }
 
     public static class ReauthorizeResult {
@@ -348,7 +306,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     // =============================================================================================
 
     @NonNull
-    public DeauthorizeFuture deauthorizeAsync(@NonNull String authToken)
+    public DeauthorizeFuture deauthorize(@NonNull String authToken)
             throws IOException {
         final JSONObject deauthorize;
         try {
@@ -359,18 +317,6 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
         }
 
         return new DeauthorizeFuture(methodCall(ProtocolContract.METHOD_DEAUTHORIZE, deauthorize, mClientTimeoutMs));
-    }
-
-    public void deauthorize(@NonNull String authToken)
-            throws IOException, JsonRpc20Exception, TimeoutException, CancellationException {
-        final DeauthorizeFuture future = deauthorizeAsync(authToken);
-        try {
-            future.get();
-        } catch (ExecutionException e) {
-            throw unpackExecutionException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while waiting for deauthorize response", e);
-        }
     }
 
     public static class DeauthorizeFuture
@@ -397,23 +343,11 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     // =============================================================================================
 
     @NonNull
-    public GetCapabilitiesFuture getCapabilitiesAsync()
+    public GetCapabilitiesFuture getCapabilities()
             throws IOException {
         final JSONObject params = new JSONObject();
         return new GetCapabilitiesFuture(methodCall(ProtocolContract.METHOD_GET_CAPABILITIES,
                 params, mClientTimeoutMs));
-    }
-
-    public GetCapabilitiesResult getCapabilities()
-            throws IOException, JsonRpc20Exception, TimeoutException, CancellationException {
-        final GetCapabilitiesFuture future = getCapabilitiesAsync();
-        try {
-            return future.get();
-        } catch (ExecutionException e) {
-            throw unpackExecutionException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while waiting for get_capabilities response", e);
-        }
     }
 
     public static class GetCapabilitiesResult {
@@ -496,9 +430,9 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     // =============================================================================================
 
     @NonNull
-    private NotifyOnCompleteFuture<Object> signPayloadAsync(@NonNull String method,
-                                                            @NonNull String authToken,
-                                                            @NonNull @Size(min = 1) byte[][] payloads)
+    private NotifyOnCompleteFuture<Object> signPayload(@NonNull String method,
+                                                       @NonNull String authToken,
+                                                       @NonNull @Size(min = 1) byte[][] payloads)
             throws IOException {
         if (authToken.isEmpty()) {
             throw new IllegalArgumentException("authToken cannot be empty");
@@ -527,7 +461,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
                                                        @NonNull String paramName,
                                                        @IntRange(from = 1) int numExpectedPayloads)
             throws JsonRpc20InvalidResponseException {
-        assert(numExpectedPayloads > 0); // checked with inputs to sign*[Async]
+        assert(numExpectedPayloads > 0); // checked with inputs to sign*
 
         final JSONArray arr;
         try {
@@ -557,7 +491,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
                                                         @NonNull String paramName,
                                                         @IntRange(from = 1) int numExpectedBooleans)
             throws JsonRpc20InvalidResponseException {
-        assert(numExpectedBooleans > 0); // checked with inputs to sign*[Async]
+        assert(numExpectedBooleans > 0); // checked with inputs to sign*
 
         final JSONArray arr;
         try {
@@ -587,7 +521,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
                                                       @NonNull String paramName,
                                                       @IntRange(from = 1) int numExpectedStrings)
             throws JsonRpc20InvalidResponseException {
-        assert(numExpectedStrings > 0); // checked with inputs to sign*[Async]
+        assert(numExpectedStrings > 0); // checked with inputs to sign*
 
         final JSONArray arr;
         try {
@@ -708,26 +642,12 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     // =============================================================================================
 
     @NonNull
-    public SignPayloadFuture signTransactionAsync(@NonNull String authToken,
-                                                  @NonNull @Size(min = 1) byte[][] transactions)
+    public SignPayloadFuture signTransaction(@NonNull String authToken,
+                                             @NonNull @Size(min = 1) byte[][] transactions)
             throws IOException {
         return new SignPayloadFuture(
-                signPayloadAsync(ProtocolContract.METHOD_SIGN_TRANSACTION, authToken, transactions),
+                signPayload(ProtocolContract.METHOD_SIGN_TRANSACTION, authToken, transactions),
                 transactions.length);
-    }
-
-    @NonNull
-    public SignPayloadResult signTransaction(@NonNull String authToken,
-                                             @NonNull @Size(min = 1) byte[][] transactions)
-            throws IOException, JsonRpc20Exception, TimeoutException, CancellationException {
-        final SignPayloadFuture future = signTransactionAsync(authToken, transactions);
-        try {
-            return future.get();
-        } catch (ExecutionException e) {
-            throw unpackExecutionException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while waiting for sign_transaction response", e);
-        }
     }
 
     // =============================================================================================
@@ -735,26 +655,12 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     // =============================================================================================
 
     @NonNull
-    public SignPayloadFuture signMessageAsync(@NonNull String authToken,
-                                              @NonNull @Size(min = 1) byte[][] messages)
+    public SignPayloadFuture signMessage(@NonNull String authToken,
+                                         @NonNull @Size(min = 1) byte[][] messages)
             throws IOException {
         return new SignPayloadFuture(
-                signPayloadAsync(ProtocolContract.METHOD_SIGN_MESSAGE, authToken, messages),
+                signPayload(ProtocolContract.METHOD_SIGN_MESSAGE, authToken, messages),
                 messages.length);
-    }
-
-    @NonNull
-    public SignPayloadResult signMessage(@NonNull String authToken,
-                                         @NonNull @Size(min = 1) byte[][] messages)
-            throws IOException, JsonRpc20Exception, TimeoutException, CancellationException {
-        final SignPayloadFuture future = signMessageAsync(authToken, messages);
-        try {
-            return future.get();
-        } catch (ExecutionException e) {
-            throw unpackExecutionException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while waiting for sign_message response", e);
-        }
     }
 
     // =============================================================================================
@@ -762,12 +668,12 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     // =============================================================================================
 
     @NonNull
-    public SignAndSendTransactionFuture signAndSendTransactionAsync(@NonNull String authToken,
-                                                                    @NonNull @Size(min = 1) byte[][] transactions,
-                                                                    @NonNull CommitmentLevel commitmentLevel,
-                                                                    @Nullable String cluster,
-                                                                    boolean skipPreflight,
-                                                                    @Nullable CommitmentLevel preflightCommitmentLevel)
+    public SignAndSendTransactionFuture signAndSendTransaction(@NonNull String authToken,
+                                                               @NonNull @Size(min = 1) byte[][] transactions,
+                                                               @NonNull CommitmentLevel commitmentLevel,
+                                                               @Nullable String cluster,
+                                                               boolean skipPreflight,
+                                                               @Nullable CommitmentLevel preflightCommitmentLevel)
             throws IOException {
         if (authToken.isEmpty()) {
             throw new IllegalArgumentException("authToken cannot be empty");
@@ -804,38 +710,10 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     }
 
     @NonNull
-    public SignAndSendTransactionFuture signAndSendTransactionAsync(@NonNull String authToken,
-                                                                    @NonNull @Size(min = 1) byte[][] transactions,
-                                                                    @NonNull CommitmentLevel commitmentLevel)
-            throws IOException {
-        return signAndSendTransactionAsync(authToken, transactions, commitmentLevel, null, false, null);
-    }
-
-    @NonNull
-    public SignAndSendTransactionResult signAndSendTransaction(@NonNull String authToken,
-                                                               @NonNull @Size(min = 1) byte[][] transactions,
-                                                               @NonNull CommitmentLevel commitmentLevel,
-                                                               @Nullable String cluster,
-                                                               boolean skipPreflight,
-                                                               @Nullable CommitmentLevel preflightCommitmentLevel)
-            throws IOException, JsonRpc20Exception, TimeoutException, CancellationException {
-        final SignAndSendTransactionFuture future =
-                signAndSendTransactionAsync(authToken, transactions, commitmentLevel,
-                        cluster, skipPreflight, preflightCommitmentLevel);
-        try {
-            return future.get();
-        } catch (ExecutionException e) {
-            throw unpackExecutionException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while waiting for sign_and_send_transaction response", e);
-        }
-    }
-
-    @NonNull
-    public SignAndSendTransactionResult signAndSendTransaction(@NonNull String authToken,
+    public SignAndSendTransactionFuture signAndSendTransaction(@NonNull String authToken,
                                                                @NonNull @Size(min = 1) byte[][] transactions,
                                                                @NonNull CommitmentLevel commitmentLevel)
-            throws IOException, JsonRpc20Exception, TimeoutException, CancellationException {
+            throws IOException {
         return signAndSendTransaction(authToken, transactions, commitmentLevel, null, false, null);
     }
 

--- a/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/Scenario.java
+++ b/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/Scenario.java
@@ -9,29 +9,18 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient;
+import com.solana.mobilewalletadapter.common.util.NotifyOnCompleteFuture;
 
 public abstract class Scenario {
     public static final int DEFAULT_CLIENT_TIMEOUT_MS = 90000;
 
-    @Nullable
-    protected final Callbacks mCallbacks;
-
     @NonNull
     protected final MobileWalletAdapterClient mMobileWalletAdapterClient;
 
-    protected Scenario(@IntRange(from = 0) int clientTimeoutMs,
-                       @Nullable Callbacks callbacks) {
-        mCallbacks = callbacks;
+    protected Scenario(@IntRange(from = 0) int clientTimeoutMs) {
         mMobileWalletAdapterClient = new MobileWalletAdapterClient(clientTimeoutMs);
     }
 
-    public abstract void start();
-    public abstract void close();
-
-    public interface Callbacks {
-        void onScenarioReady(@NonNull MobileWalletAdapterClient client);
-        void onScenarioComplete();
-        void onScenarioError();
-        void onScenarioTeardownComplete();
-    }
+    public abstract NotifyOnCompleteFuture<MobileWalletAdapterClient> start();
+    public abstract NotifyOnCompleteFuture<Void> close();
 }

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
@@ -20,11 +20,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import java.io.IOException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.random.Random
 
@@ -32,7 +32,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _uiState = MutableStateFlow(UiState())
     val uiState = _uiState.asStateFlow()
 
-    private val mobileWalletAdapterClientMutex = Mutex()
+    private val mobileWalletAdapterClientMutex = Mutex() // allow only a single MWA connection at a time
 
     suspend fun authorize(sender: StartActivityForResultSender) {
         localAssociateAndExecute(sender) { client ->
@@ -119,27 +119,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    private suspend fun doAuthorize(client: MobileWalletAdapterClient): Boolean {
+    // NOTE: blocks and waits for completion of remote method call
+    private fun doAuthorize(client: MobileWalletAdapterClient): Boolean {
         var authorized = false
         try {
-            val sem = Semaphore(1, 1)
-            // Note: not actually a blocking call - this check triggers on the thrown IOException,
-            // which occurs when the client is not connected
-            @Suppress("BlockingMethodInNonBlockingContext")
-            val future = client.authorizeAsync(
+            val result = client.authorize(
                 Uri.parse("https://solana.com"),
                 Uri.parse("favicon.ico"),
                 "Solana"
-            )
-            future.notifyOnComplete { sem.release() }
-            sem.acquire()
-            val result = try {
-                // Note: this call won't block, since we've received the completion notification
-                @Suppress("BlockingMethodInNonBlockingContext")
-                future.get()
-            } catch (e: ExecutionException) {
-                throw MobileWalletAdapterClient.unpackExecutionException(e)
-            }
+            ).get()
             Log.d(TAG, "Authorized: $result")
             _uiState.update {
                 it.copy(
@@ -148,327 +136,280 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 )
             }
             authorized = true
-        } catch (e: IOException) {
-            Log.e(TAG, "IO error while sending authorize", e)
-        } catch (e: JsonRpc20Client.JsonRpc20RemoteException) {
-            when (e.code) {
-                ProtocolContract.ERROR_AUTHORIZATION_FAILED -> Log.e(TAG, "Not authorized", e)
-                else -> Log.e(TAG, "Remote exception for authorize", e)
+        } catch (e: ExecutionException) {
+            when (val cause = e.cause) {
+                is IOException -> Log.e(TAG, "IO error while sending authorize", cause)
+                is TimeoutException ->
+                    Log.e(TAG, "Timed out while waiting for authorize result", cause)
+                is JsonRpc20Client.JsonRpc20RemoteException ->
+                    when (cause.code) {
+                        ProtocolContract.ERROR_AUTHORIZATION_FAILED ->
+                            Log.e(TAG, "Not authorized", cause)
+                        else ->
+                            Log.e(TAG, "Remote exception for authorize", cause)
+                    }
+                is JsonRpc20Client.JsonRpc20Exception ->
+                    Log.e(TAG, "JSON-RPC client exception for authorize", cause)
+                else -> throw e
             }
-        } catch (e: JsonRpc20Client.JsonRpc20Exception) {
-            Log.e(TAG, "JSON-RPC client exception for authorize", e)
-        } catch (e: TimeoutException) {
-            Log.e(TAG, "Timed out while waiting for authorize result", e)
         } catch (e: CancellationException) {
             Log.e(TAG, "authorize request was cancelled", e)
+        } catch (e: InterruptedException) {
+            Log.e(TAG, "authorize request was interrupted", e)
         }
 
         return authorized
     }
 
-    private suspend fun doReauthorize(client: MobileWalletAdapterClient): Boolean {
+    // NOTE: blocks and waits for completion of remote method call
+    private fun doReauthorize(client: MobileWalletAdapterClient): Boolean {
         var reauthorized = false
         try {
-            val sem = Semaphore(1, 1)
-            // Note: not actually a blocking call - this check triggers on the thrown IOException,
-            // which occurs when the client is not connected
-            @Suppress("BlockingMethodInNonBlockingContext")
-            val future = client.reauthorizeAsync(
+            val result = client.reauthorize(
                 Uri.parse("https://solana.com"),
                 Uri.parse("favicon.ico"),
                 "Solana",
                 _uiState.value.authToken!!
-            )
-            future.notifyOnComplete { sem.release() }
-            sem.acquire()
-            val result = try {
-                // Note: this call won't block, since we've received the completion notification
-                @Suppress("BlockingMethodInNonBlockingContext")
-                future.get()
-            } catch (e: ExecutionException) {
-                throw MobileWalletAdapterClient.unpackExecutionException(e)
-            }
+            ).get()
             Log.d(TAG, "Reauthorized: $result")
             _uiState.update { it.copy(authToken = result.authToken) }
             reauthorized = true
-        } catch (e: IOException) {
-            Log.e(TAG, "IO error while sending reauthorize", e)
-        } catch (e: JsonRpc20Client.JsonRpc20RemoteException) {
-            when (e.code) {
-                ProtocolContract.ERROR_AUTHORIZATION_FAILED -> {
-                    Log.e(TAG, "Not reauthorized", e)
-                    _uiState.update { it.copy(authToken = null) }
-                }
-                else -> Log.e(TAG, "Remote exception for reauthorize", e)
+        } catch (e: ExecutionException) {
+            when (val cause = e.cause) {
+                is IOException -> Log.e(TAG, "IO error while sending reauthorize", cause)
+                is TimeoutException ->
+                    Log.e(TAG, "Timed out while waiting for reauthorize result", cause)
+                is JsonRpc20Client.JsonRpc20RemoteException ->
+                    when (cause.code) {
+                        ProtocolContract.ERROR_AUTHORIZATION_FAILED -> {
+                            Log.e(TAG, "Not reauthorized", cause)
+                            _uiState.update { it.copy(authToken = null) }
+                        }
+                        else ->
+                            Log.e(TAG, "Remote exception for reauthorize", cause)
+                    }
+                is JsonRpc20Client.JsonRpc20Exception ->
+                    Log.e(TAG, "JSON-RPC client exception for reauthorize", cause)
+                else -> throw e
             }
-        } catch (e: JsonRpc20Client.JsonRpc20Exception) {
-            Log.e(TAG, "JSON-RPC client exception for reauthorize", e)
-        } catch (e: TimeoutException) {
-            Log.e(TAG, "Timed out while waiting for reauthorize result", e)
         } catch (e: CancellationException) {
             Log.e(TAG, "reauthorize request was cancelled", e)
+        } catch (e: InterruptedException) {
+            Log.e(TAG, "reauthorize request was interrupted", e)
         }
 
         return reauthorized
     }
 
-    private suspend fun doDeauthorize(client: MobileWalletAdapterClient): Boolean {
+    // NOTE: blocks and waits for completion of remote method call
+    private fun doDeauthorize(client: MobileWalletAdapterClient): Boolean {
         var deauthorized = false
         try {
-            val sem = Semaphore(1, 1)
-            // Note: not actually a blocking call - this check triggers on the thrown IOException,
-            // which occurs when the client is not connected
-            @Suppress("BlockingMethodInNonBlockingContext")
-            val future = client.deauthorizeAsync(_uiState.value.authToken!!)
-            future.notifyOnComplete { sem.release() }
-            sem.acquire()
-            try {
-                // Note: this call won't block, since we've received the completion notification
-                @Suppress("BlockingMethodInNonBlockingContext")
-                future.get()
-            } catch (e: ExecutionException) {
-                throw MobileWalletAdapterClient.unpackExecutionException(e)
-            }
+            client.deauthorize(_uiState.value.authToken!!).get()
             Log.d(TAG, "Deauthorized")
             _uiState.update { it.copy(authToken = null) }
             deauthorized = true
-        } catch (e: IOException) {
-            Log.e(TAG, "IO error while sending deauthorize", e)
-        } catch (e: JsonRpc20Client.JsonRpc20RemoteException) {
-            Log.e(TAG, "Remote exception for deauthorize", e)
-        } catch (e: JsonRpc20Client.JsonRpc20Exception) {
-            Log.e(TAG, "JSON-RPC client exception for deauthorize", e)
-        } catch (e: TimeoutException) {
-            Log.e(TAG, "Timed out while waiting for deauthorize result", e)
+        } catch (e: ExecutionException) {
+            when (val cause = e.cause) {
+                is IOException -> Log.e(TAG, "IO error while sending deauthorize", cause)
+                is TimeoutException ->
+                    Log.e(TAG, "Timed out while waiting for deauthorize result", cause)
+                is JsonRpc20Client.JsonRpc20RemoteException ->
+                    Log.e(TAG, "Remote exception for deauthorize", cause)
+                is JsonRpc20Client.JsonRpc20Exception ->
+                    Log.e(TAG, "JSON-RPC client exception for deauthorize", cause)
+                else -> throw e
+            }
         } catch (e: CancellationException) {
             Log.e(TAG, "deauthorize request was cancelled", e)
+        } catch (e: InterruptedException) {
+            Log.e(TAG, "deauthorize request was interrupted", e)
         }
 
         return deauthorized
     }
 
-    private suspend fun doGetCapabilities(client: MobileWalletAdapterClient) {
+    // NOTE: blocks and waits for completion of remote method call
+    private fun doGetCapabilities(client: MobileWalletAdapterClient) {
         try {
-            val sem = Semaphore(1, 1)
-            // Note: not actually a blocking call - this check triggers on the thrown IOException,
-            // which occurs when the client is not connected
-            @Suppress("BlockingMethodInNonBlockingContext")
-            val future = client.getCapabilitiesAsync()
-            future.notifyOnComplete { sem.release() }
-            sem.acquire()
-            val result = try {
-                // Note: this call won't block, since we've received the completion notification
-                @Suppress("BlockingMethodInNonBlockingContext")
-                future.get()
-            } catch (e: ExecutionException) {
-                throw MobileWalletAdapterClient.unpackExecutionException(e)
-            }
+            val result = client.getCapabilities().get()
             Log.d(TAG, "Capabilities: $result")
-        } catch (e: IOException) {
-            Log.e(TAG, "IO error while sending get_capabilities", e)
-        } catch (e: JsonRpc20Client.JsonRpc20RemoteException) {
-            Log.e(TAG, "Remote exception for get_capabilities", e)
-        } catch (e: JsonRpc20Client.JsonRpc20Exception) {
-            Log.e(TAG, "JSON-RPC client exception for get_capabilities", e)
-        } catch (e: TimeoutException) {
-            Log.e(TAG, "Timed out while waiting for get_capabilities result", e)
+        } catch (e: ExecutionException) {
+            when (val cause = e.cause) {
+                is IOException -> Log.e(TAG, "IO error while sending get_capabilities", cause)
+                is TimeoutException ->
+                    Log.e(TAG, "Timed out while waiting for get_capabilities result", cause)
+                is JsonRpc20Client.JsonRpc20RemoteException ->
+                    Log.e(TAG, "Remote exception for get_capabilities", cause)
+                is JsonRpc20Client.JsonRpc20Exception ->
+                    Log.e(TAG, "JSON-RPC client exception for get_capabilities", cause)
+                else -> throw e
+            }
         } catch (e: CancellationException) {
             Log.e(TAG, "get_capabilities request was cancelled", e)
+        } catch (e: InterruptedException) {
+            Log.e(TAG, "get_capabilities request was interrupted", e)
         }
     }
 
-    private suspend fun doSignTransaction(
+    // NOTE: blocks and waits for completion of remote method call
+    private fun doSignTransaction(
         client: MobileWalletAdapterClient,
         transactions: Array<ByteArray>
     ): Array<ByteArray>? {
         var signedTransactions: Array<ByteArray>? = null
         try {
-            val sem = Semaphore(1, 1)
-            // Note: not actually a blocking call - this check triggers on the thrown IOException,
-            // which occurs when the client is not connected
-            @Suppress("BlockingMethodInNonBlockingContext")
-            val future = client.signTransactionAsync(uiState.value.authToken!!, transactions)
-            future.notifyOnComplete { sem.release() }
-            sem.acquire()
-            val result = try {
-                // Note: this call won't block, since we've received the completion notification
-                @Suppress("BlockingMethodInNonBlockingContext")
-                future.get()
-            } catch (e: ExecutionException) {
-                throw MobileWalletAdapterClient.unpackExecutionException(e)
-            }
+            val result = client.signTransaction(uiState.value.authToken!!, transactions).get()
             Log.d(TAG, "Signed transaction(s): $result")
             signedTransactions = result.signedPayloads
-        } catch (e: IOException) {
-            Log.e(TAG, "IO error while sending sign_transaction", e)
-        } catch (e: MobileWalletAdapterClient.InvalidPayloadException) {
-            Log.e(TAG, "Transaction payload invalid", e)
-        } catch (e: JsonRpc20Client.JsonRpc20RemoteException) {
-            when (e.code) {
-                ProtocolContract.ERROR_REAUTHORIZE -> Log.e(TAG, "Reauthorization required", e)
-                ProtocolContract.ERROR_AUTHORIZATION_FAILED -> Log.e(TAG, "Auth token invalid", e)
-                ProtocolContract.ERROR_NOT_SIGNED -> Log.e(TAG, "User did not authorize signing", e)
-                ProtocolContract.ERROR_TOO_MANY_PAYLOADS -> Log.e(TAG, "Too many payloads to sign", e)
-                else -> Log.e(TAG, "Remote exception for authorize", e)
+        } catch (e: ExecutionException) {
+            when (val cause = e.cause) {
+                is IOException -> Log.e(TAG, "IO error while sending sign_transaction", cause)
+                is TimeoutException ->
+                    Log.e(TAG, "Timed out while waiting for sign_transaction result", cause)
+                is MobileWalletAdapterClient.InvalidPayloadException ->
+                    Log.e(TAG, "Transaction payload invalid", cause)
+                is JsonRpc20Client.JsonRpc20RemoteException ->
+                    when (cause.code) {
+                        ProtocolContract.ERROR_REAUTHORIZE -> Log.e(TAG, "Reauthorization required", cause)
+                        ProtocolContract.ERROR_AUTHORIZATION_FAILED -> Log.e(TAG, "Auth token invalid", cause)
+                        ProtocolContract.ERROR_NOT_SIGNED -> Log.e(TAG, "User did not authorize signing", cause)
+                        ProtocolContract.ERROR_TOO_MANY_PAYLOADS -> Log.e(TAG, "Too many payloads to sign", cause)
+                        else -> Log.e(TAG, "Remote exception for sign_transaction", cause)
+                    }
+                is JsonRpc20Client.JsonRpc20Exception ->
+                    Log.e(TAG, "JSON-RPC client exception for sign_transaction", cause)
+                else -> throw e
             }
-        } catch (e: JsonRpc20Client.JsonRpc20Exception) {
-            Log.e(TAG, "JSON-RPC client exception for sign_transaction", e)
-        } catch (e: TimeoutException) {
-            Log.e(TAG, "Timed out while waiting for sign_transaction result", e)
         } catch (e: CancellationException) {
             Log.e(TAG, "sign_transaction request was cancelled", e)
+        } catch (e: InterruptedException) {
+            Log.e(TAG, "sign_transaction request was interrupted", e)
         }
+
         return signedTransactions
     }
 
-    private suspend fun doSignMessage(
+    // NOTE: blocks and waits for completion of remote method call
+    private fun doSignMessage(
         client: MobileWalletAdapterClient,
         messages: Array<ByteArray>
     ): Array<ByteArray>? {
         var signedMessages: Array<ByteArray>? = null
         try {
-            val sem = Semaphore(1, 1)
-            // Note: not actually a blocking call - this check triggers on the thrown IOException,
-            // which occurs when the client is not connected
-            @Suppress("BlockingMethodInNonBlockingContext")
-            val future = client.signMessageAsync(uiState.value.authToken!!, messages)
-            future.notifyOnComplete { sem.release() }
-            sem.acquire()
-            val result = try {
-                // Note: this call won't block, since we've received the completion notification
-                @Suppress("BlockingMethodInNonBlockingContext")
-                future.get()
-            } catch (e: ExecutionException) {
-                throw MobileWalletAdapterClient.unpackExecutionException(e)
-            }
+            val result = client.signMessage(uiState.value.authToken!!, messages).get()
             Log.d(TAG, "Signed message(s): $result")
             signedMessages = result.signedPayloads
-        } catch (e: IOException) {
-            Log.e(TAG, "IO error while sending sign_message", e)
-        } catch (e: MobileWalletAdapterClient.InvalidPayloadException) {
-            Log.e(TAG, "Message payload invalid", e)
-        } catch (e: JsonRpc20Client.JsonRpc20RemoteException) {
-            when (e.code) {
-                ProtocolContract.ERROR_REAUTHORIZE -> Log.e(TAG, "Reauthorization required", e)
-                ProtocolContract.ERROR_AUTHORIZATION_FAILED -> Log.e(TAG, "Auth token invalid", e)
-                ProtocolContract.ERROR_NOT_SIGNED -> Log.e(TAG, "User did not authorize signing", e)
-                ProtocolContract.ERROR_TOO_MANY_PAYLOADS -> Log.e(TAG, "Too many payloads to sign", e)
-                else -> Log.e(TAG, "Remote exception for sign_message", e)
+        } catch (e: ExecutionException) {
+            when (val cause = e.cause) {
+                is IOException -> Log.e(TAG, "IO error while sending sign_message", cause)
+                is TimeoutException ->
+                    Log.e(TAG, "Timed out while waiting for sign_message result", cause)
+                is MobileWalletAdapterClient.InvalidPayloadException ->
+                    Log.e(TAG, "Message payload invalid", cause)
+                is JsonRpc20Client.JsonRpc20RemoteException ->
+                    when (cause.code) {
+                        ProtocolContract.ERROR_REAUTHORIZE -> Log.e(TAG, "Reauthorization required", cause)
+                        ProtocolContract.ERROR_AUTHORIZATION_FAILED -> Log.e(TAG, "Auth token invalid", cause)
+                        ProtocolContract.ERROR_NOT_SIGNED -> Log.e(TAG, "User did not authorize signing", cause)
+                        ProtocolContract.ERROR_TOO_MANY_PAYLOADS -> Log.e(TAG, "Too many payloads to sign", cause)
+                        else -> Log.e(TAG, "Remote exception for sign_message", cause)
+                    }
+                is JsonRpc20Client.JsonRpc20Exception ->
+                    Log.e(TAG, "JSON-RPC client exception for sign_message", cause)
+                else -> throw e
             }
-        } catch (e: JsonRpc20Client.JsonRpc20Exception) {
-            Log.e(TAG, "JSON-RPC client exception for sign_message", e)
-        } catch (e: TimeoutException) {
-            Log.e(TAG, "Timed out while waiting for sign_message result", e)
         } catch (e: CancellationException) {
             Log.e(TAG, "sign_message request was cancelled", e)
+        } catch (e: InterruptedException) {
+            Log.e(TAG, "sign_message request was interrupted", e)
         }
+
         return signedMessages
     }
 
-    private suspend fun doSignAndSendTransaction(
+    // NOTE: blocks and waits for completion of remote method call
+    private fun doSignAndSendTransaction(
         client: MobileWalletAdapterClient,
         transactions: Array<ByteArray>
     ): Array<String>? {
         var signatures: Array<String>? = null
         try {
-            val sem = Semaphore(1, 1)
-            // Note: not actually a blocking call - this check triggers on the thrown IOException,
-            // which occurs when the client is not connected
-            @Suppress("BlockingMethodInNonBlockingContext")
-            val future = client.signAndSendTransactionAsync(uiState.value.authToken!!, transactions,
-                CommitmentLevel.Confirmed, ProtocolContract.CLUSTER_TESTNET, false, null)
-            future.notifyOnComplete { sem.release() }
-            sem.acquire()
-            val result = try {
-                // Note: this call won't block, since we've received the completion notification
-                @Suppress("BlockingMethodInNonBlockingContext")
-                future.get()
-            } catch (e: ExecutionException) {
-                throw MobileWalletAdapterClient.unpackExecutionException(e)
-            }
+            val result = client.signAndSendTransaction(
+                uiState.value.authToken!!, transactions,
+                CommitmentLevel.Confirmed, ProtocolContract.CLUSTER_TESTNET, false, null
+            ).get()
             Log.d(TAG, "Signatures: ${result.signatures.contentToString()}")
             signatures = result.signatures
-        } catch (e: IOException) {
-            Log.e(TAG, "IO error while sending sign_and_send_transaction", e)
-        } catch (e: MobileWalletAdapterClient.InvalidPayloadException) {
-            Log.e(TAG, "Transaction payload invalid", e)
-        } catch (e: MobileWalletAdapterClient.NotCommittedException) {
-            Log.e(TAG, "Commitment not reached for all transactions", e)
-            signatures = e.signatures
-        } catch (e: JsonRpc20Client.JsonRpc20RemoteException) {
-            when (e.code) {
-                ProtocolContract.ERROR_REAUTHORIZE -> Log.e(TAG, "Reauthorization required", e)
-                ProtocolContract.ERROR_AUTHORIZATION_FAILED -> Log.e(TAG, "Auth token invalid", e)
-                ProtocolContract.ERROR_NOT_SIGNED -> Log.e(TAG, "User did not authorize signing", e)
-                ProtocolContract.ERROR_TOO_MANY_PAYLOADS -> Log.e(TAG, "Too many payloads to sign", e)
-                else -> Log.e(TAG, "Remote exception for authorize", e)
+        } catch (e: ExecutionException) {
+            when (val cause = e.cause) {
+                is IOException ->
+                    Log.e(TAG, "IO error while sending sign_and_send_transaction", cause)
+                is TimeoutException ->
+                    Log.e(TAG, "Timed out while waiting for sign_and_send_transaction result", cause)
+                is MobileWalletAdapterClient.InvalidPayloadException ->
+                    Log.e(TAG, "Transaction payload invalid", cause)
+                is MobileWalletAdapterClient.NotCommittedException -> {
+                    Log.e(TAG, "Commitment not reached for all transactions", cause)
+                    signatures = cause.signatures
+                }
+                is JsonRpc20Client.JsonRpc20RemoteException ->
+                    when (cause.code) {
+                        ProtocolContract.ERROR_REAUTHORIZE -> Log.e(TAG, "Reauthorization required", cause)
+                        ProtocolContract.ERROR_AUTHORIZATION_FAILED -> Log.e(TAG, "Auth token invalid", cause)
+                        ProtocolContract.ERROR_NOT_SIGNED -> Log.e(TAG, "User did not authorize signing", cause)
+                        ProtocolContract.ERROR_TOO_MANY_PAYLOADS -> Log.e(TAG, "Too many payloads to sign", cause)
+                        else -> Log.e(TAG, "Remote exception for sign_and_send_transaction", cause)
+                    }
+                is JsonRpc20Client.JsonRpc20Exception ->
+                    Log.e(TAG, "JSON-RPC client exception for sign_and_send_transaction", cause)
+                else -> throw e
             }
-        } catch (e: JsonRpc20Client.JsonRpc20Exception) {
-            Log.e(TAG, "JSON-RPC client exception for sign_and_send_transaction", e)
-        } catch (e: TimeoutException) {
-            Log.e(TAG, "Timed out while waiting for sign_and_send_transaction result", e)
         } catch (e: CancellationException) {
             Log.e(TAG, "sign_and_send_transaction request was cancelled", e)
+        } catch (e: InterruptedException) {
+            Log.e(TAG, "sign_and_send_transaction request was interrupted", e)
         }
+
         return signatures
     }
 
     private suspend fun <T> localAssociateAndExecute(
         sender: StartActivityForResultSender,
         uriPrefix: Uri? = null,
-        action: suspend (MobileWalletAdapterClient) -> T?
+        action: (MobileWalletAdapterClient) -> T?
     ): T? {
         return mobileWalletAdapterClientMutex.withLock {
-            val semConnectedOrFailed = Semaphore(1, 1)
-            val semTerminated = Semaphore(1, 1)
-            var mobileWalletAdapterClient: MobileWalletAdapterClient? = null
-            val scenarioCallbacks = object : Scenario.Callbacks {
-                override fun onScenarioReady(client: MobileWalletAdapterClient) {
-                    mobileWalletAdapterClient = client
-                    semConnectedOrFailed.release()
-                }
-
-                override fun onScenarioError() = semConnectedOrFailed.release()
-                override fun onScenarioComplete() = semConnectedOrFailed.release()
-                override fun onScenarioTeardownComplete() = semTerminated.release()
-            }
-
             val localAssociation = LocalAssociationScenario(
                 getApplication<Application>().mainLooper,
                 Scenario.DEFAULT_CLIENT_TIMEOUT_MS,
-                scenarioCallbacks,
                 uriPrefix
             )
             sender.startActivityForResult(localAssociation.createAssociationIntent())
 
-            localAssociation.start()
-            try {
-                withTimeout(ASSOCIATION_TIMEOUT_MS) {
-                    semConnectedOrFailed.acquire()
+            return@withLock withContext(Dispatchers.IO) {
+                val mobileWalletAdapterClient = try {
+                    @Suppress("BlockingMethodInNonBlockingContext") // running in Dispatchers.IO; blocking is appropriate
+                    localAssociation.start().get(ASSOCIATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                } catch (e: InterruptedException) {
+                    Log.w(TAG, "Interrupted while waiting for local association to be ready")
+                    return@withContext null
+                } catch (e: TimeoutException) {
+                    Log.e(TAG, "Timed out waiting for local association to be ready")
+                    return@withContext null
+                } catch (e: ExecutionException) {
+                    Log.e(TAG, "Failed establishing local association with wallet", e.cause)
+                    return@withContext null
                 }
-            } catch (e: TimeoutCancellationException) {
-                Log.e(TAG, "Timed out waiting for local association to be ready", e)
-                // Let garbage collection deal with cleanup; if we timed out starting, we might
-                // hang if we attempt to close.
-                return@withLock null
-            }
 
-            val result = mobileWalletAdapterClient?.let { client -> action(client) } ?: run {
-                Log.e(TAG, "Local association not ready; skip requested action")
-                null
-            }
+                // NOTE: this is a blocking method call, appropriate in the Dispatchers.IO context
+                val result = action(mobileWalletAdapterClient)
 
-            localAssociation.close()
-            try {
-                withTimeout(ASSOCIATION_TIMEOUT_MS) {
-                    semTerminated.acquire()
-                }
-            } catch (e: TimeoutCancellationException) {
-                Log.e(TAG, "Timed out waiting for local association to close", e)
-                return@withLock null
-            }
+                @Suppress("BlockingMethodInNonBlockingContext") // running in Dispatchers.IO; blocking is appropriate
+                localAssociation.close().get(ASSOCIATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
 
-            result
+                result
+            }
         }
     }
 


### PR DESCRIPTION
- Remove the callbacks
- Make the start() and close() methods consumable in either an async or blocking manner with notifiable futures
- Use the straightforward blocking paradigm in fakedapp as a more representative usage sample