### PR TITLE
Change the name of the mobile wallet adapter

### DIFF
--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -42,7 +42,7 @@ export interface AddressSelector {
     select(addresses: Base64EncodedAddress[]): Promise<Base64EncodedAddress>;
 }
 
-export const SolanaMobileWalletAdapterWalletName = 'Default wallet app' as WalletName;
+export const SolanaMobileWalletAdapterWalletName = 'Mobile Wallet Adapter' as WalletName;
 
 const SIGNATURE_LENGTH_IN_BYTES = 64;
 


### PR DESCRIPTION
At one time, we thought that we needed a name to show in the Solana Wallet Adapter dialog that communicated how MWA is not a wallet, but rather a connection to your default wallet; your favorite wallet; your choice of wallet in the Android disambiguation dialog.

By now, we've created an architecture where, you should never _see_ the MWA in a dialog at all. See https://github.com/solana-labs/wallet-adapter/pull/585

At this point, I think we've branded this thing hard enough to call it by its name, if anyone ever _does_ encounter it in a dialog or otherwise.

Its name is Mobile Wallet Adapter. Its name is Mobile Wallet Adapter. Its name, is Mobile Wallet Adapter. 