### PR TITLE
Refactor some pieces of AuthRepository.java

### DIFF
--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
@@ -16,14 +16,6 @@ import androidx.annotation.NonNull;
     private static final String DATABASE_NAME_SUFFIX = "-solana-wallet-lib-auth.db";
     private static final int DATABASE_SCHEMA_VERSION = 5;
 
-    /*package*/ static final String TABLE_IDENTITIES = "identities";
-    /*package*/ static final String COLUMN_IDENTITIES_ID = "id"; // type: int
-    /*package*/ static final String COLUMN_IDENTITIES_NAME = "name"; // type: String
-    /*package*/ static final String COLUMN_IDENTITIES_URI = "uri"; // type: String
-    /*package*/ static final String COLUMN_IDENTITIES_ICON_RELATIVE_URI = "icon_relative_uri"; // type: String
-    /*package*/ static final String COLUMN_IDENTITIES_SECRET_KEY = "secret_key"; // type: byte[]
-    /*package*/ static final String COLUMN_IDENTITIES_SECRET_KEY_IV = "secret_key_iv"; // type: byte[]
-
     /*package*/ static final String TABLE_AUTHORIZATIONS = "authorizations";
     /*package*/ static final String COLUMN_AUTHORIZATIONS_ID = "id"; // type: int
     /*package*/ static final String COLUMN_AUTHORIZATIONS_IDENTITY_ID = "identity_id"; // type: long
@@ -42,14 +34,6 @@ import androidx.annotation.NonNull;
     /*package*/ static final String COLUMN_WALLET_URI_BASE_ID = "id"; // type: long
     /*package*/ static final String COLUMN_WALLET_URI_BASE_URI = "uri"; // type: String
 
-    private static final String CREATE_TABLE_IDENTITIES =
-            "CREATE TABLE " + TABLE_IDENTITIES + " (" +
-                    COLUMN_IDENTITIES_ID + " INTEGER NOT NULL PRIMARY KEY," +
-                    COLUMN_IDENTITIES_NAME + " TEXT NOT NULL," +
-                    COLUMN_IDENTITIES_URI + " TEXT NOT NULL," +
-                    COLUMN_IDENTITIES_ICON_RELATIVE_URI + " TEXT NOT NULL," +
-                    COLUMN_IDENTITIES_SECRET_KEY + " BLOB NOT NULL," +
-                    COLUMN_IDENTITIES_SECRET_KEY_IV + " BLOB NOT NULL)";
     private static final String CREATE_TABLE_AUTHORIZATIONS =
             "CREATE TABLE " + TABLE_AUTHORIZATIONS + " (" +
                     COLUMN_AUTHORIZATIONS_ID + " INTEGER NOT NULL PRIMARY KEY," +
@@ -80,7 +64,7 @@ import androidx.annotation.NonNull;
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        db.execSQL(CREATE_TABLE_IDENTITIES);
+        db.execSQL(IdentityRecordSchema.CREATE_TABLE_IDENTITIES);
         db.execSQL(CREATE_TABLE_AUTHORIZATIONS);
         db.execSQL(CREATE_TABLE_PUBLIC_KEYS);
         db.execSQL(CREATE_TABLE_WALLET_URI_BASE);
@@ -89,7 +73,7 @@ import androidx.annotation.NonNull;
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         Log.w(TAG, "Old database schema detected; pre-v1.0.0, no DB schema backward compatibility is implemented");
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_IDENTITIES);
+        db.execSQL("DROP TABLE IF EXISTS " + IdentityRecordSchema.TABLE_IDENTITIES);
         db.execSQL("DROP TABLE IF EXISTS " + TABLE_AUTHORIZATIONS);
         db.execSQL("DROP TABLE IF EXISTS " + TABLE_PUBLIC_KEYS);
         db.execSQL("DROP TABLE IF EXISTS " + TABLE_WALLET_URI_BASE);

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepository.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepository.java
@@ -197,8 +197,14 @@ public class AuthRepository {
             final String iconRelativeUri = c.getString(3);
             final byte[] keyCiphertext = c.getBlob(4);
             final byte[] keyIV = c.getBlob(5);
-            identityRecord = new IdentityRecord(id, name, Uri.parse(uri),
-                    Uri.parse(iconRelativeUri), keyCiphertext, keyIV);
+            identityRecord = new IdentityRecord.IdentityRecordBuilder()
+                    .setId(id)
+                    .setName(name)
+                    .setUri(Uri.parse(uri))
+                    .setRelativeIconUri(Uri.parse(iconRelativeUri))
+                    .setSecretKeyCiphertext(keyCiphertext)
+                    .setSecretKeyIV(keyIV)
+                    .build();
         }
 
         // Verify the HMAC on the auth token
