### PR TITLE
feat: add a `hasAuthorizationResult()` method to the wallet adapter plugin

### DIFF
--- a/js/packages/wallet-adapter-mobile/src/__forks__/react-native/createDefaultAuthorizationResultCache.ts
+++ b/js/packages/wallet-adapter-mobile/src/__forks__/react-native/createDefaultAuthorizationResultCache.ts
@@ -20,6 +20,13 @@ export default function createDefaultAuthorizationResultCache(): AuthorizationRe
                 // eslint-disable-next-line no-empty
             } catch {}
         },
+        async hasResult() {
+            try {
+                return (await AsyncStorage.getItem(CACHE_KEY)) != null;
+            } catch {
+                return false;
+            }
+        },
         async set(authorizationResult: AuthorizationResult) {
             try {
                 await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(authorizationResult));

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -35,6 +35,7 @@ import { Cluster } from '@solana-mobile/mobile-wallet-adapter-protocol';
 export interface AuthorizationResultCache {
     clear(): Promise<void>;
     get(): Promise<AuthorizationResult | undefined>;
+    hasResult(): Promise<boolean>;
     set(authorizationResult: AuthorizationResult): Promise<void>;
 }
 
@@ -83,8 +84,8 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
         this._appIdentity = config.appIdentity;
         this._cluster = config.cluster;
         if (this._readyState !== WalletReadyState.Unsupported) {
-            this._authorizationResultCache.get().then((authorizationResult) => {
-                if (authorizationResult) {
+            this._authorizationResultCache.hasResult().then((hasResult) => {
+                if (hasResult) {
                     // Having a prior authorization result is, right now, the best
                     // indication that a mobile wallet is installed. There is no API
                     // we can use to test for whether the association URI is supported.
@@ -130,6 +131,10 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', e);
             throw e;
         }
+    }
+
+    async hasCachedAuthorizationResult(): Promise<boolean> {
+        return await this._authorizationResultCache.hasResult();
     }
 
     async connect(): Promise<void> {

--- a/js/packages/wallet-adapter-mobile/src/createDefaultAuthorizationResultCache.ts
+++ b/js/packages/wallet-adapter-mobile/src/createDefaultAuthorizationResultCache.ts
@@ -28,6 +28,16 @@ export default function createDefaultAuthorizationResultCache(): AuthorizationRe
                 // eslint-disable-next-line no-empty
             } catch {}
         },
+        async hasResult() {
+            if (!storage) {
+                return false;
+            }
+            try {
+                return storage.getItem(CACHE_KEY) != null;
+            } catch {
+                return false;
+            }
+        },
         async set(authorizationResult: AuthorizationResult) {
             if (!storage) {
                 return;


### PR DESCRIPTION
#### Problem

There is no way of knowing if it's ‘safe’ to call `connect()` on the mobile wallet adapter plugin as part of an autoconnect scheme. Firing off the `solana-wallet://` Universal Link without user interaction is not allowed, and will result in the browser either silently dropping the navigation or throwing up an interstitial dialog. We only want `@solana/wallet-adapter-react` to attempt autoconnect when we _know_ autoconnecting won't result in a round trip to the mobile wallet.

#### Proposed solution

Expose a `hasAuthorizationResult()` API.

#### Notes

I also contemplated just considering `readyState === WalletReadyState.Installed` as a strong-enough signal that autoconnect will go through without a wallet round-trip, but that's not airtight. You can still end up in a situation where `Installed` is the ready state _and_ the authorization cache is clear (ie. you just cleared it).