### PR TITLE
Increase total connection backoff schedule to 30s

### DIFF
--- a/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/LocalAssociationScenario.java
+++ b/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/LocalAssociationScenario.java
@@ -28,8 +28,8 @@ import java.util.concurrent.TimeUnit;
 
 public class LocalAssociationScenario extends Scenario {
     private static final String TAG = LocalAssociationScenario.class.getSimpleName();
-    private static final int CONNECT_MAX_ATTEMPTS = 6;
-    private static final int[] CONNECT_BACKOFF_SCHEDULE_MS = { 100, 250, 500, 750 };
+    private static final int CONNECT_MAX_ATTEMPTS = 34;
+    private static final int[] CONNECT_BACKOFF_SCHEDULE_MS = { 150, 150, 200, 500, 500, 750, 750, 1000 }; // == 30s, which allows time for a user to choose a wallet from the disambiguation dialog, and for that wallet to start
     private static final int CONNECT_TIMEOUT_MS = 200; // localhost connections should be very fast
 
     @WebSocketsTransportContract.LocalPortRange

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
@@ -22,15 +22,12 @@ import com.solana.mobilewalletadapter.common.protocol.CommitmentLevel
 import com.solana.mobilewalletadapter.fakedapp.usecase.GetLatestBlockhashUseCase
 import com.solana.mobilewalletadapter.fakedapp.usecase.MemoTransactionUseCase
 import com.solana.mobilewalletadapter.fakedapp.usecase.RequestAirdropUseCase
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
-import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
@@ -483,8 +480,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         sender: StartActivityForResultSender,
         uriPrefix: Uri? = null,
         action: suspend (MobileWalletAdapterClient) -> T?
-    ): T? {
-        return mobileWalletAdapterClientSem.withPermit {
+    ): T? = coroutineScope {
+        return@coroutineScope mobileWalletAdapterClientSem.withPermit {
             val localAssociation = LocalAssociationScenario(Scenario.DEFAULT_CLIENT_TIMEOUT_MS)
 
             val associationIntent = LocalAssociationIntentCreator.createAssociationIntent(
@@ -493,7 +490,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 localAssociation.session
             )
             try {
-                sender.startActivityForResult(associationIntent)
+                sender.startActivityForResult(associationIntent) {
+                    viewModelScope.launch {
+                        // Ensure this coroutine will wrap up in a timely fashion when the launched
+                        // activity completes
+                        delay(LOCAL_ASSOCIATION_CANCEL_AFTER_WALLET_CLOSED_TIMEOUT_MS)
+                        this@coroutineScope.cancel()
+                    }
+                }
             } catch (e: ActivityNotFoundException) {
                 Log.e(TAG, "Failed to start intent=$associationIntent", e)
                 showMessage(R.string.msg_no_wallet_found)
@@ -501,33 +505,37 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             }
 
             return@withPermit withContext(Dispatchers.IO) {
-                val mobileWalletAdapterClient = try {
+                try {
+                    val mobileWalletAdapterClient = try {
+                        runInterruptible {
+                            localAssociation.start().get(LOCAL_ASSOCIATION_START_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                        }
+                    } catch (e: InterruptedException) {
+                        Log.w(TAG, "Interrupted while waiting for local association to be ready")
+                        return@withContext null
+                    } catch (e: TimeoutException) {
+                        Log.e(TAG, "Timed out waiting for local association to be ready")
+                        return@withContext null
+                    } catch (e: ExecutionException) {
+                        Log.e(TAG, "Failed establishing local association with wallet", e.cause)
+                        return@withContext null
+                    } catch (e: CancellationException) {
+                        Log.e(TAG, "Local association was cancelled before connected", e)
+                        return@withContext null
+                    }
+
+                    // NOTE: this is a blocking method call, appropriate in the Dispatchers.IO context
+                    action(mobileWalletAdapterClient)
+                } finally {
                     @Suppress("BlockingMethodInNonBlockingContext") // running in Dispatchers.IO; blocking is appropriate
-                    localAssociation.start().get(ASSOCIATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-                } catch (e: InterruptedException) {
-                    Log.w(TAG, "Interrupted while waiting for local association to be ready")
-                    return@withContext null
-                } catch (e: TimeoutException) {
-                    Log.e(TAG, "Timed out waiting for local association to be ready")
-                    return@withContext null
-                } catch (e: ExecutionException) {
-                    Log.e(TAG, "Failed establishing local association with wallet", e.cause)
-                    return@withContext null
+                    localAssociation.close().get(LOCAL_ASSOCIATION_CLOSE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 }
-
-                // NOTE: this is a blocking method call, appropriate in the Dispatchers.IO context
-                val result = action(mobileWalletAdapterClient)
-
-                @Suppress("BlockingMethodInNonBlockingContext") // running in Dispatchers.IO; blocking is appropriate
-                localAssociation.close().get(ASSOCIATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-
-                result
             }
         }
     }
 
     interface StartActivityForResultSender {
-        fun startActivityForResult(intent: Intent) // throws ActivityNotFoundException
+        fun startActivityForResult(intent: Intent, onActivityCompleteCallback: () -> Unit) // throws ActivityNotFoundException
     }
 
     data class UiState(
@@ -540,7 +548,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     companion object {
         private val TAG = MainViewModel::class.simpleName
-        private const val ASSOCIATION_TIMEOUT_MS = 10000L
+        private const val LOCAL_ASSOCIATION_START_TIMEOUT_MS = 60000L // LocalAssociationScenario.start() has a shorter timeout; this is just a backup safety measure
+        private const val LOCAL_ASSOCIATION_CLOSE_TIMEOUT_MS = 5000L
+        private const val LOCAL_ASSOCIATION_CANCEL_AFTER_WALLET_CLOSED_TIMEOUT_MS = 5000L
         private val TESTNET_RPC_URI = Uri.parse("https://api.testnet.solana.com")
     }
 }


### PR DESCRIPTION
Fixes #82

The connection timeout needs to be substantially increased, for two reasons:
1. Some wallets take longer than the current timeout (3.1s with the current
   clientlib implementation) to start and being listening for websocket
   connections. Data reported by several wallets indicate that 5-6 seconds is
   a more realistic startup time number for a cold start of wallets built using
   frameworks like React Native or Dart+Flutter.
2. If multiple wallets are installed AND the user has not chosen a default, the
   time that the user spends in the disambiguation dialog selecting a wallet
   needs to be included in this timeout as well.

This fix both extends the timeout, and also adds logic to the fakedapp sample to
short-circuit this connection timeout to 5s after the invoked wallet app
terminates.