### PR TITLE
feat: you can now configure the `SolanaMobileWalletAdapter` with an address selector

### DIFF
--- a/examples/example-web-app/pages/_app.tsx
+++ b/examples/example-web-app/pages/_app.tsx
@@ -5,7 +5,11 @@ import { createTheme } from '@mui/material';
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { clusterApiUrl } from '@solana/web3.js';
-import { createDefaultAuthorizationResultCache, SolanaMobileWalletAdapter } from '@solana-mobile/wallet-adapter-mobile';
+import {
+    createDefaultAddressSelector,
+    createDefaultAuthorizationResultCache,
+    SolanaMobileWalletAdapter,
+} from '@solana-mobile/wallet-adapter-mobile';
 import type { AppProps } from 'next/app';
 import { SnackbarProvider } from 'notistack';
 import { useMemo } from 'react';
@@ -22,6 +26,7 @@ function ExampleMobileDApp({ Component, pageProps }: AppProps) {
                 ? [] // No wallet adapters when server-side rendering.
                 : [
                       new SolanaMobileWalletAdapter({
+                          addressSelector: createDefaultAddressSelector(),
                           appIdentity: {
                               icon: 'images/app_icon.png',
                               name: 'Mobile Web dApp',

--- a/js/packages/wallet-adapter-mobile/README.md
+++ b/js/packages/wallet-adapter-mobile/README.md
@@ -10,6 +10,7 @@ Create an instance of the mobile wallet adapter like this.
 
 ```typescript
 new SolanaMobileWalletAdapter({
+    addressSelector: createDefaultAddressSelector(),
     appIdentity: {
         name: 'My app',
         uri: 'https://myapp.io',
@@ -24,6 +25,7 @@ Use that adapter instance alongside the other adapters used by your app.
 ```typescript
 const wallets = useMemo(() => [
     new SolanaMobileWalletAdapter({
+        addressSelector: createDefaultAddressSelector(),
         appIdentity: {
             name: 'My app',
             uri: 'https://myapp.io',

--- a/js/packages/wallet-adapter-mobile/src/createDefaultAddressSelector.ts
+++ b/js/packages/wallet-adapter-mobile/src/createDefaultAddressSelector.ts
@@ -1,0 +1,9 @@
+import { AddressSelector } from './adapter';
+
+export default function createDefaultAddressSelector(): AddressSelector {
+    return {
+        async select(addresses) {
+            return addresses[0];
+        },
+    };
+}

--- a/js/packages/wallet-adapter-mobile/src/index.ts
+++ b/js/packages/wallet-adapter-mobile/src/index.ts
@@ -1,2 +1,3 @@
 export * from './adapter';
+export { default as createDefaultAddressSelector } from './createDefaultAddressSelector';
 export { default as createDefaultAuthorizationResultCache } from './createDefaultAuthorizationResultCache';


### PR DESCRIPTION
# Background

Mobile wallet adapter allows us to authorize multiple addresses from a single click of the ‘connect’ button. This causes an impedance mismatch between MWA and `@solana/wallet-adapter` that doesn't have the concept of multiple addresses.

# Problem statement

The existing `wallet-adapter` API is single-key, like this:

```typescript
const {publicKey, signTransaction} = useWallet();
```

How, in this world, should `wallet-adapter` make the choice of `publicKey`, if the user decides to authorize multiple addresses in a mobile wallet adapter session?

# Summary of changes

* Added a configuration param to `SolanaMobileWalletAdapter` called `addressSelector`. Developers can provide an implementation of this to make a sensible selection of address given multiple addresses.
* Made a `createDefaultAddressSelector` helper, that just chooses the first address in the list.

Note, that because the selector is async, app developers have a great amount of freedom to pause execution of the wallet adapter plugin to show – for instance – an address selection UI to their users.