### PR TITLE
Match the slot when fetching the blockhash and simulating the transaction

### DIFF
--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -22,6 +22,7 @@ import {
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
 import {
+    Blockhash,
     Connection,
     PublicKey,
     SendOptions,
@@ -307,7 +308,7 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
     ): Promise<TransactionSignature> {
         return await this.runWithGuard(async () => {
             const { authToken } = this.assertIsAuthorized();
-            const minContextSlot = options?.minContextSlot;
+            let minContextSlot = options?.minContextSlot;
             try {
                 return await this.transact(async (wallet) => {
                     function getTargetCommitment() {
@@ -358,9 +359,21 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
                               (async () => {
                                   transaction.feePayer ||= this.publicKey ?? undefined;
                                   if (transaction.recentBlockhash == null) {
-                                      const { blockhash } = await connection.getLatestBlockhash({
-                                          commitment: getTargetCommitment(),
-                                      });
+                                      let blockhash: Blockhash;
+                                      if (minContextSlot != null) {
+                                          const latestBlockhash = await connection.getLatestBlockhash({
+                                              commitment: getTargetCommitment(),
+                                              minContextSlot,
+                                          });
+                                          blockhash = latestBlockhash.blockhash;
+                                      } else {
+                                          const { context, value: latestBlockhash } =
+                                              await connection.getLatestBlockhashAndContext({
+                                                  commitment: getTargetCommitment(),
+                                              });
+                                          blockhash = latestBlockhash.blockhash;
+                                          minContextSlot = context.slot;
+                                      }
                                       transaction.recentBlockhash = blockhash;
                                   }
                               })(),


### PR DESCRIPTION
#### Problem

* If a min slot was specified but a blockhash was _not_ we have been fetching the blockhash at any old slot.
* If neither a min slot nor a blockhash were specified, we could use to fetch the min slot along with the blockhash, and forward that along to `sendTransaction`

#### Summary of changes

* ✅ slot ❌ blockhash: specify the min-slot when fetching the blockhash
* ❌ slot ❌ blockhash: fetch the slot along with the blockhash and use it when sending the transaction