### PR TITLE
Adding Rx convenience MobileWalletAdapter APIs

### DIFF
--- a/android/clientlib-rxjava/build.gradle
+++ b/android/clientlib-rxjava/build.gradle
@@ -19,9 +19,11 @@ android {
 }
 
 dependencies {
-    compileOnly 'androidx.annotation:annotation:1.4.0'
+    compileOnly "androidx.annotation:annotation:1.4.0"
 
     api(project(":clientlib"))
 
     implementation "io.reactivex.rxjava2:rxjava:2.2.21"
+    implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
+
 }

--- a/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/RxMobileWalletAdapter.java
+++ b/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/RxMobileWalletAdapter.java
@@ -1,0 +1,6 @@
+package com.solana.mobilewalletadapter.clientlib;
+
+public class RxMobileWalletAdapter {
+
+
+}

--- a/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/RxMobileWalletAdapter.java
+++ b/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/RxMobileWalletAdapter.java
@@ -1,6 +1,158 @@
 package com.solana.mobilewalletadapter.clientlib;
 
+import android.net.Uri;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.Size;
+
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.AuthorizeResult;
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.ReauthorizeResult;
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignAndSendTransactionResult;
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignPayloadResult;
+import com.solana.mobilewalletadapter.clientlib.scenario.RxLocalAssociationScenario;
+import com.solana.mobilewalletadapter.common.protocol.CommitmentLevel;
+
+import io.reactivex.Completable;
+import io.reactivex.Single;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+
 public class RxMobileWalletAdapter {
 
+    @NonNull
+    private final RxLocalAssociationScenario mRxLocalAssociationScenario;
 
+    public RxMobileWalletAdapter(@IntRange(from = 0) int clientTimeoutMs) {
+        this.mRxLocalAssociationScenario = new RxLocalAssociationScenario(clientTimeoutMs);
+    }
+
+    @CheckResult
+    @NonNull
+    public Single<AuthorizeResult> authorize(@Nullable Uri identityUri,
+                                             @Nullable Uri iconUri,
+                                             @Nullable String identityName) {
+        return mRxLocalAssociationScenario
+                .start()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMap(rxMobileWalletAdapterClient ->
+                        rxMobileWalletAdapterClient.authorize(identityUri, iconUri, identityName)
+                )
+                .zipWith(
+                        mRxLocalAssociationScenario.close().toSingle(() -> true),
+                        ((authorizeResult, b) -> authorizeResult)
+                );
+    }
+
+    @CheckResult
+    @NonNull
+    public Single<ReauthorizeResult> reauthorize(@Nullable Uri identityUri,
+                                                 @Nullable Uri iconUri,
+                                                 @Nullable String identityName,
+                                                 @NonNull String authToken) {
+        return mRxLocalAssociationScenario
+                .start()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMap(rxMobileWalletAdapterClient ->
+                        rxMobileWalletAdapterClient.reauthorize(identityUri, iconUri, identityName, authToken)
+                )
+                .zipWith(
+                        mRxLocalAssociationScenario.close().toSingle(() -> true),
+                        ((authorizeResult, b) -> authorizeResult)
+                );
+    }
+
+    @CheckResult
+    @NonNull
+    public Completable deauthorize(@NonNull String authToken) {
+        return mRxLocalAssociationScenario
+                .start()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMapCompletable(rxMobileWalletAdapterClient ->
+                        rxMobileWalletAdapterClient.deauthorize(authToken)
+                )
+                .andThen(mRxLocalAssociationScenario.close());
+    }
+
+    @CheckResult
+    @NonNull
+    public Single<SignPayloadResult> signTransaction(@NonNull String authToken,
+                                                     @NonNull @Size(min = 1) byte[][] transactions) {
+        return mRxLocalAssociationScenario
+                .start()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMap(rxMobileWalletAdapterClient ->
+                        rxMobileWalletAdapterClient.signTransaction(authToken, transactions)
+                )
+                .zipWith(
+                        mRxLocalAssociationScenario.close().toSingle(() -> true),
+                        ((authorizeResult, b) -> authorizeResult)
+                );
+    }
+
+    @CheckResult
+    @NonNull
+    public Single<SignPayloadResult> signMessage(@NonNull String authToken,
+                                                 @NonNull @Size(min = 1) byte[][] messages) {
+        return mRxLocalAssociationScenario
+                .start()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMap(rxMobileWalletAdapterClient ->
+                        rxMobileWalletAdapterClient.signMessage(authToken, messages)
+                )
+                .zipWith(
+                        mRxLocalAssociationScenario.close().toSingle(() -> true),
+                        ((authorizeResult, b) -> authorizeResult)
+                );
+    }
+
+    @CheckResult
+    @NonNull
+    public Single<SignAndSendTransactionResult> signAndSendTransaction(@NonNull String authToken,
+                                                                       @NonNull @Size(min = 1) byte[][] transactions,
+                                                                       @NonNull CommitmentLevel commitmentLevel,
+                                                                       @Nullable String cluster,
+                                                                       boolean skipPreflight,
+                                                                       @Nullable CommitmentLevel preflightCommitmentLevel) {
+        return mRxLocalAssociationScenario
+                .start()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMap(rxMobileWalletAdapterClient ->
+                        rxMobileWalletAdapterClient.signAndSendTransaction(
+                                authToken, transactions, commitmentLevel, cluster, skipPreflight, preflightCommitmentLevel
+                        )
+                )
+                .zipWith(
+                        mRxLocalAssociationScenario.close().toSingle(() -> true),
+                        ((authorizeResult, b) -> authorizeResult)
+                );
+    }
+
+    @CheckResult
+    @NonNull
+    public Single<SignAndSendTransactionResult> signAndSendTransaction(@NonNull String authToken,
+                                                                       @NonNull @Size(min = 1) byte[][] transactions,
+                                                                       @NonNull CommitmentLevel commitmentLevel) {
+        return mRxLocalAssociationScenario
+                .start()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .flatMap(rxMobileWalletAdapterClient ->
+                        rxMobileWalletAdapterClient.signAndSendTransaction(
+                                authToken, transactions, commitmentLevel
+                        )
+                )
+                .zipWith(
+                        mRxLocalAssociationScenario.close().toSingle(() -> true),
+                        ((authorizeResult, b) -> authorizeResult)
+                );
+    }
 }

