### PR TITLE
fix: add the `preflight_commitment` param to `signAndSendTransaction`

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol-web3js/src/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/src/transact.ts
@@ -96,6 +96,7 @@ export async function transact<TReturn>(
                                     ...rest,
                                     commitment: targetCommitment,
                                     payloads,
+                                    preflight_commitment: targetCommitment,
                                 });
                                 return signatures as TransactionSignature[];
                             } as Web3MobileWallet[TMethodName];

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -76,6 +76,7 @@ export interface SignAndSendTransactionsAPI {
         cluster: Cluster;
         commitment: Finality;
         payloads: Base64EncodedTransaction[];
+        preflight_commitment: Finality;
     }): Promise<Readonly<{ signatures: Base58EncodedSignature[] }>>;
 }
 


### PR DESCRIPTION
Among other things, this makes it so that you can now actually send a transaction with the example web app!

https://user-images.githubusercontent.com/13243/180575485-7c2da55d-ae19-4b16-ad46-0ab9cdd81b15.mov