### PR TITLE
Revert "feat: add a `hasAuthorizationResult()` method to the wallet adapter plugin (#283)

### DIFF
--- a/js/packages/wallet-adapter-mobile/src/__forks__/react-native/createDefaultAuthorizationResultCache.ts
+++ b/js/packages/wallet-adapter-mobile/src/__forks__/react-native/createDefaultAuthorizationResultCache.ts
@@ -20,13 +20,6 @@ export default function createDefaultAuthorizationResultCache(): AuthorizationRe
                 // eslint-disable-next-line no-empty
             } catch {}
         },
-        async hasResult() {
-            try {
-                return (await AsyncStorage.getItem(CACHE_KEY)) != null;
-            } catch {
-                return false;
-            }
-        },
         async set(authorizationResult: AuthorizationResult) {
             try {
                 await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(authorizationResult));

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -35,7 +35,6 @@ import { Cluster } from '@solana-mobile/mobile-wallet-adapter-protocol';
 export interface AuthorizationResultCache {
     clear(): Promise<void>;
     get(): Promise<AuthorizationResult | undefined>;
-    hasResult(): Promise<boolean>;
     set(authorizationResult: AuthorizationResult): Promise<void>;
 }
 
@@ -84,8 +83,8 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
         this._appIdentity = config.appIdentity;
         this._cluster = config.cluster;
         if (this._readyState !== WalletReadyState.Unsupported) {
-            this._authorizationResultCache.hasResult().then((hasResult) => {
-                if (hasResult) {
+            this._authorizationResultCache.get().then((authorizationResult) => {
+                if (authorizationResult) {
                     // Having a prior authorization result is, right now, the best
                     // indication that a mobile wallet is installed. There is no API
                     // we can use to test for whether the association URI is supported.
@@ -131,10 +130,6 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
             this.emit('error', e);
             throw e;
         }
-    }
-
-    async hasCachedAuthorizationResult(): Promise<boolean> {
-        return await this._authorizationResultCache.hasResult();
     }
 
     async connect(): Promise<void> {

--- a/js/packages/wallet-adapter-mobile/src/createDefaultAuthorizationResultCache.ts
+++ b/js/packages/wallet-adapter-mobile/src/createDefaultAuthorizationResultCache.ts
@@ -28,16 +28,6 @@ export default function createDefaultAuthorizationResultCache(): AuthorizationRe
                 // eslint-disable-next-line no-empty
             } catch {}
         },
-        async hasResult() {
-            if (!storage) {
-                return false;
-            }
-            try {
-                return storage.getItem(CACHE_KEY) != null;
-            } catch {
-                return false;
-            }
-        },
         async set(authorizationResult: AuthorizationResult) {
             if (!storage) {
                 return;


### PR DESCRIPTION
Actually, #283 makes no sense. We need a _synchronous_ API to detect that.

This reverts commit c1de405a487e245db4d669eb875840ec6d38b1a3.