### PR TITLE
fix: you can now build the JS packages on Windows

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -33,7 +33,7 @@
         "clean": "shx rm -rf lib/*",
         "build": "yarn clean && rollup --config ../../rollup.config.ts --configPlugin rollup-plugin-ts",
         "build:watch": "yarn clean && rollup --config ../../rollup.config.ts --configPlugin rollup-plugin-ts --watch",
-        "postbuild": "echo '{\"type\":\"commonjs\"}' | npx json > lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > lib/esm/package.json",
+        "postbuild": "cross-env echo {\\\"type\\\":\\\"commonjs\\\"} | npx json > lib/cjs/package.json && echo {\\\"type\\\":\\\"module\\\"} | npx json > lib/esm/package.json",
         "prepublishOnly": "agadoo"
     },
     "peerDependencies": {
@@ -45,6 +45,7 @@
         "js-base64": "^3.7.2"
     },
     "devDependencies": {
-        "agadoo": "^2.0.0"
+        "agadoo": "^2.0.0",
+        "cross-env": "^7.0.3"
     }
 }

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -35,7 +35,7 @@
         "clean": "shx rm -rf lib/*",
         "build": "yarn clean && rollup --config ../../rollup.config.ts --configPlugin rollup-plugin-ts",
         "build:watch": "yarn clean && rollup --config ../../rollup.config.ts --configPlugin rollup-plugin-ts --watch",
-        "postbuild": "echo '{\"type\":\"commonjs\"}' | npx json > lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > lib/esm/package.json",
+        "postbuild": "cross-env echo {\\\"type\\\":\\\"commonjs\\\"} | npx json > lib/cjs/package.json && echo {\\\"type\\\":\\\"module\\\"} | npx json > lib/esm/package.json",
         "prepublishOnly": "agadoo"
     },
     "dependencies": {
@@ -43,6 +43,7 @@
     },
     "devDependencies": {
         "@types/react-native": "^0.69.3",
-        "agadoo": "^2.0.0"
+        "agadoo": "^2.0.0",
+        "cross-env": "^7.0.3"
     }
 }

--- a/js/packages/wallet-adapter-mobile/package.json
+++ b/js/packages/wallet-adapter-mobile/package.json
@@ -33,7 +33,7 @@
         "clean": "shx rm -rf lib/*",
         "build": "yarn clean && rollup --config ../../rollup.config.ts --configPlugin rollup-plugin-ts",
         "build:watch": "yarn clean && rollup --config ../../rollup.config.ts --configPlugin rollup-plugin-ts --watch",
-        "postbuild": "echo '{\"type\":\"commonjs\"}' | npx json > lib/cjs/package.json && echo '{\"type\":\"module\"} ' | npx json > lib/esm/package.json",
+        "postbuild": "cross-env echo {\\\"type\\\":\\\"commonjs\\\"} | npx json > lib/cjs/package.json && echo {\\\"type\\\":\\\"module\\\"} | npx json > lib/esm/package.json",
         "prepublishOnly": "agadoo"
     },
     "peerDependencies": {
@@ -48,6 +48,7 @@
     },
     "devDependencies": {
         "agadoo": "^2.0.0",
+        "cross-env": "^7.0.3",
         "shx": "^0.3.4"
     }
 }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -3571,6 +3571,13 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3582,7 +3589,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
I believe that Windows _includes_ the single quotes in the old `postbuild` script, which creates a `package.json` that is _not_ well-formed JSON.

# Summary of changes

* Lean on `cross-env` so that this script is escaped properly on Unix _and_ Windows.