### PR TITLE
A few misc fixes and cleanups

### DIFF
--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
@@ -29,18 +29,20 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 viewModel.uiState.collect { uiState ->
-                    viewBinding.btnReauthorize.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnDeauthorize.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnRequestAirdrop.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignTxnX1.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignTxnX3.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignTxnX20.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignMsgX1.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignMsgX3.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignMsgX20.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignAndSendTxnX1.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignAndSendTxnX3.isEnabled = uiState.hasAuthToken
-                    viewBinding.btnSignAndSendTxnX20.isEnabled = uiState.hasAuthToken
+                    uiState.hasAuthToken.let { isAuthorized ->
+                        viewBinding.btnReauthorize.isEnabled = isAuthorized
+                        viewBinding.btnDeauthorize.isEnabled = isAuthorized
+                        viewBinding.btnRequestAirdrop.isEnabled = isAuthorized
+                        viewBinding.btnSignTxnX1.isEnabled = isAuthorized
+                        viewBinding.btnSignTxnX3.isEnabled = isAuthorized
+                        viewBinding.btnSignTxnX20.isEnabled = isAuthorized
+                        viewBinding.btnSignMsgX1.isEnabled = isAuthorized
+                        viewBinding.btnSignMsgX3.isEnabled = isAuthorized
+                        viewBinding.btnSignMsgX20.isEnabled = isAuthorized
+                        viewBinding.btnSignAndSendTxnX1.isEnabled = isAuthorized
+                        viewBinding.btnSignAndSendTxnX3.isEnabled = isAuthorized
+                        viewBinding.btnSignAndSendTxnX20.isEnabled = isAuthorized
+                    }
 
                     if (uiState.messages.isNotEmpty()) {
                         val message = uiState.messages.first()
@@ -59,65 +61,63 @@ class MainActivity : AppCompatActivity() {
         }
 
         viewBinding.btnGetCapabilities.setOnClickListener {
-            lifecycleScope.launch { viewModel.getCapabilities(intentSender) }
+            viewModel.getCapabilities(intentSender)
         }
 
         viewBinding.btnAuthorize.setOnClickListener {
-            lifecycleScope.launch { viewModel.authorize(intentSender) }
+            viewModel.authorize(intentSender)
         }
 
         viewBinding.btnReauthorize.setOnClickListener {
-            lifecycleScope.launch { viewModel.reauthorize(intentSender) }
+            viewModel.reauthorize(intentSender)
         }
 
         viewBinding.btnDeauthorize.setOnClickListener {
-            lifecycleScope.launch { viewModel.deauthorize(intentSender) }
+            viewModel.deauthorize(intentSender)
         }
 
         viewBinding.btnRequestAirdrop.setOnClickListener {
-            lifecycleScope.launch {
-                viewModel.requestAirdrop()
-            }
+            viewModel.requestAirdrop()
         }
 
         viewBinding.btnSignTxnX1.setOnClickListener {
-            lifecycleScope.launch { viewModel.signTransaction(intentSender, 1) }
+            viewModel.signTransaction(intentSender, 1)
         }
 
         viewBinding.btnSignTxnX3.setOnClickListener {
-            lifecycleScope.launch { viewModel.signTransaction(intentSender, 3) }
+            viewModel.signTransaction(intentSender, 3)
         }
 
         viewBinding.btnSignTxnX20.setOnClickListener {
-            lifecycleScope.launch { viewModel.signTransaction(intentSender, 20) }
+            viewModel.signTransaction(intentSender, 20)
         }
 
         viewBinding.btnAuthorizeSign.setOnClickListener {
-            lifecycleScope.launch { viewModel.authorizeAndSignTransaction(intentSender) }
+            viewModel.authorizeAndSignTransaction(intentSender)
         }
 
         viewBinding.btnSignMsgX1.setOnClickListener {
-            lifecycleScope.launch { viewModel.signMessage(intentSender, 1) }
+            viewModel.signMessage(intentSender, 1)
         }
 
         viewBinding.btnSignMsgX3.setOnClickListener {
-            lifecycleScope.launch { viewModel.signMessage(intentSender, 3) }
+            viewModel.signMessage(intentSender, 3)
         }
 
         viewBinding.btnSignMsgX20.setOnClickListener {
-            lifecycleScope.launch { viewModel.signMessage(intentSender, 20) }
+            viewModel.signMessage(intentSender, 20)
         }
 
         viewBinding.btnSignAndSendTxnX1.setOnClickListener {
-            lifecycleScope.launch { viewModel.signAndSendTransaction(intentSender, 1) }
+            viewModel.signAndSendTransaction(intentSender, 1)
         }
 
         viewBinding.btnSignAndSendTxnX3.setOnClickListener {
-            lifecycleScope.launch { viewModel.signAndSendTransaction(intentSender, 3) }
+            viewModel.signAndSendTransaction(intentSender, 3)
         }
 
         viewBinding.btnSignAndSendTxnX20.setOnClickListener {
-            lifecycleScope.launch { viewModel.signAndSendTransaction(intentSender, 20) }
+            viewModel.signAndSendTransaction(intentSender, 20)
         }
     }
 

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
@@ -42,7 +43,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val mobileWalletAdapterClientSem = Semaphore(1) // allow only a single MWA connection at a time
 
-    suspend fun authorize(sender: StartActivityForResultSender) {
+    fun authorize(sender: StartActivityForResultSender) = viewModelScope.launch {
         val result = localAssociateAndExecute(sender) { client ->
             doAuthorize(client)
         }
@@ -50,7 +51,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         showMessage(if (result == true) R.string.msg_request_succeeded else R.string.msg_request_failed)
     }
 
-    suspend fun reauthorize(sender: StartActivityForResultSender) {
+    fun reauthorize(sender: StartActivityForResultSender) = viewModelScope.launch {
         val result = localAssociateAndExecute(sender) { client ->
             doReauthorize(client)
         }
@@ -58,7 +59,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         showMessage(if (result == true) R.string.msg_request_succeeded else R.string.msg_request_failed)
     }
 
-    suspend fun deauthorize(sender: StartActivityForResultSender) {
+    fun deauthorize(sender: StartActivityForResultSender) = viewModelScope.launch {
         val result = localAssociateAndExecute(sender) { client ->
             doDeauthorize(client)
         }
@@ -66,7 +67,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         showMessage(if (result == true) R.string.msg_request_succeeded else R.string.msg_request_failed)
     }
 
-    suspend fun getCapabilities(sender: StartActivityForResultSender) {
+    fun getCapabilities(sender: StartActivityForResultSender) = viewModelScope.launch {
         val result = localAssociateAndExecute(sender) { client ->
             doGetCapabilities(client)
         }
@@ -74,7 +75,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         showMessage(if (result != null) R.string.msg_request_succeeded else R.string.msg_request_failed)
     }
 
-    suspend fun requestAirdrop() {
+    fun requestAirdrop() = viewModelScope.launch {
         try {
             RequestAirdropUseCase(TESTNET_RPC_URI, _uiState.value.publicKeyBase58!!)
             Log.d(TAG, "Airdrop request sent")
@@ -85,7 +86,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    suspend fun signTransaction(sender: StartActivityForResultSender, numTransactions: Int) {
+    fun signTransaction(sender: StartActivityForResultSender, numTransactions: Int) = viewModelScope.launch {
         val latestBlockhash = viewModelScope.async(Dispatchers.IO) {
             GetLatestBlockhashUseCase(TESTNET_RPC_URI)
         }
@@ -121,7 +122,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    suspend fun authorizeAndSignTransaction(sender: StartActivityForResultSender) {
+    fun authorizeAndSignTransaction(sender: StartActivityForResultSender) = viewModelScope.launch {
         val latestBlockhash = viewModelScope.async(Dispatchers.IO) {
             GetLatestBlockhashUseCase(TESTNET_RPC_URI)
         }
@@ -162,7 +163,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    suspend fun signMessage(sender: StartActivityForResultSender, numMessages: Int) {
+    fun signMessage(sender: StartActivityForResultSender, numMessages: Int) = viewModelScope.launch {
         val signedMessages = localAssociateAndExecute(sender) { client ->
             val messages = Array(numMessages) {
                 Random.nextBytes(16384)
@@ -173,7 +174,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         showMessage(if (signedMessages != null) R.string.msg_request_succeeded else R.string.msg_request_failed)
     }
 
-    suspend fun signAndSendTransaction(sender: StartActivityForResultSender, numTransactions: Int) {
+    fun signAndSendTransaction(sender: StartActivityForResultSender, numTransactions: Int) = viewModelScope.launch {
         val latestBlockhash = viewModelScope.async(Dispatchers.IO) {
             GetLatestBlockhashUseCase(TESTNET_RPC_URI)
         }

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/GetLatestBlockhashUseCase.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/GetLatestBlockhashUseCase.kt
@@ -47,7 +47,11 @@ object GetLatestBlockhashUseCase {
         jo.put("jsonrpc", "2.0")
         jo.put("id", 1)
         jo.put("method", "getLatestBlockhash")
-        jo.put("params", JSONArray())
+        val config = JSONObject()
+        config.put("commitment", "finalized")
+        val arr = JSONArray()
+        arr.put(config)
+        jo.put("params", arr)
 
         return jo.toString()
     }

--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/usecase/SendTransactionUseCase.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/usecase/SendTransactionUseCase.kt
@@ -34,6 +34,9 @@ object SendTransactionUseCase {
             // Send all transactions and accumulate transaction signatures
             val signatures = Array<String?>(transactions.size) { null }
             transactions.forEachIndexed { i, transaction ->
+                val transactionBase64 = Base64.encodeToString(transaction, Base64.NO_WRAP)
+                Log.d(TAG, "Sending transaction: '$transactionBase64'")
+
                 val conn = URL(rpcUri.toString()).openConnection() as HttpURLConnection
                 conn.requestMethod = "POST"
                 conn.setRequestProperty("Content-Type", "application/json")
@@ -43,7 +46,7 @@ object SendTransactionUseCase {
                 conn.outputStream.use { outputStream ->
                     outputStream.write(
                         createSendTransactionRequest(
-                            transaction,
+                            transactionBase64,
                             skipPreflight,
                             preflightCommitment
                         ).encodeToByteArray()
@@ -111,7 +114,7 @@ object SendTransactionUseCase {
     }
 
     private fun createSendTransactionRequest(
-        transaction: ByteArray,
+        transactionBase64: String,
         skipPreflight: Boolean,
         preflightCommitment: CommitmentLevel?
     ): String {
@@ -123,8 +126,7 @@ object SendTransactionUseCase {
         val arr = JSONArray()
 
         // Parameter 0 - base64-encoded transaction
-        val transactionBase64 = Base64.encode(transaction, Base64.NO_WRAP)
-        arr.put(String(transactionBase64))
+        arr.put(transactionBase64)
 
         // Parameter 1 - options
         val opt = JSONObject()


### PR DESCRIPTION
- Use the ViewModel lifecycle scope, rather than the activity lifecycle scope,
  for issuing mobile wallet adapter requests
- Output the base64-encoded transaction being submitted to logcat, for debug
  purposes
- Explicitly request the latest finalized blockhash when retrieving latest