### PR TITLE
fix: upgrade Android clientlib to 0.9.0 in React Native native module

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/android/build.gradle
+++ b/js/packages/mobile-wallet-adapter-protocol/android/build.gradle
@@ -132,7 +132,7 @@ def kotlin_version = getExtOrDefault('kotlinVersion')
 dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
-  implementation "com.solanamobile:mobile-wallet-adapter-clientlib:0.2.0"
+  implementation "com.solanamobile:mobile-wallet-adapter-clientlib:0.9.0"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.2"
 }


### PR DESCRIPTION
I noticed this fall behind, because my React Native apps were still using the [old timeout](https://github.com/solana-mobile/mobile-wallet-adapter/blame/121101848f95f34016ea4b5a1a82efaf502065ec/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/scenario/LocalAssociationScenario.java#L31) for session establishment.