### PR TITLE
A demonstration of connect-free app architecture, in React Native.

### DIFF
--- a/examples/example-react-native-app/components/AccountBalance.tsx
+++ b/examples/example-react-native-app/components/AccountBalance.tsx
@@ -2,7 +2,7 @@ import {useConnection} from '@solana/wallet-adapter-react';
 import {LAMPORTS_PER_SOL, PublicKey} from '@solana/web3.js';
 import React, {useCallback, useMemo} from 'react';
 import {StyleSheet, View} from 'react-native';
-import {Subheading, Text} from 'react-native-paper';
+import {Headline, Text} from 'react-native-paper';
 import useSWR from 'swr';
 
 type Props = Readonly<{
@@ -29,11 +29,11 @@ export default function AccountBalance({publicKey}: Props) {
   );
   return (
     <View style={styles.container}>
-      <Subheading>Balance: </Subheading>
-      <Text style={styles.currencySymbol} variant="titleLarge">
+      <Headline>Balance: </Headline>
+      <Text style={styles.currencySymbol} variant="headlineLarge">
         {'\u25ce'}
       </Text>
-      <Subheading>{balance}</Subheading>
+      <Headline>{balance}</Headline>
     </View>
   );
 }

--- a/examples/example-react-native-app/components/AccountInfo.tsx
+++ b/examples/example-react-native-app/components/AccountInfo.tsx
@@ -1,15 +1,18 @@
 import {PublicKey} from '@solana/web3.js';
 import React, {Suspense, useMemo} from 'react';
-import {ActivityIndicator, Linking, StyleSheet} from 'react-native';
-import {Card, Headline, Surface} from 'react-native-paper';
+import {ActivityIndicator, Linking, StyleSheet, View} from 'react-native';
+import {Card, Subheading, Surface, useTheme} from 'react-native-paper';
 
 import AccountBalance from './AccountBalance';
+import DisconnectButton from './DisconnectButton';
+import FundAccountButton from './FundAccountButton';
 
 type Props = Readonly<{
   publicKey: PublicKey;
 }>;
 
 export default function AccountInfo({publicKey}: Props) {
+  const {colors} = useTheme();
   const publicKeyBase58String = useMemo(
     () => publicKey.toBase58(),
     [publicKey],
@@ -17,25 +20,42 @@ export default function AccountInfo({publicKey}: Props) {
   return (
     <Surface elevation={4} style={styles.container}>
       <Card.Content>
-        <Headline
+        <Suspense fallback={<ActivityIndicator />}>
+          <View style={styles.balanceRow}>
+            <AccountBalance publicKey={publicKey} />
+            <FundAccountButton publicKey={publicKey}>
+              Add Funds
+            </FundAccountButton>
+          </View>
+        </Suspense>
+        <Subheading
           numberOfLines={1}
           onPress={() => {
             Linking.openURL(
               `https://explorer.solana.com/address/${publicKeyBase58String}?cluster=devnet`,
             );
-          }}>
-          {publicKeyBase58String}
-        </Headline>
-        <Suspense fallback={<ActivityIndicator />}>
-          <AccountBalance publicKey={publicKey} />
-        </Suspense>
+          }}
+          style={styles.keyRow}>
+          {'\u{1f5dd} ' + publicKeyBase58String}
+        </Subheading>
+        <DisconnectButton buttonColor={colors.error} mode="contained">
+          Disconnect
+        </DisconnectButton>
       </Card.Content>
     </Surface>
   );
 }
 
 const styles = StyleSheet.create({
+  balanceRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
   container: {
     paddingVertical: 12,
+  },
+  keyRow: {
+    marginBottom: 12,
   },
 });

