### PR TITLE
A method that gets called when no wallet can be found

### DIFF
--- a/examples/example-web-app/pages/_app.tsx
+++ b/examples/example-web-app/pages/_app.tsx
@@ -8,6 +8,7 @@ import { clusterApiUrl } from '@solana/web3.js';
 import {
     createDefaultAddressSelector,
     createDefaultAuthorizationResultCache,
+    createDefaultWalletNotFoundHandler,
     SolanaMobileWalletAdapter,
 } from '@solana-mobile/wallet-adapter-mobile';
 import type { AppProps } from 'next/app';
@@ -34,6 +35,7 @@ function ExampleMobileDApp({ Component, pageProps }: AppProps) {
                           },
                           authorizationResultCache: createDefaultAuthorizationResultCache(),
                           cluster: CLUSTER,
+                          onWalletNotFound: createDefaultWalletNotFoundHandler(),
                       }),
                   ],
         [],

--- a/js/packages/wallet-adapter-mobile/README.md
+++ b/js/packages/wallet-adapter-mobile/README.md
@@ -18,6 +18,7 @@ new SolanaMobileWalletAdapter({
     },
     authorizationResultCache: createDefaultAuthorizationResultCache(),
     cluster: WalletAdapterNetwork.Devnet,
+    onWalletNotFound: createDefaultWalletNotFoundHandler(),
 });
 ```
 
@@ -34,6 +35,7 @@ const wallets = useMemo(() => [
        },
         authorizationResultCache: createDefaultAuthorizationResultCache(),
         cluster: WalletAdapterNetwork.Devnet,
+        onWalletNotFound: createDefaultWalletNotFoundHandler(),
     });
     new PhantomWalletAdapter(),
     /* ... other wallets ... */
@@ -89,3 +91,9 @@ Alternatively, you can use the included `createDefaultAuthorizationResultCache()
 ### Cluster
 
 Each authorization a dApp makes with a wallet is tied to a particular Solana cluster. If a dApp wants to change the cluster on which to transact, it must seek an authorization for that cluster.
+
+### Wallet-not-found handler
+
+When you call `connect()` but no wallet responds within a reasonable amount of time, it is presumed that no compatible wallet is installed. You must supply an `onWalletNotFound` function to handle this case.
+
+Alternatively, you can use the included `createDefaultWalletNotFoundHandler()` method to create a function that opens the Solana Mobile ecosystem wallets webpage.

--- a/js/packages/wallet-adapter-mobile/src/createDefaultWalletNotFoundHandler.ts
+++ b/js/packages/wallet-adapter-mobile/src/createDefaultWalletNotFoundHandler.ts
@@ -1,0 +1,13 @@
+import { SolanaMobileWalletAdapter } from './adapter';
+
+async function defaultWalletNotFoundHandler(mobileWalletAdapter: SolanaMobileWalletAdapter) {
+    if (typeof window !== 'undefined') {
+        window.location.assign(mobileWalletAdapter.url);
+    }
+}
+
+export default function createDefaultWalletNotFoundHandler(): (
+    mobileWalletAdapter: SolanaMobileWalletAdapter,
+) => Promise<void> {
+    return defaultWalletNotFoundHandler;
+}

--- a/js/packages/wallet-adapter-mobile/src/index.ts
+++ b/js/packages/wallet-adapter-mobile/src/index.ts
@@ -1,3 +1,4 @@
 export * from './adapter';
 export { default as createDefaultAddressSelector } from './createDefaultAddressSelector';
 export { default as createDefaultAuthorizationResultCache } from './createDefaultAuthorizationResultCache';
+export { default as createDefaultWalletNotFoundHandler } from './createDefaultWalletNotFoundHandler';


### PR DESCRIPTION
Here, we add a config to the `SolanaMobileWalletAdapter` plugin – a handler that gets called when the protocol throws `ERROR_NO_WALLET_FOUND`.

Downstream projects should use this to present some sort of UI to their users, letting them know how and where to install their first MWA-compatible wallet.