### PR TITLE
fix: move fee payer and blockhash backfilling from protocol implementation to wallet adapter plugin

### DIFF
--- a/examples/example-react-native-app/components/RecordMessageButton.tsx
+++ b/examples/example-react-native-app/components/RecordMessageButton.tsx
@@ -58,7 +58,6 @@ export default function RecordMessageButton({children, message}: Props) {
           }),
         );
         return await wallet.signAndSendTransactions({
-          connection,
           transactions: [memoProgramTransaction],
         });
       });


### PR DESCRIPTION
The web3.js protocol wrapper was only ever meant to translate between `@solana/web3.js` _datatypes_ and the raw underlying API's datatypes. Right now it does too much work.

# Summary of changes

* Move fee payer backfilling into the wallet adapter plugin
* Move blockhash backfilling into the wallet adapter plugin and choose the lower of the two commitments.