### PR TITLE
Thread the currently selected address through to each `signMessages` call

### DIFF
--- a/examples/example-react-native-app/screens/MainScreen.tsx
+++ b/examples/example-react-native-app/screens/MainScreen.tsx
@@ -8,7 +8,7 @@ import SignMessageButton from '../components/SignMessageButton';
 import useAuthorization from '../utils/useAuthorization';
 
 export default function MainScreen() {
-  const {publicKey} = useAuthorization();
+  const {account} = useAuthorization();
   const [memoText, setMemoText] = useState('');
   return (
     <>
@@ -36,7 +36,7 @@ export default function MainScreen() {
           <Divider style={styles.spacer} />
           <SignMessageButton message={memoText}>Sign Message</SignMessageButton>
         </ScrollView>
-        {publicKey ? <AccountInfo publicKey={publicKey} /> : null}
+        {account ? <AccountInfo publicKey={account.publicKey} /> : null}
       </Portal.Host>
     </>
   );

--- a/examples/example-react-native-app/utils/useAuthorization.tsx
+++ b/examples/example-react-native-app/utils/useAuthorization.tsx
@@ -11,24 +11,30 @@ import {toUint8Array} from 'js-base64';
 import {useCallback} from 'react';
 import useSWR from 'swr';
 
+type Account = Readonly<{
+  address: Base64EncodedAddress;
+  publicKey: PublicKey;
+}>;
+
 const STORAGE_KEY = 'cachedAuthorization';
 
 function getDataFromAuthorizationResult(
   authorizationResult: AuthorizationResult,
 ) {
   return {
+    account: getAccountFromAuthorizationResult(authorizationResult),
     authorization: authorizationResult,
-    publicKey: getPublicKeyFromAuthorizationResult(authorizationResult),
   };
 }
 
-function getPublicKeyFromAuthorizationResult(
+function getAccountFromAuthorizationResult(
   authorizationResult: AuthorizationResult,
-): PublicKey {
-  return getPublicKeyFromAddress(
-    // TODO(#44): support multiple addresses
-    authorizationResult.addresses[0],
-  );
+): Account {
+  const address = authorizationResult.addresses[0]; // TODO(#44): support multiple addresses
+  return {
+    address,
+    publicKey: getPublicKeyFromAddress(address),
+  };
 }
 
 async function authorizationFetcher(storageKey: string) {
@@ -94,7 +100,7 @@ export default function useAuthorization() {
             identity: APP_IDENTITY,
           }));
       setAuthorization(authorizationResult);
-      return getPublicKeyFromAuthorizationResult(authorizationResult);
+      return getAccountFromAuthorizationResult(authorizationResult);
     },
     [data, setAuthorization],
   );
@@ -109,8 +115,8 @@ export default function useAuthorization() {
     [data?.authorization.auth_token, setAuthorization],
   );
   return {
+    account: data?.account ?? null,
     authorizeSession,
     deauthorizeSession,
-    publicKey: data?.publicKey ?? null,
   };
 }

--- a/js/packages/mobile-wallet-adapter-protocol-web3js/src/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/src/transact.ts
@@ -1,6 +1,7 @@
 import { Connection, PublicKey, Transaction, TransactionSignature } from '@solana/web3.js';
 import {
     AuthorizeAPI,
+    Base64EncodedAddress,
     CloneAuthorizationAPI,
     DeauthorizeAPI,
     Finality,
@@ -26,7 +27,7 @@ interface Web3SignTransactionsAPI {
 }
 
 interface Web3SignMessagesAPI {
-    signMessages(params: { payloads: Uint8Array[] }): Promise<Uint8Array[]>;
+    signMessages(params: { address: Base64EncodedAddress; payloads: Uint8Array[] }): Promise<Uint8Array[]>;
 }
 
 export interface Web3MobileWallet

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -63,6 +63,7 @@ export interface ReauthorizeAPI {
 }
 export interface SignMessagesAPI {
     signMessages(params: {
+        address: Base64EncodedAddress;
         payloads: Base64EncodedMessage[];
     }): Promise<Readonly<{ signed_payloads: Base64EncodedSignedMessage[] }>>;
 }


### PR DESCRIPTION
#### Problem

Unlike transactions, from which the requisite signer can be _inferred_, when we call methods like `signMessages` we have to _tell_ the wallet which authorized address we would like to sign the message with.

#### Summary of changes

* Added an `address` param to the `signMessages` API of the JavaScript protocol implementation.
* Updated the JavaScript example apps to supply `account` to `signMessages()`.

Addresses #175.