### PR TITLE
fix: lower example apps' finality to 'processed'

### DIFF
--- a/examples/example-react-native-app/App.tsx
+++ b/examples/example-react-native-app/App.tsx
@@ -60,7 +60,9 @@ function asyncStorageProvider() {
 
 export default function App() {
   return (
-    <ConnectionProvider endpoint={DEVNET_ENDPOINT}>
+    <ConnectionProvider
+      config={{commitment: 'processed'}}
+      endpoint={DEVNET_ENDPOINT}>
       <SafeAreaView style={styles.shell}>
         <PaperProvider>
           <SnackbarProvider>

--- a/examples/example-react-native-app/components/FundAccountButton.tsx
+++ b/examples/example-react-native-app/components/FundAccountButton.tsx
@@ -24,7 +24,7 @@ export default function FundAccountButton({children, publicKey}: Props) {
       publicKey,
       LAMPORTS_PER_AIRDROP,
     );
-    return await connection.confirmTransaction(signature, 'finalized');
+    return await connection.confirmTransaction(signature);
   }, [connection]);
   return (
     <Button

--- a/examples/example-react-native-app/components/RecordMessageButton.tsx
+++ b/examples/example-react-native-app/components/RecordMessageButton.tsx
@@ -42,10 +42,7 @@ export default function RecordMessageButton({children, message}: Props) {
       const [signature] = await transact(async wallet => {
         const [freshAccount, latestBlockhash] = await Promise.all([
           authorizeSession(wallet),
-          connection.getLatestBlockhash({
-            // FIXME(#199): `fakewallet` always simulates transactions at `finalized` commitment
-            commitment: 'finalized',
-          }),
+          connection.getLatestBlockhash(),
         ]);
         const memoProgramTransaction = new Transaction({
           ...latestBlockhash,

--- a/examples/example-web-app/components/FundAccountButton.tsx
+++ b/examples/example-web-app/components/FundAccountButton.tsx
@@ -21,7 +21,7 @@ export default function FundAccountButton({ children }: Props) {
     const requestAirdropGuarded = useGuardedCallback(
         async (publicKey) => {
             const signature = await connection.requestAirdrop(publicKey, LAMPORTS_PER_AIRDROP);
-            return await connection.confirmTransaction(signature, 'finalized');
+            return await connection.confirmTransaction(signature);
         },
         [connection],
     );

--- a/examples/example-web-app/components/RecordMessageButton.tsx
+++ b/examples/example-web-app/components/RecordMessageButton.tsx
@@ -29,10 +29,7 @@ export default function RecordMessageButton({ children, message }: Props) {
     const recordMessageGuarded = useGuardedCallback(
         async (messageBuffer: Buffer): Promise<[string, RpcResponseAndContext<SignatureResult>]> => {
             const memoProgramTransaction = new Transaction({
-                ...(await connection.getLatestBlockhash({
-                    // FIXME(#199): `fakewallet` always simulates transactions at `finalized` commitment
-                    commitment: 'finalized',
-                })),
+                ...(await connection.getLatestBlockhash()),
                 feePayer: publicKey,
             }).add(
                 new TransactionInstruction({

--- a/examples/example-web-app/pages/_app.tsx
+++ b/examples/example-web-app/pages/_app.tsx
@@ -41,7 +41,7 @@ function ExampleMobileDApp({ Component, pageProps }: AppProps) {
     return (
         <ThemeProvider theme={theme}>
             <SnackbarProvider autoHideDuration={10000}>
-                <ConnectionProvider endpoint={ENDPOINT}>
+                <ConnectionProvider config={{ commitment: 'processed' }} endpoint={ENDPOINT}>
                     <WalletProvider wallets={wallets}>
                         <Component {...pageProps} />
                     </WalletProvider>


### PR DESCRIPTION
This will make the airdrop and memo transactions feel snappier.