--- a/examples/example-react-native-app/components/ConnectButton.tsx
+++ b/examples/example-react-native-app/components/ConnectButton.tsx
@@ -8,7 +8,7 @@ import useGuardedCallback from '../utils/useGuardedCallback';
 type Props = Readonly<ComponentProps<typeof Button>>;
 
 export default function ConnectButton(props: Props) {
-  const {setAuthorization} = useAuthorization();
+  const {authorizeSession} = useAuthorization();
   const [authorizationInProgress, setAuthorizationInProgress] = useState(false);
   const handleConnectPress = useGuardedCallback(async () => {
     try {
@@ -16,12 +16,9 @@ export default function ConnectButton(props: Props) {
         return;
       }
       setAuthorizationInProgress(true);
-      const authorizationResult = await transact(async wallet => {
-        return await wallet.authorize({
-          identity: {name: 'React Native dApp'},
-        });
+      await transact(async wallet => {
+        await authorizeSession(wallet);
       });
-      setAuthorization(authorizationResult);
     } finally {
       setAuthorizationInProgress(false);
     }

--- a/examples/example-react-native-app/components/DisconnectButton.tsx
+++ b/examples/example-react-native-app/components/DisconnectButton.tsx
@@ -1,3 +1,4 @@
+import {transact} from '@solana-mobile/mobile-wallet-adapter-protocol-web3js';
 import React, {ComponentProps} from 'react';
 import {Button} from 'react-native-paper';
 
@@ -6,12 +7,14 @@ import useAuthorization from '../utils/useAuthorization';
 type Props = Readonly<ComponentProps<typeof Button>>;
 
 export default function DisconnectButton(props: Props) {
-  const {setAuthorization} = useAuthorization();
+  const {deauthorizeSession} = useAuthorization();
   return (
     <Button
       {...props}
       onPress={() => {
-        setAuthorization(null);
+        transact(async wallet => {
+          await deauthorizeSession(wallet);
+        });
       }}
     />
   );

--- a/examples/example-react-native-app/components/FundAccountButton.tsx
+++ b/examples/example-react-native-app/components/FundAccountButton.tsx
@@ -1,34 +1,34 @@
 import {useConnection} from '@solana/wallet-adapter-react';
+import {PublicKey} from '@solana/web3.js';
 import React, {useContext, useState} from 'react';
 import {Button} from 'react-native-paper';
 import {useSWRConfig} from 'swr';
 
-import useAuthorization from '../utils/useAuthorization';
 import useGuardedCallback from '../utils/useGuardedCallback';
 import {SnackbarContext} from './SnackbarProvider';
 
 type Props = Readonly<{
   children?: React.ReactNode;
+  publicKey: PublicKey;
 }>;
 
 const LAMPORTS_PER_AIRDROP = 100000000;
 
-export default function FundAccountButton({children}: Props) {
-  const {authorization} = useAuthorization();
+export default function FundAccountButton({children, publicKey}: Props) {
   const {connection} = useConnection();
   const {mutate} = useSWRConfig();
   const setSnackbarProps = useContext(SnackbarContext);
   const [airdropInProgress, setAirdropInProgress] = useState(false);
   const requestAirdropGuarded = useGuardedCallback(async () => {
     const signature = await connection.requestAirdrop(
-      authorization!.publicKey,
+      publicKey,
       LAMPORTS_PER_AIRDROP,
     );
     return await connection.confirmTransaction(signature, 'finalized');
   }, [connection]);
   return (
     <Button
-      mode="outlined"
+      mode="elevated"
       loading={airdropInProgress}
       onPress={async () => {
         if (airdropInProgress) {

--- a/examples/example-react-native-app/screens/MainScreen.tsx
+++ b/examples/example-react-native-app/screens/MainScreen.tsx
@@ -1,25 +1,14 @@
 import React, {useState} from 'react';
 import {ScrollView, StyleSheet} from 'react-native';
-import {
-  Appbar,
-  Divider,
-  Portal,
-  Text,
-  TextInput,
-  useTheme,
-} from 'react-native-paper';
+import {Appbar, Divider, Portal, Text, TextInput} from 'react-native-paper';
 
 import AccountInfo from '../components/AccountInfo';
-import ConnectButton from '../components/ConnectButton';
-import DisconnectButton from '../components/DisconnectButton';
-import FundAccountButton from '../components/FundAccountButton';
 import RecordMessageButton from '../components/RecordMessageButton';
 import SignMessageButton from '../components/SignMessageButton';
 import useAuthorization from '../utils/useAuthorization';
 
 export default function MainScreen() {
-  const {authorization} = useAuthorization();
-  const {colors} = useTheme();
+  const {publicKey} = useAuthorization();
   const [memoText, setMemoText] = useState('');
   return (
     <>
@@ -28,42 +17,26 @@ export default function MainScreen() {
       </Appbar.Header>
       <Portal.Host>
         <ScrollView contentContainerStyle={styles.container}>
-          {authorization?.publicKey ? (
-            <>
-              <Text variant="bodyLarge">
-                Write a message to record on the blockchain.
-              </Text>
-              <Divider style={styles.spacer} />
-              <TextInput
-                label="What's on your mind?"
-                onChangeText={text => {
-                  setMemoText(text);
-                }}
-                style={styles.textInput}
-                value={memoText}
-              />
-              <Divider style={styles.spacer} />
-              <RecordMessageButton message={memoText}>
-                Record Message
-              </RecordMessageButton>
-              <Divider style={styles.spacer} />
-              <SignMessageButton message={memoText}>
-                Sign Message
-              </SignMessageButton>
-              <Divider style={styles.spacer} />
-              <FundAccountButton>Fund Account (devnet)</FundAccountButton>
-              <Divider style={styles.spacer} />
-              <DisconnectButton buttonColor={colors.error} mode="contained">
-                Disconnect
-              </DisconnectButton>
-            </>
-          ) : (
-            <ConnectButton mode="contained">Connect</ConnectButton>
-          )}
+          <Text variant="bodyLarge">
+            Write a message to record on the blockchain.
+          </Text>
+          <Divider style={styles.spacer} />
+          <TextInput
+            label="What's on your mind?"
+            onChangeText={text => {
+              setMemoText(text);
+            }}
+            style={styles.textInput}
+            value={memoText}
+          />
+          <Divider style={styles.spacer} />
+          <RecordMessageButton message={memoText}>
+            Record Message
+          </RecordMessageButton>
+          <Divider style={styles.spacer} />
+          <SignMessageButton message={memoText}>Sign Message</SignMessageButton>
         </ScrollView>
-        {authorization?.publicKey ? (
-          <AccountInfo publicKey={authorization.publicKey} />
-        ) : null}
+        {publicKey ? <AccountInfo publicKey={publicKey} /> : null}
       </Portal.Host>
     </>
   );


### PR DESCRIPTION
# Premise

One of the incredibly powerful things about the mobile wallet adapter architecture is that you can issue _multiple directives_ to a wallet in a _single_ session. One of these directives is to *authorize the app in the first place*.

This means that you can create a truly *connect-free* application. A user can not have a wallet connected _at all_, perform an action in the app that requires authorization, and the app can decide whether:

1. They have an existing authorization that can be reused, or
2. Whether to authorize the app in the same session in which the privileges method is called. 

# Summary of change

* Eliminated the ‘connect’ button.
* Clicking ‘record’ or ’sign’ now
  * Authorizes the dApp if it hasn't been authorized yet, or
  * Reuses the cached authorization if it has.

# Demo

Look ma, no connect button!

https://user-images.githubusercontent.com/13243/180129478-e2434d95-4fe6-49ee-ae6c-8bf8be4ba667.mp4

