### PR TITLE
feat: a method you can call on the mobile wallet adapter in autoconnect scenarios

### DIFF
--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -132,6 +132,24 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
+    async autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(): Promise<void> {
+        if (this.connecting || this.connected) {
+            return;
+        }
+        return await this.runWithGuard(async () => {
+            if (this._readyState !== WalletReadyState.Installed && this._readyState !== WalletReadyState.Loadable) {
+                throw new WalletNotReadyError();
+            }
+            this._connecting = true;
+            const cachedAuthorizationResult = await this._authorizationResultCache.get();
+            if (cachedAuthorizationResult) {
+                // TODO: Evaluate whether there's any threat to not `awaiting` this expression
+                this.handleAuthorizationResult(cachedAuthorizationResult);
+            }
+            this._connecting = false;
+        });
+    }
+
     async connect(): Promise<void> {
         if (this.connecting || this.connected) {
             return;


### PR DESCRIPTION
#### Problem

There is no way of knowing if it's ‘safe’ to call `connect()` on the mobile wallet adapter plugin as part of an autoconnect scheme. Firing off the `solana-wallet://` Universal Link without user interaction is not allowed, and will result in the browser either silently dropping the navigation or throwing up an interstitial dialog. We only want `@solana/wallet-adapter-react` to attempt autoconnect when we _know_ autoconnecting won't result in a round trip to the mobile wallet.

#### Proposed solution

Expose a `autoConnect()` API.

#### Notes

The upcoming wallet standard already has a way to express ‘connect, but shutup about it’ through the [`silent`](https://github.com/wallet-standard/wallet-standard/blob/9509658f0be0624ebac6e2e3d4e0263454e38b4a/packages/core/features/src/connect.ts#L29-L33) param to connect. When this plugin gets upgraded for the standard, this method will go away and we'll use that.