### PR TITLE
Use `TextEncoder` instead of `Buffer` to encode JSON RPC messages

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/src/jsonRpcMessage.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/jsonRpcMessage.ts
@@ -28,7 +28,7 @@ export async function encryptJsonRpcMessage<TParams>(
     const ciphertext = await crypto.subtle.encrypt(
         getAlgorithmParams(sequenceNumberVector, initializationVector),
         sharedSecret,
-        Buffer.from(plaintext),
+        new TextEncoder().encode(plaintext),
     );
     const response = new Uint8Array(
         sequenceNumberVector.byteLength + initializationVector.byteLength + ciphertext.byteLength,


### PR DESCRIPTION
Someone noticed this crashing their app, because they didn't have `Buffer` polyfilled. We don't need it! Let's use [`TextEncoder`](https://caniuse.com/textencoder) instead.

#### Test plan

1. Create a `SolanaMobileWalletAdapter` with the `appIdentity.name`: Café 😭

Observe that FakeWallet renders the name correctly.