### PR TITLE
Throw a different sort of error in the event of a websocket timeout

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/src/errors.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/errors.ts
@@ -4,6 +4,7 @@ export const SolanaMobileWalletAdapterErrorCode = {
     ERROR_FORBIDDEN_WALLET_BASE_URL: 'ERROR_FORBIDDEN_WALLET_BASE_URL',
     ERROR_SECURE_CONTEXT_REQUIRED: 'ERROR_SECURE_CONTEXT_REQUIRED',
     ERROR_SESSION_CLOSED: 'ERROR_SESSION_CLOSED',
+    ERROR_SESSION_TIMEOUT: 'ERROR_SESSION_TIMEOUT',
     ERROR_WALLET_NOT_FOUND: 'ERROR_WALLET_NOT_FOUND',
 } as const;
 type SolanaMobileWalletAdapterErrorCodeEnum =
@@ -18,6 +19,7 @@ type ErrorDataTypeMap = {
     [SolanaMobileWalletAdapterErrorCode.ERROR_SESSION_CLOSED]: {
         closeEvent: CloseEvent;
     };
+    [SolanaMobileWalletAdapterErrorCode.ERROR_SESSION_TIMEOUT]: undefined;
     [SolanaMobileWalletAdapterErrorCode.ERROR_WALLET_NOT_FOUND]: undefined;
 };
 

--- a/js/packages/mobile-wallet-adapter-protocol/src/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/transact.ts
@@ -128,7 +128,7 @@ export async function transact<TReturn>(
             if (Date.now() - connectionStartTime >= WEBSOCKET_CONNECTION_CONFIG.timeoutMs) {
                 reject(
                     new SolanaMobileWalletAdapterError(
-                        SolanaMobileWalletAdapterErrorCode.ERROR_WALLET_NOT_FOUND,
+                        SolanaMobileWalletAdapterErrorCode.ERROR_SESSION_TIMEOUT,
                         `Failed to connect to the wallet websocket on port ${sessionPort}.`,
                     ),
                 );


### PR DESCRIPTION
#### Problem

Right now, we can't distinguish between:

* No wallet responded to your association attempt.
* The wallet that responded failed to complete the session before the timeout.

#### Summary of changes

Throw a different sort of error in the event of a timeout. In particular, this prevents the ‘no wallet’ website from being loaded in the event that the wallet opens, but fails to establish a WebSocket server before the timeout.