### PR TITLE
fix: use TextEncoder polyfill on React Native

### DIFF
--- a/examples/example-react-native-app/components/RecordMessageButton.tsx
+++ b/examples/example-react-native-app/components/RecordMessageButton.tsx
@@ -11,6 +11,7 @@ import {transact} from '@solana-mobile/mobile-wallet-adapter-protocol-web3js';
 import React, {useContext, useState} from 'react';
 import {Linking, StyleSheet, View} from 'react-native';
 import {Button, Dialog, Paragraph, Portal} from 'react-native-paper';
+import {TextEncoder} from 'text-encoding';
 
 import useAuthorization from '../utils/useAuthorization';
 import useGuardedCallback from '../utils/useGuardedCallback';
@@ -68,7 +69,7 @@ export default function RecordMessageButton({children, message}: Props) {
             setRecordingInProgress(true);
             try {
               const result = await recordMessageGuarded(
-                new (globalThis as any).TextEncoder().encode(message) as Buffer,
+                new TextEncoder().encode(message) as Buffer,
               );
               if (result) {
                 const [signature, response] = result;

--- a/examples/example-react-native-app/package.json
+++ b/examples/example-react-native-app/package.json
@@ -24,7 +24,8 @@
     "react-native-paper": "^5.0.0-rc.3",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-vector-icons": "^9.2.0",
-    "swr": "^2.0.0-beta.6"
+    "swr": "^2.0.0-beta.6",
+    "text-encoding": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -34,6 +35,7 @@
     "@types/metro-config": "^0.66.0",
     "@types/react-native": "^0.69.0",
     "@types/react-test-renderer": "^18.0.0",
+    "@types/text-encoding": "^0.0.36",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "babel-jest": "^26.6.3",


### PR DESCRIPTION
Turns out the only reason this worked before was because I always had a debugger session connected. This meant that the JavaScript ran in Chrome, where `TextEncoder` was available. When you run the app in JSC, it's not there and needs to be polyfilled.