### PR TITLE
Reduce sign_message size in fakedapp to the max size of a transaction

### DIFF
--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
@@ -183,7 +183,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 return@localAssociateAndExecute null
             }
             val messages = Array(numMessages) {
-                Random.nextBytes(16384)
+                Random.nextBytes(1232)
             }
             doSignMessages(client, messages, arrayOf(_uiState.value.publicKey!!))
         }


### PR DESCRIPTION
This ensures contexts that have message signing size implementation limits (like Seed Vault) can successfully sign the test messages.