### PR TITLE
Change fakewallet preflight commitment level

### DIFF
--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/usecase/SendTransactionsUseCase.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/usecase/SendTransactionsUseCase.kt
@@ -87,6 +87,7 @@ object SendTransactionsUseCase {
         // Parameter 1 - options
         val opt = JSONObject()
         opt.put("encoding", "base64")
+        opt.put("preflightCommitment", "processed")
         if (minContextSlot != null) {
             opt.put("minContextSlot", minContextSlot)
         }


### PR DESCRIPTION
Fixes #199
The transaction simulation in fakewallet relies on preflight, and is too strict
for the simple fakewallet implementation. Turn down the preflight commitment
level to correspond with the test & development nature of fakewallet.