### PR TITLE
fix: `fakewallet` no longer bakes the Base64-encoded address into the account label itself

### DIFF
--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -7,7 +7,6 @@ package com.solana.mobilewalletadapter.fakewallet
 import android.app.Application
 import android.content.Intent
 import android.net.Uri
-import android.util.Base64
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -91,7 +90,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
                 Log.d(TAG, "Generated a new keypair (pub=${publicKey.encoded.contentToString()}) for authorize request")
                 request.request.completeWithAuthorize(
                     publicKey.encoded,
-                    "fakewallet [${Base64.encodeToString(publicKey.encoded, Base64.NO_WRAP)}]",
+                    "fakewallet",
                     null,
                     request.sourceVerificationState.authorizationScope.encodeToByteArray()
                 )


### PR DESCRIPTION
The apps already handle formatting of the account address + label.

This PR avoids this sort of thing: 
![image](https://user-images.githubusercontent.com/13243/183158761-042a3d49-2e18-43bf-9b29-75367ebbc726.png)
