### PR TITLE
fix: example apps now always fetch blockhash at finalized commitment for compatibility with `fakewallet`

### DIFF
--- a/examples/example-react-native-app/components/RecordMessageButton.tsx
+++ b/examples/example-react-native-app/components/RecordMessageButton.tsx
@@ -36,7 +36,10 @@ export default function RecordMessageButton({children, message}: Props) {
       const [signature] = await transact(async wallet => {
         const [freshAccount, latestBlockhash] = await Promise.all([
           authorizeSession(wallet),
-          connection.getLatestBlockhash(),
+          connection.getLatestBlockhash({
+            // FIXME(#199): `fakewallet` always simulates transactions at `finalized` commitment
+            commitment: 'finalized',
+          }),
         ]);
         const memoProgramTransaction = new Transaction({
           ...latestBlockhash,

--- a/examples/example-web-app/components/RecordMessageButton.tsx
+++ b/examples/example-web-app/components/RecordMessageButton.tsx
@@ -29,7 +29,10 @@ export default function RecordMessageButton({ children, message }: Props) {
     const recordMessageGuarded = useGuardedCallback(
         async (messageBuffer: Buffer): Promise<[string, RpcResponseAndContext<SignatureResult>]> => {
             const memoProgramTransaction = new Transaction({
-                ...(await connection.getLatestBlockhash()),
+                ...(await connection.getLatestBlockhash({
+                    // FIXME(#199): `fakewallet` always simulates transactions at `finalized` commitment
+                    commitment: 'finalized',
+                })),
                 feePayer: publicKey,
             }).add(
                 new TransactionInstruction({


### PR DESCRIPTION
Patches #199.