@@ -396,8 +402,14 @@ public class AuthRepository {
             identityId = (int) db.insert(AuthDatabase.TABLE_IDENTITIES, null, identityContentValues);
         }
 
-        final IdentityRecord identityRecord = new IdentityRecord(identityId, name, uri,
-                relativeIconUri, identityKeyCiphertext, identityKeyIV);
+        final IdentityRecord identityRecord = new IdentityRecord.IdentityRecordBuilder()
+                .setId(identityId)
+                .setName(name)
+                .setUri(uri)
+                .setRelativeIconUri(relativeIconUri)
+                .setSecretKeyCiphertext(identityKeyCiphertext)
+                .setSecretKeyIV(identityKeyIV)
+                .build();
 
         // Next, try and look up the public key
         int publicKeyId = -1;
@@ -625,8 +637,14 @@ public class AuthRepository {
                 final byte[] identityKeyCiphertext = c.getBlob(4);
                 final byte[] identityKeyIV = c.getBlob(5);
                 // Note: values should never be null, but protect against bugs and corruption
-                final IdentityRecord identity = new IdentityRecord(id, name, Uri.parse(uri),
-                        Uri.parse(iconRelativeUri), identityKeyCiphertext, identityKeyIV);
+                final IdentityRecord identity = new IdentityRecord.IdentityRecordBuilder()
+                        .setId(id)
+                        .setName(name)
+                        .setUri(Uri.parse(uri))
+                        .setRelativeIconUri(Uri.parse(iconRelativeUri))
+                        .setSecretKeyCiphertext(identityKeyCiphertext)
+                        .setSecretKeyIV(identityKeyIV)
+                        .build();
                 identities.add(identity);
             }
         }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/DbContentProvider.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/DbContentProvider.java
