### PR TITLE
fix: track whether or not the wallet connected successfully before ending the session

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/src/__forks__/react-native/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/__forks__/react-native/transact.ts
@@ -31,8 +31,10 @@ export async function transact<TReturn>(
     callback: (wallet: MobileWallet) => TReturn,
     config?: WalletAssociationConfig,
 ): Promise<TReturn> {
+    let didSuccessfullyConnect = false;
     try {
         await SolanaMobileWalletAdapter.startSession(config);
+        didSuccessfullyConnect = true;
         const wallet = new Proxy<MobileWallet>({} as MobileWallet, {
             get<TMethodName extends keyof MobileWallet>(target: MobileWallet, p: TMethodName) {
                 if (target[p] == null) {
@@ -67,6 +69,8 @@ export async function transact<TReturn>(
         });
         return await callback(wallet);
     } finally {
-        await SolanaMobileWalletAdapter.endSession();
+        if (didSuccessfullyConnect) {
+            await SolanaMobileWalletAdapter.endSession();
+        }
     }
 }


### PR DESCRIPTION
We don't want to _unconditionally_ end sessions unless we're sure that they were successfully started.