### PR TITLE
fix: rename JS wallet API to more closely match upcoming Kotlin API

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/README.md
+++ b/js/packages/mobile-wallet-adapter-protocol/README.md
@@ -9,17 +9,17 @@ If you are simply looking to integrate a JavaScript application with mobile wall
 Use this API to start a session:
 
 ```typescript
-import {withLocalWallet} from '@solana-mobile/mobile-wallet-adapter-protocol';
+import {transact} from '@solana-mobile/mobile-wallet-adapter-protocol';
 
-await withLocalWallet(async (wallet) => {
+await transact(async (wallet) => {
     /* ... */
 });
 ```
 
-The callback you provide will be called once a session has been established with a wallet. It will recieve the `MobileWallet` API as an argument. You can call protocol-specified methods using this function. Whatever you return from this callback will be returned by `withLocalWallet`.
+The callback you provide will be called once a session has been established with a wallet. It will recieve the `MobileWallet` API as an argument. You can call protocol-specified methods using this function. Whatever you return from this callback will be returned by `transact`.
 
 ```typescript
-const signedPayloads = await withLocalWallet(async (wallet) => {
+const signedPayloads = await transact(async (wallet) => {
     const {signed_payloads} = await wallet('sign_message', {
         auth_token,
         payloads: [/* ... */],
@@ -36,7 +36,7 @@ You can catch exceptions at any level. See `errors.ts` for a list of exceptions 
 
 ```typescript
 try {
-    await withLocalWallet(async (wallet) => {
+    await transact(async (wallet) => {
         try {
             await wallet('sign_transaction', /* ... */);
         } catch (e) {

--- a/js/packages/mobile-wallet-adapter-protocol/src/__forks__/react-native/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/__forks__/react-native/transact.ts
@@ -1,7 +1,7 @@
 import { NativeModules, Platform } from 'react-native';
 
 import { SolanaMobileWalletAdapterProtocolJsonRpcError } from '../../errors';
-import { MobileWallet, WalletAssociationConfig } from '../../types';
+import { MobileWalletAPI, WalletAssociationConfig } from '../../types';
 
 const LINKING_ERROR =
     `The package 'solana-mobile-wallet-adapter-protocol' doesn't seem to be linked. Make sure: \n\n` +
@@ -27,8 +27,8 @@ const SolanaMobileWalletAdapter =
               },
           );
 
-export default async function withLocalWallet<TReturn>(
-    callback: (wallet: MobileWallet) => TReturn,
+export async function transact<TReturn>(
+    callback: (walletAPI: MobileWalletAPI) => TReturn,
     config?: WalletAssociationConfig,
 ): Promise<TReturn> {
     try {

--- a/js/packages/mobile-wallet-adapter-protocol/src/index.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/index.ts
@@ -1,3 +1,3 @@
-export { default as withLocalWallet } from './withLocalWallet';
 export * from './errors';
+export * from './transact';
 export * from './types';

--- a/js/packages/mobile-wallet-adapter-protocol/src/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/transact.ts
@@ -10,7 +10,7 @@ import generateECDHKeypair from './generateECDHKeypair';
 import { decryptJsonRpcMessage, encryptJsonRpcMessage } from './jsonRpcMessage';
 import parseHelloRsp, { SharedSecret } from './parseHelloRsp';
 import { startSession } from './startSession';
-import { AssociationKeypair, MobileWallet, WalletAssociationConfig } from './types';
+import { AssociationKeypair, MobileWalletAPI, WalletAssociationConfig } from './types';
 
 const WEBSOCKET_CONNECTION_CONFIG = {
     maxAttempts: 34,
@@ -42,8 +42,8 @@ function assertSecureContext() {
     }
 }
 
-export default async function withLocalWallet<TReturn>(
-    callback: (wallet: MobileWallet) => TReturn,
+export async function transact<TReturn>(
+    callback: (walletAPI: MobileWalletAPI) => TReturn,
     config?: WalletAssociationConfig,
 ): Promise<TReturn> {
     assertSecureContext();
@@ -120,7 +120,7 @@ export default async function withLocalWallet<TReturn>(
                         state.ecdhPrivateKey,
                     );
                     state = { __type: 'connected', sharedSecret };
-                    const wallet: MobileWallet = async (method, params) => {
+                    const walletAPI: MobileWalletAPI = async (method, params) => {
                         const id = nextJsonRpcMessageId++;
                         socket.send(
                             await encryptJsonRpcMessage(
@@ -138,7 +138,7 @@ export default async function withLocalWallet<TReturn>(
                         });
                     };
                     try {
-                        resolve(await callback(wallet));
+                        resolve(await callback(walletAPI));
                     } catch (e) {
                         reject(e);
                     } finally {

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -43,7 +43,7 @@ export type WalletAssociationConfig = Readonly<{
     baseUri?: string;
 }>;
 
-export interface MobileWallet {
+export interface MobileWalletAPI {
     (method: 'authorize', params: { identity: AppIdentity }): Promise<
         Readonly<{
             auth_token: AuthToken;


### PR DESCRIPTION
We're moving toward the API being:

```
transact(walletAPI => { /* ... */ });
```

…to leave open the future for an API like

```
transact.usingRemoteWallet(remoteConfig, walletAPI => { /* ... */ });
````