### PR TITLE
Update spec and JavaScript impl to add human-readable labels to accounts

### DIFF
--- a/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
+++ b/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
@@ -177,9 +177,10 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
 
             final byte[] publicKey;
             try {
-                final byte[][] addresses = JsonPack.unpackBase64PayloadsArrayToByteArrays(
-                        jo.getJSONArray(ProtocolContract.RESULT_ADDRESSES));
-                publicKey = addresses[0]; // TODO(#44): support multiple addresses
+                final JSONArray accounts = jo.getJSONArray(ProtocolContract.RESULT_ACCOUNTS);
+                final JSONObject account = accounts.getJSONObject(0); // TODO(#44): support multiple addresses
+                final String b64EncodedAddress = account.getString(ProtocolContract.RESULT_ACCOUNTS_ADDRESS);
+                publicKey = JsonPack.unpackBase64PayloadToByteArray(b64EncodedAddress);
             } catch (JSONException e) {
                 throw new JsonRpc20InvalidResponseException("expected one or more addresses");
             }

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
@@ -9,7 +9,7 @@ public class ProtocolContract {
     // METHOD_AUTHORIZE takes an optional PARAMETER_IDENTITY
     public static final String PARAMETER_CLUSTER = "cluster"; // type: String (one of the CLUSTER_* values)
     // METHOD_AUTHORIZE returns a RESULT_AUTH_TOKEN
-    // METHOD_AUTHORIZE returns a RESULT_ADDRESSES
+    // METHOD_AUTHORIZE returns a RESULT_ACCOUNTS
     // METHOD_AUTHORIZE returns an optional RESULT_WALLET_URI_BASE
 
     public static final String METHOD_DEAUTHORIZE = "deauthorize";
@@ -19,7 +19,7 @@ public class ProtocolContract {
     // METHOD_REAUTHORIZE takes an optional PARAMETER_IDENTITY
     // METHOD_REAUTHORIZE takes a PARAMETER_AUTH_TOKEN
     // METHOD_REAUTHORIZE returns a RESULT_AUTH_TOKEN
-    // METHOD_REAUTHORIZE returns a RESULT_ADDRESSES
+    // METHOD_REAUTHORIZE returns a RESULT_ACCOUNTS
     // METHOD_REAUTHORIZE returns an optional RESULT_WALLET_URI_BASE
 
     public static final String METHOD_CLONE_AUTHORIZATION = "clone_authorization";
@@ -56,7 +56,10 @@ public class ProtocolContract {
     public static final String PARAMETER_PAYLOADS = "payloads"; // type: JSON array of String (base64-encoded payloads)
 
     public static final String RESULT_AUTH_TOKEN = "auth_token"; // type: String
-    public static final String RESULT_ADDRESSES = "addresses"; // type: JSON array of String (base64-encoded addresses)
+    public static final String RESULT_ACCOUNTS = "accounts"; // type: JSON array of Account
+    public static final String RESULT_ACCOUNTS_ADDRESS = "address"; // type: String (base64-encoded addresses)
+    public static final String RESULT_ACCOUNTS_LABEL = "label"; // type: String
+
     public static final String RESULT_WALLET_URI_BASE = "wallet_uri_base"; // type: String (absolute URI)
 
     public static final String RESULT_SIGNED_PAYLOADS = "signed_payloads"; // type: JSON array of String (base64-encoded signed payloads)

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/util/JsonPack.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/util/JsonPack.java
@@ -30,9 +30,15 @@ public class JsonPack {
         final byte[][] byteArrays = new byte[numEntries][];
         for (int i = 0; i < numEntries; i++) {
             final String b64 = arr.getString(i);
-            byteArrays[i] = Base64.decode(b64, Base64.DEFAULT);
+            byteArrays[i] = unpackBase64PayloadToByteArray(b64);
         }
         return byteArrays;
+    }
+
+    @NonNull
+    public static byte[] unpackBase64PayloadToByteArray(@NonNull String b64Payload)
+            throws JSONException {
+        return Base64.decode(b64Payload, Base64.DEFAULT);
     }
 
     @NonNull

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -146,9 +146,14 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             final JSONObject o = new JSONObject();
             try {
                 o.put(ProtocolContract.RESULT_AUTH_TOKEN, result.authToken);
-                final JSONArray addresses = new JSONArray(); // TODO(#44): support multiple addresses
-                addresses.put(publicKeyBase64);
-                o.put(ProtocolContract.RESULT_ADDRESSES, addresses);
+                final JSONArray accounts = new JSONArray().put(
+                        // TODO(#44): support multiple accounts
+                        new JSONObject()
+                                .put(ProtocolContract.RESULT_ACCOUNTS_ADDRESS, publicKeyBase64)
+                                // TODO(#187): Implement account labels
+                                .put(ProtocolContract.RESULT_ACCOUNTS_LABEL, "My First Wallet")
+                );
+                o.put(ProtocolContract.RESULT_ACCOUNTS, accounts);
                 o.put(ProtocolContract.RESULT_WALLET_URI_BASE, result.walletUriBase); // OK if null
             } catch (JSONException e) {
                 throw new RuntimeException("Failed preparing authorization response", e);

--- a/examples/example-react-native-app/components/AccountInfo.tsx
+++ b/examples/example-react-native-app/components/AccountInfo.tsx
@@ -20,6 +20,15 @@ type Props = Readonly<{
   selectedAccount: Account;
 }>;
 
+function getLabelFromAccount(account: Account) {
+  const base58EncodedPublicKey = account.publicKey.toBase58();
+  if (account.label) {
+    return `${account.label} (${base58EncodedPublicKey.slice(0, 8)})`;
+  } else {
+    return base58EncodedPublicKey;
+  }
+}
+
 export default function AccountInfo({
   accounts,
   onChange,
@@ -28,6 +37,10 @@ export default function AccountInfo({
   const {colors} = useTheme();
   const selectedAccountPublicKeyBase58String = useMemo(
     () => selectedAccount.publicKey.toBase58(),
+    [selectedAccount],
+  );
+  const selectedAccountLabel = useMemo(
+    () => getLabelFromAccount(selectedAccount),
     [selectedAccount],
   );
   const [menuVisible, setMenuVisible] = useState(false);
@@ -50,7 +63,7 @@ export default function AccountInfo({
             );
           }}
           style={styles.keyRow}>
-          {'\u{1f5dd} ' + selectedAccountPublicKeyBase58String}
+          {'\u{1f5dd} ' + selectedAccountLabel}
         </Subheading>
         {accounts.length > 1 ? (
           <Menu
@@ -78,7 +91,7 @@ export default function AccountInfo({
                     setMenuVisible(false);
                   }}
                   key={base58PublicKey}
-                  title={base58PublicKey}
+                  title={getLabelFromAccount(account)}
                 />
               );
             })}

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -1,3 +1,8 @@
+export type Account = Readonly<{
+    address: Base64EncodedAddress;
+    label?: string;
+}>;
+
 /**
  * Properties that wallets may present to users when an app
  * asks for authorization to execute privileged methods (see
@@ -22,7 +27,7 @@ export type AssociationKeypair = CryptoKeyPair;
  * use it later to invoke privileged methods.
  */
 export type AuthorizationResult = Readonly<{
-    addresses: Base64EncodedAddress[];
+    accounts: Account[];
     auth_token: AuthToken;
     wallet_uri_base: string;
 }>;

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -126,7 +126,9 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
                 if (this._readyState !== WalletReadyState.Installed) {
                     this.emit('readyStateChange', (this._readyState = WalletReadyState.Installed));
                 }
-                this._selectedAddress = await this._addressSelector.select(cachedAuthorizationResult.addresses);
+                this._selectedAddress = await this._addressSelector.select(
+                    cachedAuthorizationResult.accounts.map(({ address }) => address),
+                );
                 this.emit(
                     'connect',
                     // Having just set `this._selectedAddress`, `this.publicKey` is definitely non-null
@@ -155,13 +157,17 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
         const didPublicKeysChange =
             // Case 1: We started from having no authorization.
             this._authorizationResult == null ||
-            // Case 2: The number of authorized public keys changed.
-            this._authorizationResult?.addresses.length !== authorizationResult.addresses.length ||
+            // Case 2: The number of authorized accounts changed.
+            this._authorizationResult?.accounts.length !== authorizationResult.accounts.length ||
             // Case 3: The new list of addresses isn't exactly the same as the old list, in the same order.
-            this._authorizationResult.addresses.some((address, ii) => address !== authorizationResult.addresses[ii]);
+            this._authorizationResult.accounts.some(
+                (account, ii) => account.address !== authorizationResult.accounts[ii].address,
+            );
         this._authorizationResult = authorizationResult;
         if (didPublicKeysChange) {
-            const nextSelectedAddress = await this._addressSelector.select(authorizationResult.addresses);
+            const nextSelectedAddress = await this._addressSelector.select(
+                authorizationResult.accounts.map(({ address }) => address),
+            );
             if (nextSelectedAddress !== this._selectedAddress) {
                 this._selectedAddress = nextSelectedAddress;
                 delete this._publicKey;

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -328,7 +328,10 @@ where:
 ```
 {
     “auth_token”: “<auth_token>”,
-    “addresses”: [“<address>", ...]
+    “accounts”: [
+        {“address”: “<address>", “label”: “<label>”},
+        ...
+    ],
     “wallet_uri_base”: “<wallet_uri_base>”,
 }
 ```
@@ -336,7 +339,9 @@ where:
 where:
 
 - `auth_token`: an opaque string representing a unique identifying token issued by the wallet endpoint to the dapp endpoint. The format and contents are an implementation detail of the wallet endpoint. The dapp endpoint can use this on future connections to `reauthorize` access to [privileged methods](#privileged-methods).
-- `addresses`: one or more base64-encoded addresses, for the accounts to which this auth token corresponds
+- `accounts`: one or more value objects that represent the accounts to which this auth token corresponds. These objects hold the following properties:
+  - `address`: a base64-encoded address for this account
+  - `label`: (optional) a human-readable string that describes the account. Wallet endpoints that allow their users to label their accounts may choose to return those labels here to enhance the user experience at the dapp endpoint.
 - `wallet_uri_base`: (optional) if this wallet endpoint has an [endpoint-specific URI](#endpoint-specific-uris) that the dapp endpoint should use for subsequent connections, this member will be included in the result object. The dapp endpoint should use this URI for all subsequent connections where it expects to use this `auth_token`.
 
 ###### Errors
@@ -348,7 +353,7 @@ where:
 
 ##### Description
 
-This method allows the dapp endpoint to request authorization from the wallet endpoint for access to [privileged methods](#privileged-methods). On success, it returns an `auth_token` providing access to privileged methods, along with addresses for all authorized accounts. It may also return a URI suitable for future use as an [endpoint-specific URI](#endpoint-specific-uris). After a successful call to `authorize`, the current session will be placed into an authorized state, with privileges associated with the returned `auth_token`. On failure, the current session with be placed into the unauthorized state.
+This method allows the dapp endpoint to request authorization from the wallet endpoint for access to [privileged methods](#privileged-methods). On success, it returns an `auth_token` providing access to privileged methods, along with addresses and optional labels for all authorized accounts. It may also return a URI suitable for future use as an [endpoint-specific URI](#endpoint-specific-uris). After a successful call to `authorize`, the current session will be placed into an authorized state, with privileges associated with the returned `auth_token`. On failure, the current session with be placed into the unauthorized state.
 
 The returned `auth_token` is an opaque string with meaning only to the wallet endpoint which created it. It is recommended that the wallet endpoint include a mechanism to authenticate the contents of auth tokens it issues (for e.g., with an HMAC, or by encryption with a secret symmetric key). This `auth_token` may be used to [`reauthorize`](#reauthorize) future sessions between these dapp and wallet endpoints. 
 
@@ -434,7 +439,10 @@ where:
 ```
 {
     “auth_token”: “<auth_token>”,
-    "addresses": [“<address>", ...]
+    “accounts”: [
+        {“address”: “<address>", “label”: “<label>”},
+        ...
+    ],
     “wallet_uri_base”: “<wallet_uri_base>”,
 }
 ```
@@ -442,7 +450,7 @@ where:
 where:
 
 - `auth_token`: as defined for [`authorize`](#authorize)
-- `addresses`: as defined for [`authorize`](#authorize)
+- `accounts`: as defined for [`authorize`](#authorize)
 - `wallet_uri_base`: as defined for [`authorize`](#authorize)
 
 ###### Errors
@@ -455,7 +463,7 @@ where:
 
 This method attempts to put the current session in an authorized state, with privileges associated with the specified `auth_token`.
 
-On success, the current session will be placed into an authorized state. Additionally, updated values for `auth_token`, `addresses`, and/or `wallet_uri_base` will be returned. These may differ from those originally provided in the [`authorize`](#authorize) response for this auth token; if so, they override any previous values for these parameters. The prior values should be discarded and not reused. This allows a wallet endpoint to update the auth token used by the dapp endpoint, or to modify the set of authorized account addresses without requiring the dapp endpoint to restart the authorization process.
+On success, the current session will be placed into an authorized state. Additionally, updated values for `auth_token`, `accounts`, and/or `wallet_uri_base` will be returned. These may differ from those originally provided in the [`authorize`](#authorize) response for this auth token; if so, they override any previous values for these parameters. The prior values should be discarded and not reused. This allows a wallet endpoint to update the auth token used by the dapp endpoint, or to modify the set of authorized account addresses or their labels without requiring the dapp endpoint to restart the authorization process.
 
 If the result is `ERROR_AUTHORIZATION_FAILED`, this auth token cannot be reused, and should be discarded. The dapp endpoint should request a new token with the [`authorize`](#authorize) method. The session with be placed into the unauthorized state.
 


### PR DESCRIPTION
# Problem

Using a dApp today demands that you memorize part of a base58 encoded public key, because that's the primary way by which a given account in your wallet is represented.

In the _wallets_ on the other hand, you're allowed to add convenient, human-readable labels, like ‘My NFT wallet.’

# Summary of changes

- [X] Update the spec to return `{address: Base64EncodedAddress, label?: string}` from `authorize` and `reauthorize`. dApps can now use that label in their UI for a better experience.
- [x] Update server/client implementation to supply labels with accounts
- [x] Update JavaScript protocol method signatures
- [x] Update React Native Example App to display labels
- [x] Update Web example app to handle accounts with labels

# Test plan

React Native example app, with address label:

<img width="376" alt="image" src="https://user-images.githubusercontent.com/13243/182250047-72880f4d-4358-46e3-8441-2b6491298ce8.png">

Addresses #187.