### PR TITLE
Remove max transaction size from protocol

### DIFF
--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
@@ -85,7 +85,5 @@ public class ProtocolContract {
     public static final String CLUSTER_TESTNET = "testnet";
     public static final String CLUSTER_DEVNET = "devnet";
 
-    public static final int TRANSACTION_MAX_SIZE_BYTES = 1232;
-
     private ProtocolContract() {}
 }


### PR DESCRIPTION
Fixes #141
This properly belongs as a wallet behavior - they get to define what is and is not a valid transaction