### PR TITLE
Rename pub_key to addresses

### DIFF
--- a/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
+++ b/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
@@ -203,9 +203,10 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
 
             final String publicKey;
             try {
-                publicKey = jo.getString(ProtocolContract.RESULT_PUBLIC_KEY);
+                final JSONArray addresses = jo.getJSONArray(ProtocolContract.RESULT_ADDRESSES);
+                publicKey = addresses.getString(0); // TODO(#44): support multiple addresses
             } catch (JSONException e) {
-                throw new JsonRpc20InvalidResponseException("expected a public key");
+                throw new JsonRpc20InvalidResponseException("expected one or more addresses");
             }
 
             final String walletUriBaseStr = jo.has(ProtocolContract.RESULT_WALLET_URI_BASE) ?

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
@@ -8,7 +8,7 @@ public class ProtocolContract {
     public static final String METHOD_AUTHORIZE = "authorize";
     // METHOD_AUTHORIZE takes an optional PARAMETER_IDENTITY
     // METHOD_AUTHORIZE returns a RESULT_AUTH_TOKEN
-    // METHOD_AUTHORIZE returns a RESULT_PUBLIC_KEY
+    // METHOD_AUTHORIZE returns a RESULT_ADDRESSES
     // METHOD_AUTHORIZE returns an optional RESULT_WALLET_URI_BASE
 
     public static final String METHOD_DEAUTHORIZE = "deauthorize";
@@ -54,7 +54,7 @@ public class ProtocolContract {
     public static final String PARAMETER_PAYLOADS = "payloads"; // type: JSON array of String (base64-encoded payloads)
 
     public static final String RESULT_AUTH_TOKEN = "auth_token"; // type: String
-    public static final String RESULT_PUBLIC_KEY = "pub_key"; // type: String (base58-encoded public key)
+    public static final String RESULT_ADDRESSES = "addresses"; // type: JSON array of String (base58-encoded addresses)
     public static final String RESULT_WALLET_URI_BASE = "wallet_uri_base"; // type: String (absolute URI)
 
     public static final String RESULT_SIGNED_PAYLOADS = "signed_payloads"; // type: JSON array of String (base64-encoded signed payloads)

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -182,7 +182,9 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             final JSONObject o = new JSONObject();
             try {
                 o.put(ProtocolContract.RESULT_AUTH_TOKEN, result.authToken);
-                o.put(ProtocolContract.RESULT_PUBLIC_KEY, Base58.encode(result.publicKey));
+                final JSONArray addresses = new JSONArray(); // TODO(#44): support multiple addresses
+                addresses.put(Base58.encode(result.publicKey));
+                o.put(ProtocolContract.RESULT_ADDRESSES, addresses);
                 o.put(ProtocolContract.RESULT_WALLET_URI_BASE, result.walletUriBase); // OK if null
             } catch (JSONException e) {
                 throw new RuntimeException("Failed preparing authorize response", e);

--- a/examples/example-react-native-app/utils/useAuthorization.tsx
+++ b/examples/example-react-native-app/utils/useAuthorization.tsx
@@ -59,7 +59,7 @@ export default function useAuthorization() {
   const publicKey = useMemo(
     () =>
       cachedAuthorization
-        ? new PublicKey(cachedAuthorization.pub_key)
+        ? new PublicKey(cachedAuthorization.addresses[0]) // TODO(#44): support multiple addresses
         : undefined,
     [cachedAuthorization],
   );
@@ -75,7 +75,7 @@ export default function useAuthorization() {
         const authorizationResult = await wallet.authorize({
           identity: APP_IDENTITY,
         });
-        freshPublicKey = new PublicKey(authorizationResult.pub_key);
+        freshPublicKey = new PublicKey(authorizationResult.addresses[0]); // TODO(#44): support multiple addresses
         setAuthorization(authorizationResult);
       }
       return freshPublicKey;

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -22,8 +22,8 @@ export type AssociationKeypair = CryptoKeyPair;
  * use it later to invoke privileged methods.
  */
 export type AuthorizationResult = Readonly<{
-    auth_token: AuthToken;
     addresses: Base58EncodedAddress[];
+    auth_token: AuthToken;
     wallet_uri_base: string;
 }>;
 

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -23,11 +23,13 @@ export type AssociationKeypair = CryptoKeyPair;
  */
 export type AuthorizationResult = Readonly<{
     auth_token: AuthToken;
-    pub_key: string;
+    addresses: Base58EncodedAddress[];
     wallet_uri_base: string;
 }>;
 
 export type AuthToken = string;
+
+type Base58EncodedAddress = string;
 
 type Base58EncodedSignature = string;
 

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -106,8 +106,8 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
             try {
                 await this.transact(async (wallet) => {
                     const {
-                        auth_token,
                         addresses,
+                        auth_token,
                         wallet_uri_base,
                     } = await wallet.authorize({ identity: this._appIdentity });
                     try {
@@ -116,8 +116,8 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
                         throw new WalletPublicKeyError((e instanceof Error && e?.message) || 'Unknown error', e);
                     }
                     this.handleAuthorizationResult({
-                        auth_token,
                         addresses,
+                        auth_token,
                         wallet_uri_base: wallet_uri_base,
                     }); // TODO: Evaluate whether there's any threat to not `awaiting` this expression
                     this.emit(

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -56,7 +56,7 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     get publicKey(): PublicKey | null {
         if (this._publicKey == null && this._authorizationResult != null) {
-            this._publicKey = new PublicKey(this._authorizationResult.pub_key);
+            this._publicKey = new PublicKey(this._authorizationResult.addresses[0]); // TODO(#44): support multiple addresses
         }
         return this._publicKey ? this._publicKey : null;
     }
@@ -107,17 +107,17 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
                 await this.transact(async (wallet) => {
                     const {
                         auth_token,
-                        pub_key: base58PublicKey,
+                        addresses,
                         wallet_uri_base,
                     } = await wallet.authorize({ identity: this._appIdentity });
                     try {
-                        this._publicKey = new PublicKey(base58PublicKey);
+                        this._publicKey = new PublicKey(addresses[0]); // TODO(#44): support multiple addresses
                     } catch (e) {
                         throw new WalletPublicKeyError((e instanceof Error && e?.message) || 'Unknown error', e);
                     }
                     this.handleAuthorizationResult({
                         auth_token,
-                        pub_key: base58PublicKey,
+                        addresses,
                         wallet_uri_base: wallet_uri_base,
                     }); // TODO: Evaluate whether there's any threat to not `awaiting` this expression
                     this.emit(


### PR DESCRIPTION
Fixes #140
This also makes this parameter an array of strings, though the clients still all
only support a single account address