@@ -1,0 +1,56 @@
+package com.solana.mobilewalletadapter.walletlib.authorization;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+public abstract class DbContentProvider<T> {
+    public SQLiteDatabase mDb;
+
+    public DbContentProvider(SQLiteDatabase db) {
+        this.mDb = db;
+    }
+
+    protected abstract T cursorToEntity(Cursor cursor);
+
+    public long insert(String tableName, ContentValues values) {
+        return mDb.insert(tableName,null, values);
+    }
+
+    public int delete(String tableName, String selection, String[] selectionArgs) {
+        return mDb.delete(tableName, selection, selectionArgs);
+    }
+
+    public Cursor query(String tableName, String[] columns,
+                        String selection, String[] selectionArgs, String sortOrder) {
+
+        return mDb.query(tableName, columns,
+                selection, selectionArgs, null, null, sortOrder);
+    }
+
+    public Cursor query(String tableName, String[] columns,
+                        String selection, String[] selectionArgs, String sortOrder,
+                        String limit) {
+
+        return mDb.query(tableName, columns, selection,
+                selectionArgs, null, null, sortOrder, limit);
+    }
+
+    public Cursor query(String tableName, String[] columns,
+                        String selection, String[] selectionArgs, String groupBy,
+                        String having, String orderBy, String limit) {
+
+        return mDb.query(tableName, columns, selection,
+                selectionArgs, groupBy, having, orderBy, limit);
+    }
+
+    public int update(String tableName, ContentValues values,
+                      String selection, String[] selectionArgs) {
+        return mDb.update(tableName, values, selection,
+                selectionArgs);
+    }
+
+    public Cursor rawQuery(String sql, String[] selectionArgs) {
+        return mDb.rawQuery(sql, selectionArgs);
+    }
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecord.java
@@ -12,23 +12,43 @@ import androidx.annotation.NonNull;
 import java.util.Objects;
 
 public class IdentityRecord {
+    private final int id;
+    private final String name;
+    private final Uri uri;
+    private final Uri relativeIconUri;
+    private final byte[] secretKeyCiphertext;
+    private final byte[] secretKeyIV;
+
     @IntRange(from = 1)
-    /*package*/ final int id;
+    /*package*/ int getId() {
+        return id;
+    }
 
     @NonNull
-    public final String name;
+    public String getName() {
+        return name;
+    }
 
     @NonNull
-    public final Uri uri;
+    public Uri getUri() {
+        return uri;
+    }
 
     @NonNull
-    public final Uri relativeIconUri;
+    public Uri getRelativeIconUri() {
+        return relativeIconUri;
+    }
 
     @NonNull
-    /*package*/ final byte[] secretKeyCiphertext;
+    /*package*/  byte[] getSecretKeyCiphertext() {
+        return secretKeyCiphertext;
+    }
 
     @NonNull
-    /*package*/ final byte[] secretKeyIV;
+    /*package*/  byte[] getSecretKeyIV() {
+        return secretKeyIV;
+    }
+
 
     /*package*/ IdentityRecord(IdentityRecordBuilder builder) {
         // N.B. This is a package-visibility constructor; these values will all be validated by
@@ -84,7 +104,7 @@ public class IdentityRecord {
         @NonNull
         private byte[] secretKeyIV;
 
-        public IdentityRecordBuilder() {
+        /*package*/ IdentityRecordBuilder() {
         }
 
         public IdentityRecordBuilder setId(int id) {

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecord.java
@@ -30,20 +30,15 @@ public class IdentityRecord {
     @NonNull
     /*package*/ final byte[] secretKeyIV;
 
-    /*package*/ IdentityRecord(int id,
-                               @NonNull String name,
-                               @NonNull Uri uri,
-                               @NonNull Uri relativeIconUri,
-                               @NonNull byte[] secretKeyCiphertext,
-                               @NonNull byte[] secretKeyIV) {
+    /*package*/ IdentityRecord(IdentityRecordBuilder builder) {
         // N.B. This is a package-visibility constructor; these values will all be validated by
         // other components within this package.
-        this.id = id;
-        this.name = name;
-        this.uri = uri;
-        this.relativeIconUri = relativeIconUri;
-        this.secretKeyCiphertext = secretKeyCiphertext;
-        this.secretKeyIV = secretKeyIV;
+        this.id = builder.id;
+        this.name = builder.name;
+        this.uri = builder.uri;
+        this.relativeIconUri = builder.relativeIconUri;
+        this.secretKeyCiphertext = builder.secretKeyCiphertext;
+        this.secretKeyIV = builder.secretKeyIV;
     }
 
     @Override
@@ -68,5 +63,63 @@ public class IdentityRecord {
                 ", uri=" + uri +
                 ", relativeIconUri=" + relativeIconUri +
                 '}';
+    }
+
+    public static class IdentityRecordBuilder {
+        @IntRange(from = 1)
+        private int id;
+
+        @NonNull
+        private String name;
+
+        @NonNull
+        private Uri uri;
+
+        @NonNull
+        private Uri relativeIconUri;
+
+        @NonNull
+        private byte[] secretKeyCiphertext;
+
+        @NonNull
+        private byte[] secretKeyIV;
+
+        public IdentityRecordBuilder() {
+        }
+
+        public IdentityRecordBuilder setId(int id) {
+            this.id = id;
+            return this;
+        }
+
+        public IdentityRecordBuilder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public IdentityRecordBuilder setUri(@NonNull Uri uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public IdentityRecordBuilder setRelativeIconUri(@NonNull Uri relativeIconUri) {
+            this.relativeIconUri = relativeIconUri;
+            return this;
+        }
+
+        public IdentityRecordBuilder setSecretKeyCiphertext(@NonNull byte[] secretKeyCiphertext) {
+            this.secretKeyCiphertext = secretKeyCiphertext;
+            return this;
+        }
+
+        public IdentityRecordBuilder setSecretKeyIV(@NonNull byte[] secretKeyIV) {
+            this.secretKeyIV = secretKeyIV;
+            return this;
+        }
+
+        public IdentityRecord build() {
+            return new IdentityRecord(this);
+        }
+
     }
 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDao.java
@@ -33,21 +33,25 @@ public class IdentityRecordDao extends DbContentProvider<IdentityRecord>
     }
 
     @Override
-    protected IdentityRecord cursorToEntity(Cursor cursor) {
-        final int id = cursor.getInt(0);
-        final String name = cursor.getString(1);
-        final String uri = cursor.getString(2);
-        final String iconRelativeUri = cursor.getString(3);
-        final byte[] identityKeyCiphertext = cursor.getBlob(4);
-        final byte[] identityKeyIV = cursor.getBlob(5);
-        return new IdentityRecord.IdentityRecordBuilder()
-                .setId(id)
-                .setName(name)
-                .setUri(Uri.parse(uri))
-                .setRelativeIconUri(Uri.parse(iconRelativeUri))
-                .setSecretKeyCiphertext(identityKeyCiphertext)
-                .setSecretKeyIV(identityKeyIV)
-                .build();
+    protected IdentityRecord cursorToEntity(@NonNull Cursor cursor) {
+        try {
+            final int id = cursor.getInt(cursor.getColumnIndexOrThrow(IdentityRecordSchema.COLUMN_IDENTITIES_ID));
+            final String name = cursor.getString(cursor.getColumnIndexOrThrow(IdentityRecordSchema.COLUMN_IDENTITIES_NAME));
+            final String uri = cursor.getString(cursor.getColumnIndexOrThrow(IdentityRecordSchema.COLUMN_IDENTITIES_URI));
+            final String iconRelativeUri = cursor.getString(cursor.getColumnIndexOrThrow(IdentityRecordSchema.COLUMN_IDENTITIES_ICON_RELATIVE_URI));
+            final byte[] identityKeyCiphertext = cursor.getBlob(cursor.getColumnIndexOrThrow(IdentityRecordSchema.COLUMN_IDENTITIES_SECRET_KEY));
+            final byte[] identityKeyIV = cursor.getBlob(cursor.getColumnIndexOrThrow(IdentityRecordSchema.COLUMN_IDENTITIES_SECRET_KEY_IV));
+            return new IdentityRecord.IdentityRecordBuilder()
+                    .setId(id)
+                    .setName(name)
+                    .setUri(Uri.parse(uri))
+                    .setRelativeIconUri(Uri.parse(iconRelativeUri))
+                    .setSecretKeyCiphertext(identityKeyCiphertext)
+                    .setSecretKeyIV(identityKeyIV)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            return new IdentityRecord.IdentityRecordBuilder().build();
+        }
     }
 
 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDao.java
@@ -1,0 +1,53 @@
+package com.solana.mobilewalletadapter.walletlib.authorization;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IdentityRecordDao extends DbContentProvider<IdentityRecord>
+        implements IdentityRecordDaoInterface, IdentityRecordSchema {
+
+    public IdentityRecordDao(SQLiteDatabase db) {
+        super(db);
+    }
+
+    @Override
+    @NonNull
+    public List<IdentityRecord> getAuthorizedIdentities() {
+        final ArrayList<IdentityRecord> identities = new ArrayList<>();
+        try (final Cursor c = super.query(IdentityRecordSchema.TABLE_IDENTITIES,
+                IDENTITY_RECORD_COLUMNS,
+                null,
+                null,
+                IdentityRecordSchema.COLUMN_IDENTITIES_NAME)) {
+            while (c.moveToNext()) {
+                identities.add(cursorToEntity(c));
+            }
+        }
+        return identities;
+    }
+
+    @Override
+    protected IdentityRecord cursorToEntity(Cursor cursor) {
+        final int id = cursor.getInt(0);
+        final String name = cursor.getString(1);
+        final String uri = cursor.getString(2);
+        final String iconRelativeUri = cursor.getString(3);
+        final byte[] identityKeyCiphertext = cursor.getBlob(4);
+        final byte[] identityKeyIV = cursor.getBlob(5);
+        return new IdentityRecord.IdentityRecordBuilder()
+                .setId(id)
+                .setName(name)
+                .setUri(Uri.parse(uri))
+                .setRelativeIconUri(Uri.parse(iconRelativeUri))
+                .setSecretKeyCiphertext(identityKeyCiphertext)
+                .setSecretKeyIV(identityKeyIV)
+                .build();
+    }
+
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDao.java
@@ -3,8 +3,10 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +35,43 @@ public class IdentityRecordDao extends DbContentProvider<IdentityRecord>
     }
 
     @Override
+    @Nullable
+    public IdentityRecord findIdentityById(String id) {
+        try (final Cursor c = super.query(IdentityRecordSchema.TABLE_IDENTITIES,
+                IDENTITY_RECORD_COLUMNS,
+                IdentityRecordSchema.COLUMN_IDENTITIES_ID + "=?",
+                new String[] { id },
+                null)) {
+            if (!c.moveToNext()) {
+                Log.w(TAG, "Identity not found: " + id);
+                return null;
+            }
+
+            return cursorToEntity(c);
+        }
+    }
+
+    @Nullable
+    @Override
+    public IdentityRecord findIdentityByParams(String name, String uri, String relativeIconUri) {
+        try (final Cursor c = super.query(IdentityRecordSchema.TABLE_IDENTITIES,
+                new String[] { IdentityRecordSchema.COLUMN_IDENTITIES_ID,
+                        IdentityRecordSchema.COLUMN_IDENTITIES_SECRET_KEY,
+                        IdentityRecordSchema.COLUMN_IDENTITIES_SECRET_KEY_IV },
+                IdentityRecordSchema.COLUMN_IDENTITIES_NAME + "=? AND " +
+                        IdentityRecordSchema.COLUMN_IDENTITIES_URI + "=? AND " +
+                        IdentityRecordSchema.COLUMN_IDENTITIES_ICON_RELATIVE_URI + "=?",
+                new String[] { name, uri, relativeIconUri},
+                null)) {
+            if (!c.moveToNext()) {
+                Log.w(TAG, "Identity not found with name=" + name);
+                return null;
+            }
+            return cursorToEntity(c);
+        }
+    }
+
+    @Override
     protected IdentityRecord cursorToEntity(@NonNull Cursor cursor) {
         try {
             final int id = cursor.getInt(cursor.getColumnIndexOrThrow(IdentityRecordSchema.COLUMN_IDENTITIES_ID));
@@ -54,4 +93,5 @@ public class IdentityRecordDao extends DbContentProvider<IdentityRecord>
         }
     }
 
+    private static final String TAG = "IDENTITY_RECORD_DAO";
 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDaoInterface.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDaoInterface.java
@@ -1,0 +1,10 @@
+package com.solana.mobilewalletadapter.walletlib.authorization;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
+public interface IdentityRecordDaoInterface {
+    @NonNull
+    List<IdentityRecord> getAuthorizedIdentities();
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDaoInterface.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordDaoInterface.java
@@ -1,10 +1,17 @@
 package com.solana.mobilewalletadapter.walletlib.authorization;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.List;
 
 public interface IdentityRecordDaoInterface {
     @NonNull
     List<IdentityRecord> getAuthorizedIdentities();
+
+    @Nullable
+    IdentityRecord findIdentityById(String id);
+
+    @Nullable
+    IdentityRecord findIdentityByParams(String name, String uri, String relativeIconUri);
 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordSchema.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/IdentityRecordSchema.java
@@ -1,0 +1,29 @@
+package com.solana.mobilewalletadapter.walletlib.authorization;
+
+public interface IdentityRecordSchema {
+    String TABLE_IDENTITIES = "identities";
+    String COLUMN_IDENTITIES_ID = "id"; // type: int
+    String COLUMN_IDENTITIES_NAME = "name"; // type: String
+    String COLUMN_IDENTITIES_URI = "uri"; // type: String
+    String COLUMN_IDENTITIES_ICON_RELATIVE_URI = "icon_relative_uri"; // type: String
+    String COLUMN_IDENTITIES_SECRET_KEY = "secret_key"; // type: byte[]
+    String COLUMN_IDENTITIES_SECRET_KEY_IV = "secret_key_iv"; // type: byte[]
+
+    String CREATE_TABLE_IDENTITIES =
+            "CREATE TABLE " + TABLE_IDENTITIES + " (" +
+                    COLUMN_IDENTITIES_ID + " INTEGER NOT NULL PRIMARY KEY," +
+                    COLUMN_IDENTITIES_NAME + " TEXT NOT NULL," +
+                    COLUMN_IDENTITIES_URI + " TEXT NOT NULL," +
+                    COLUMN_IDENTITIES_ICON_RELATIVE_URI + " TEXT NOT NULL," +
+                    COLUMN_IDENTITIES_SECRET_KEY + " BLOB NOT NULL," +
+                    COLUMN_IDENTITIES_SECRET_KEY_IV + " BLOB NOT NULL)";
+
+    String [] IDENTITY_RECORD_COLUMNS = new String[] {
+            COLUMN_IDENTITIES_ID,
+            COLUMN_IDENTITIES_NAME,
+            COLUMN_IDENTITIES_URI,
+            COLUMN_IDENTITIES_ICON_RELATIVE_URI,
+            COLUMN_IDENTITIES_SECRET_KEY,
+            COLUMN_IDENTITIES_SECRET_KEY_IV
+    };
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/Scenario.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/Scenario.java
@@ -270,8 +270,8 @@ public abstract class Scenario {
             }
 
             mIoHandler.post(() -> mCallbacks.onSignTransactionsRequest(new SignTransactionsRequest(
-                    request, authRecord.identity.name, authRecord.identity.uri,
-                    authRecord.identity.relativeIconUri, authRecord.scope,
+                    request, authRecord.identity.getName(), authRecord.identity.getUri(),
+                    authRecord.identity.getRelativeIconUri(), authRecord.scope,
                     authRecord.publicKey, authRecord.cluster)));
         }
 
@@ -289,8 +289,8 @@ public abstract class Scenario {
 
             try {
                 final SignMessagesRequest smr = new SignMessagesRequest(request,
-                        authRecord.identity.name, authRecord.identity.uri,
-                        authRecord.identity.relativeIconUri, authRecord.scope,
+                        authRecord.identity.getName(), authRecord.identity.getUri(),
+                        authRecord.identity.getRelativeIconUri(), authRecord.scope,
                         authRecord.publicKey, authRecord.cluster);
                 mIoHandler.post(() -> mCallbacks.onSignMessagesRequest(smr));
             } catch (IllegalArgumentException e) {
@@ -313,8 +313,8 @@ public abstract class Scenario {
             }
 
             mIoHandler.post(() -> mCallbacks.onSignAndSendTransactionsRequest(
-                    new SignAndSendTransactionsRequest(request, authRecord.identity.name,
-                            authRecord.identity.uri, authRecord.identity.relativeIconUri,
+                    new SignAndSendTransactionsRequest(request, authRecord.identity.getName(),
+                            authRecord.identity.getUri(), authRecord.identity.getRelativeIconUri(),
                             authRecord.scope, authRecord.publicKey, authRecord.cluster)));
         }
     };


### PR DESCRIPTION
1. Converted identityRecord to BuilderPattern. 

In this case, most fields are non-Nulls, however there would be other classes coming out of AuthRepository where it would make sense to use BuilderPattern. And I would like it to be consistent in the package. 

2. Created an abstract DbContentProvider class which can be extended by each Dao implementation. This class provides basic methods for query, insert, delete, rawQuery etc. 

3. Move a few methods for Identity table into an interface. 