### PR TITLE
Shim sign and send for those that do not support it

### DIFF
--- a/examples/example-web-app/yarn.lock
+++ b/examples/example-web-app/yarn.lock
@@ -360,7 +360,7 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@solana-mobile/mobile-wallet-adapter-protocol-web3js@^0.9.1":
+"@solana-mobile/mobile-wallet-adapter-protocol-web3js@^0.9.5":
   version "0.0.0"
   uid ""
 
@@ -368,7 +368,7 @@
   version "0.0.0"
   uid ""
 
-"@solana-mobile/mobile-wallet-adapter-protocol@^0.9.1":
+"@solana-mobile/mobile-wallet-adapter-protocol@^0.9.5":
   version "0.0.0"
   uid ""
 

--- a/js/packages/mobile-wallet-adapter-protocol/src/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/transact.ts
@@ -187,7 +187,7 @@ export async function transact<TReturn>(
                                                 id,
                                                 jsonrpc: '2.0',
                                                 method,
-                                                params,
+                                                params: params ?? {},
                                             },
                                             sharedSecret,
                                         ),


### PR DESCRIPTION
If a wallet does not support `signAndSendTransactions` then the mobile wallet adapter plugin will now use the `signTransactions` method to obtain a signed transaction, then send that transaction on the client side.

#### Test plan

1. Recompile `fakewallet` setting `supportsSignAndSendTransactions` to `false`
2. Use the example web app to send a transaction

https://user-images.githubusercontent.com/13243/196574787-a7f15358-c98b-4c92-aa13-a481401f3e08.mp4