### PR TITLE
reauthorize now returns the same response object as authorize

### DIFF
--- a/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/AdapterOperations.kt
+++ b/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/AdapterOperations.kt
@@ -4,8 +4,8 @@ import android.net.Uri
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient
 
 interface AdapterOperations {
-    suspend fun authorize(identityUri: Uri, iconUri: Uri, identityName: String, rpcCluster: RpcCluster = RpcCluster.MainnetBeta): MobileWalletAdapterClient.AuthorizeResult
-    suspend fun reauthorize(identityUri: Uri, iconUri: Uri, identityName: String, authToken: String): MobileWalletAdapterClient.ReauthorizeResult
+    suspend fun authorize(identityUri: Uri, iconUri: Uri, identityName: String, rpcCluster: RpcCluster = RpcCluster.MainnetBeta): MobileWalletAdapterClient.AuthorizationResult
+    suspend fun reauthorize(identityUri: Uri, iconUri: Uri, identityName: String, authToken: String): MobileWalletAdapterClient.AuthorizationResult
     suspend fun deauthorize(authToken: String)
     suspend fun getCapabilities(): MobileWalletAdapterClient.GetCapabilitiesResult
     suspend fun signMessages(transactions: Array<ByteArray>): MobileWalletAdapterClient.SignPayloadsResult

--- a/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/LocalAdapterOperations.kt
+++ b/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/LocalAdapterOperations.kt
@@ -16,7 +16,7 @@ class LocalAdapterOperations(
 
     var client: MobileWalletAdapterClient? = null
 
-    override suspend fun authorize(identityUri: Uri, iconUri: Uri, identityName: String, rpcCluster: RpcCluster): MobileWalletAdapterClient.AuthorizeResult {
+    override suspend fun authorize(identityUri: Uri, iconUri: Uri, identityName: String, rpcCluster: RpcCluster): MobileWalletAdapterClient.AuthorizationResult {
         return withContext(ioDispatcher) {
             @Suppress("BlockingMethodInNonBlockingContext")
             client?.authorize(identityUri, iconUri, identityName, rpcCluster.name)?.get()
@@ -24,7 +24,7 @@ class LocalAdapterOperations(
         }
     }
 
-    override suspend fun reauthorize(identityUri: Uri, iconUri: Uri, identityName: String, authToken: String): MobileWalletAdapterClient.ReauthorizeResult {
+    override suspend fun reauthorize(identityUri: Uri, iconUri: Uri, identityName: String, authToken: String): MobileWalletAdapterClient.AuthorizationResult {
         return withContext(ioDispatcher) {
             @Suppress("BlockingMethodInNonBlockingContext")
             client?.reauthorize(identityUri, iconUri, identityName, authToken)?.get()

--- a/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/RxMobileWalletAdapterClient.java
+++ b/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/RxMobileWalletAdapterClient.java
@@ -8,11 +8,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Size;
 
-import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.AuthorizeFuture;
-import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.AuthorizeResult;
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.AuthorizationFuture;
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.AuthorizationResult;
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.DeauthorizeFuture;
-import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.ReauthorizeFuture;
-import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.ReauthorizeResult;
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignAndSendTransactionsFuture;
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignAndSendTransactionsResult;
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignPayloadsFuture;
@@ -37,13 +35,13 @@ public class RxMobileWalletAdapterClient {
 
     @CheckResult
     @NonNull
-    public Single<AuthorizeResult> authorize(@Nullable Uri identityUri,
-                                             @Nullable Uri iconUri,
-                                             @Nullable String identityName,
-                                             @Nullable String cluster) {
+    public Single<AuthorizationResult> authorize(@Nullable Uri identityUri,
+                                                 @Nullable Uri iconUri,
+                                                 @Nullable String identityName,
+                                                 @Nullable String cluster) {
         try {
-            AuthorizeFuture authorizeFuture = mMobileWalletAdapterClient.authorize(identityUri, iconUri, identityName, cluster);
-            return Single.fromFuture(authorizeFuture);
+            AuthorizationFuture authorizationFuture = mMobileWalletAdapterClient.authorize(identityUri, iconUri, identityName, cluster);
+            return Single.fromFuture(authorizationFuture);
         } catch (Exception e) {
             return Single.error(e);
         }
@@ -51,12 +49,12 @@ public class RxMobileWalletAdapterClient {
 
     @CheckResult
     @NonNull
-    public Single<ReauthorizeResult> reauthorize(@Nullable Uri identityUri,
-                                                 @Nullable Uri iconUri,
-                                                 @Nullable String identityName,
-                                                 @NonNull String authToken) {
+    public Single<AuthorizationResult> reauthorize(@Nullable Uri identityUri,
+                                                   @Nullable Uri iconUri,
+                                                   @Nullable String identityName,
+                                                   @NonNull String authToken) {
         try {
-            ReauthorizeFuture reauthorizeFuture = mMobileWalletAdapterClient.reauthorize(identityUri, iconUri, identityName, authToken);
+            AuthorizationFuture reauthorizeFuture = mMobileWalletAdapterClient.reauthorize(identityUri, iconUri, identityName, authToken);
             return Single.fromFuture(reauthorizeFuture);
         } catch (Exception e) {
             return Single.error(e);

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
@@ -19,6 +19,8 @@ public class ProtocolContract {
     // METHOD_REAUTHORIZE takes an optional PARAMETER_IDENTITY
     // METHOD_REAUTHORIZE takes a PARAMETER_AUTH_TOKEN
     // METHOD_REAUTHORIZE returns a RESULT_AUTH_TOKEN
+    // METHOD_REAUTHORIZE returns a RESULT_ADDRESSES
+    // METHOD_REAUTHORIZE returns an optional RESULT_WALLET_URI_BASE
 
     public static final String METHOD_CLONE_AUTHORIZATION = "clone_authorization";
     // METHOD_CLONE_AUTHORIZATION returns a RESULT_AUTH_TOKEN

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
@@ -271,7 +271,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 _uiState.value.authToken!!
             ).get()
             Log.d(TAG, "Reauthorized: $result")
-            _uiState.update { it.copy(authToken = result.authToken) }
+            _uiState.update {
+                it.copy(
+                    authToken = result.authToken,
+                    publicKey = result.publicKey
+                )
+            }
             reauthorized = true
         } catch (e: ExecutionException) {
             when (val cause = e.cause) {

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
@@ -12,7 +12,7 @@ import androidx.annotation.NonNull;
 
 /*package*/ class AuthDatabase extends SQLiteOpenHelper {
     private static final String DATABASE_NAME_SUFFIX = "-solana-wallet-lib-auth.db";
-    private static final int DATABASE_SCHEMA_VERSION = 3;
+    private static final int DATABASE_SCHEMA_VERSION = 4;
 
     /*package*/ static final String TABLE_IDENTITIES = "identities";
     /*package*/ static final String COLUMN_IDENTITIES_ID = "id"; // type: int
@@ -27,12 +27,18 @@ import androidx.annotation.NonNull;
     /*package*/ static final String COLUMN_AUTHORIZATIONS_IDENTITY_ID = "identity_id"; // type: long
     /*package*/ static final String COLUMN_AUTHORIZATIONS_ISSUED = "issued"; // type: long
     /*package*/ static final String COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID = "public_key_id"; // type: long
+    /*package*/ static final String COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID = "wallet_uri_base_id"; // type: long
     /*package*/ static final String COLUMN_AUTHORIZATIONS_SCOPE = "scope"; // type: byte[]
     /*package*/ static final String COLUMN_AUTHORIZATIONS_CLUSTER = "cluster"; // type: String
+
 
     /*package*/ static final String TABLE_PUBLIC_KEYS = "public_keys";
     /*package*/ static final String COLUMN_PUBLIC_KEYS_ID = "id"; // type: long
     /*package*/ static final String COLUMN_PUBLIC_KEYS_RAW = "public_key_raw"; // type: byte[]
+
+    /*package*/ static final String TABLE_WALLET_URI_BASE = "wallet_uri_base";
+    /*package*/ static final String COLUMN_WALLET_URI_BASE_ID = "id"; // type: long
+    /*package*/ static final String COLUMN_WALLET_URI_BASE_URI = "uri"; // type: String
 
     private static final String CREATE_TABLE_IDENTITIES =
             "CREATE TABLE " + TABLE_IDENTITIES + " (" +
@@ -48,12 +54,17 @@ import androidx.annotation.NonNull;
                     COLUMN_AUTHORIZATIONS_IDENTITY_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_ISSUED + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID + " INTEGER NOT NULL," +
+                    COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_SCOPE + " BLOB NOT NULL," +
                     COLUMN_AUTHORIZATIONS_CLUSTER + " TEXT NOT NULL)";
     private static final String CREATE_TABLE_PUBLIC_KEYS =
             "CREATE TABLE " + TABLE_PUBLIC_KEYS + " (" +
                     COLUMN_PUBLIC_KEYS_ID + " INTEGER NOT NULL PRIMARY KEY," +
                     COLUMN_PUBLIC_KEYS_RAW + " BLOB NOT NULL)";
+    private static final String CREATE_TABLE_WALLET_URI_BASE =
+            "CREATE TABLE " + TABLE_WALLET_URI_BASE + " (" +
+                    COLUMN_WALLET_URI_BASE_ID + " INTEGER NOT NULL PRIMARY KEY," +
+                    COLUMN_WALLET_URI_BASE_URI + " TEXT)";
 
     AuthDatabase(@NonNull Context context, @NonNull AuthIssuerConfig authIssuerConfig) {
         super(context, getDatabaseName(authIssuerConfig), null, DATABASE_SCHEMA_VERSION);
@@ -69,6 +80,7 @@ import androidx.annotation.NonNull;
         db.execSQL(CREATE_TABLE_IDENTITIES);
         db.execSQL(CREATE_TABLE_AUTHORIZATIONS);
         db.execSQL(CREATE_TABLE_PUBLIC_KEYS);
+        db.execSQL(CREATE_TABLE_WALLET_URI_BASE);
     }
 
     @Override

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
@@ -4,8 +4,11 @@
 
 package com.solana.mobilewalletadapter.walletlib.authorization;
 
+import android.net.Uri;
+
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -32,7 +35,14 @@ public class AuthRecord {
     @NonNull
     public final byte[] scope;
 
+    @Nullable
+    public final Uri walletUriBase;
+
+    @IntRange(from = 1)
     /*package*/ final int publicKeyId;
+
+    @IntRange(from = 1)
+    /*package*/ final int walletUriBaseId;
 
     private boolean mRevoked;
 
@@ -41,7 +51,9 @@ public class AuthRecord {
                            @NonNull byte[] publicKey,
                            @NonNull String cluster,
                            @NonNull byte[] scope,
+                           @Nullable Uri walletUriBase,
                            @IntRange(from = 1) int publicKeyId,
+                           @IntRange(from = 1) int walletUriBaseId,
                            @IntRange(from = 0) long issued,
                            @IntRange(from = 0) long expires) {
         // N.B. This is a package-visibility constructor; these values will all be validated by
@@ -51,7 +63,9 @@ public class AuthRecord {
         this.publicKey = publicKey;
         this.cluster = cluster;
         this.scope = scope;
+        this.walletUriBase = walletUriBase;
         this.publicKeyId = publicKeyId;
+        this.walletUriBaseId = walletUriBaseId;
         this.issued = issued;
         this.expires = expires;
     }
@@ -95,6 +109,7 @@ public class AuthRecord {
                 ", publicKey=" + Arrays.toString(publicKey) +
                 ", cluster='" + cluster + '\'' +
                 ", scope=" + Arrays.toString(scope) +
+                ", walletUriBase='" + walletUriBase + '\'' +
                 ", issued=" + issued +
                 ", expires=" + expires +
                 ", mRevoked=" + mRevoked +

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/Scenario.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/Scenario.java
@@ -137,14 +137,14 @@ public abstract class Scenario {
                         final Uri relativeIconUri = request.iconUri != null ? request.iconUri : Uri.EMPTY;
                         final AuthRecord authRecord = mAuthRepository.issue(
                                 name, uri, relativeIconUri, authorize.publicKey, request.cluster,
-                                authorize.scope);
+                                authorize.walletUriBase, authorize.scope);
                         Log.d(TAG, "Authorize request completed successfully; issued auth: " + authRecord);
                         synchronized (mLock) {
                             mActiveAuthorization = authRecord;
                         }
 
                         final String authToken = mAuthRepository.toAuthToken(authRecord);
-                        request.complete(new MobileWalletAdapterServer.AuthorizeResult(
+                        request.complete(new MobileWalletAdapterServer.AuthorizationResult(
                                 authToken, authorize.publicKey, authorize.walletUriBase));
                     } else {
                         synchronized (mLock) {
@@ -221,7 +221,8 @@ public abstract class Scenario {
                     }
 
                     mIoHandler.post(() -> request.complete(
-                            new MobileWalletAdapterServer.ReauthorizeResult(authToken)));
+                            new MobileWalletAdapterServer.AuthorizationResult(
+                                    authToken, authRecord.publicKey, authRecord.walletUriBase)));
                 } catch (ExecutionException | InterruptedException e) {
                     throw new RuntimeException("Unexpected exception while waiting for reauthorization", e);
                 } catch (CancellationException e) {

--- a/examples/example-react-native-app/utils/useAuthorization.tsx
+++ b/examples/example-react-native-app/utils/useAuthorization.tsx
@@ -85,19 +85,16 @@ export default function useAuthorization() {
   );
   const authorizeSession = useCallback(
     async (wallet: AuthorizeAPI & ReauthorizeAPI) => {
-      if (data) {
-        await wallet.reauthorize({
-          auth_token: data.authorization.auth_token,
-        });
-        return data.publicKey;
-      } else {
-        const authorizationResult = await wallet.authorize({
-          cluster: 'devnet',
-          identity: APP_IDENTITY,
-        });
-        setAuthorization(authorizationResult);
-        return getPublicKeyFromAuthorizationResult(authorizationResult);
-      }
+      const authorizationResult = await (data
+        ? wallet.reauthorize({
+            auth_token: data.authorization.auth_token,
+          })
+        : wallet.authorize({
+            cluster: 'devnet',
+            identity: APP_IDENTITY,
+          }));
+      setAuthorization(authorizationResult);
+      return getPublicKeyFromAuthorizationResult(authorizationResult);
     },
     [data, setAuthorization],
   );

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -59,7 +59,7 @@ export interface DeauthorizeAPI {
     deauthorize(params: { auth_token: AuthToken }): Promise<Readonly<Record<string, never>>>;
 }
 export interface ReauthorizeAPI {
-    reauthorize(params: { auth_token: AuthToken }): Promise<Readonly<{ auth_token: AuthToken }>>;
+    reauthorize(params: { auth_token: AuthToken }): Promise<AuthorizationResult>;
 }
 export interface SignMessagesAPI {
     signMessages(params: {


### PR DESCRIPTION
Fixes #143
This will support a future change to allow wallets to update account addresses
and wallet URI base on calls to reauthorize, allow for more dynamic usage of
auth tokens.