--- a/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/RxMobileWalletAdapterClient.java
+++ b/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/RxMobileWalletAdapterClient.java
@@ -31,6 +31,10 @@ public class RxMobileWalletAdapterClient {
         mMobileWalletAdapterClient = new MobileWalletAdapterClient(clientTimeoutMs);
     }
 
+    public RxMobileWalletAdapterClient(@NonNull MobileWalletAdapterClient mobileWalletAdapterClient) {
+        mMobileWalletAdapterClient = mobileWalletAdapterClient;
+    }
+
     @CheckResult
     @NonNull
     public Single<AuthorizeResult> authorize(@Nullable Uri identityUri,

--- a/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/RxLocalAssociationScenario.java
+++ b/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/RxLocalAssociationScenario.java
@@ -4,7 +4,7 @@ import androidx.annotation.CheckResult;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 
-import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient;
+import com.solana.mobilewalletadapter.clientlib.protocol.RxMobileWalletAdapterClient;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
@@ -20,8 +20,9 @@ public class RxLocalAssociationScenario {
 
     @CheckResult
     @NonNull
-    public Single<MobileWalletAdapterClient> start() {
-        return Single.fromFuture(mLocalAssociationScenario.start());
+    public Single<RxMobileWalletAdapterClient> start() {
+        return Single.fromFuture(mLocalAssociationScenario.start())
+                .map(RxMobileWalletAdapterClient::new);
     }
 
     @CheckResult

--- a/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/RxLocalAssociationScenario.java
+++ b/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/RxLocalAssociationScenario.java
@@ -1,0 +1,32 @@
+package com.solana.mobilewalletadapter.clientlib.scenario;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient;
+
+import io.reactivex.Completable;
+import io.reactivex.Single;
+
+public class RxLocalAssociationScenario {
+
+    @NonNull
+    private final LocalAssociationScenario mLocalAssociationScenario;
+
+    public RxLocalAssociationScenario(@IntRange(from = 0) int clientTimeoutMs) {
+        this.mLocalAssociationScenario = new LocalAssociationScenario(clientTimeoutMs);
+    }
+
+    @CheckResult
+    @NonNull
+    public Single<MobileWalletAdapterClient> start() {
+        return Single.fromFuture(mLocalAssociationScenario.start());
+    }
+
+    @CheckResult
+    @NonNull
+    public Completable close() {
+        return Completable.fromFuture(mLocalAssociationScenario.close());
+    }
+}


### PR DESCRIPTION
To match the coroutines APIs which are allowing devs to map the whole flow (start/action/close) into a single...Single 😁 