### PR TITLE
The React Native example app now works without being connected to the debugger

### DIFF
--- a/examples/example-react-native-app/components/SignMessageButton.tsx
+++ b/examples/example-react-native-app/components/SignMessageButton.tsx
@@ -1,4 +1,5 @@
 import {transact} from '@solana-mobile/mobile-wallet-adapter-protocol-web3js';
+import {fromUint8Array} from 'js-base64';
 import React, {useContext, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {Button, Dialog, Paragraph, Portal, Text} from 'react-native-paper';
@@ -11,10 +12,6 @@ type Props = Readonly<{
   children?: React.ReactNode;
   message: string;
 }>;
-
-function getBase64StringFromByteArray(byteArray: Uint8Array): string {
-  return globalThis.btoa(String.fromCharCode.call(null, ...byteArray));
-}
 
 export default function SignMessageButton({children, message}: Props) {
   const {authorization} = useAuthorization();
@@ -101,9 +98,7 @@ export default function SignMessageButton({children, message}: Props) {
           <Dialog.Content>
             <Paragraph>
               <Text>
-                {previewSignature
-                  ? getBase64StringFromByteArray(previewSignature)
-                  : null}
+                {previewSignature ? fromUint8Array(previewSignature) : null}
               </Text>
             </Paragraph>
             <Dialog.Actions>

--- a/examples/example-react-native-app/package.json
+++ b/examples/example-react-native-app/package.json
@@ -16,6 +16,7 @@
     "@solana/wallet-adapter-base": "^0.9.8",
     "@solana/wallet-adapter-react": "^0.15.7",
     "@solana/web3.js": "^1.48.0",
+    "js-base64": "^3.7.2",
     "localstorage-polyfill": "^1.0.1",
     "react": "^18.0.0",
     "react-native": "^0.69.0",

--- a/examples/example-react-native-app/package.json
+++ b/examples/example-react-native-app/package.json
@@ -7,7 +7,7 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "preinstall": "(cd ../../js/ && yarn && yarn build)"
+    "preinstall": "rm -rf node_modules/ && (cd ../../js/ && yarn && yarn build)"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.7",

--- a/examples/example-react-native-app/yarn.lock
+++ b/examples/example-react-native-app/yarn.lock
@@ -1354,6 +1354,7 @@
   version "0.0.1-alpha.6"
   dependencies:
     "@solana-mobile/mobile-wallet-adapter-protocol" "^0.0.1-alpha.6"
+    js-base64 "^3.7.2"
 
 "@solana-mobile/mobile-wallet-adapter-protocol@^0.0.1-alpha.6", "@solana-mobile/mobile-wallet-adapter-protocol@file:../../js/packages/mobile-wallet-adapter-protocol":
   version "0.0.1-alpha.6"
@@ -4820,6 +4821,11 @@ joi@^17.2.1:
     "@sideway/address" "^4.1.3"
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
+
+js-base64@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
+  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
 
 js-sha3@^0.8.0:
   version "0.8.0"

--- a/examples/example-web-app/yarn.lock
+++ b/examples/example-web-app/yarn.lock
@@ -3293,6 +3293,11 @@ joi@^17.2.1:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-base64@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
+  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
+
 js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"

--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -40,7 +40,8 @@
         "@solana/web3.js": "^1.48.0"
     },
     "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^0.0.1-alpha.6"
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^0.0.1-alpha.6",
+        "js-base64": "^3.7.2"
     },
     "devDependencies": {
         "agadoo": "^2.0.0"

--- a/js/packages/mobile-wallet-adapter-protocol-web3js/src/__forks__/react-native/base64Utils.ts
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/src/__forks__/react-native/base64Utils.ts
@@ -1,0 +1,1 @@
+export { fromUint8Array, toUint8Array } from 'js-base64';

--- a/js/packages/mobile-wallet-adapter-protocol-web3js/src/base64Utils.ts
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/src/base64Utils.ts
@@ -1,0 +1,12 @@
+export function fromUint8Array(byteArray: Uint8Array): string {
+    return window.btoa(String.fromCharCode.call(null, ...byteArray));
+}
+
+export function toUint8Array(base64EncodedByteArray: string): Uint8Array {
+    return new Uint8Array(
+        window
+            .atob(base64EncodedByteArray)
+            .split('')
+            .map((c) => c.charCodeAt(0)),
+    );
+}

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -5490,6 +5490,11 @@ joi@^17.2.1:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-base64@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
+  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
+
 js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"


### PR DESCRIPTION
Ha. When you have the debugger connected, the JS runs in Chrome rather than in JSC. This means that when you're connected to the debugger you can use `window.btoa` but when you're running in JSC you can't.