### PR TITLE
fix: typo in autoConnect function name [DO NOT MERGE ⚠️]

### DIFF
--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -150,7 +150,7 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    async autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(): Promise<void> {
+    async autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_HIRED(): Promise<void> {
         if (this.connecting || this.connected) {
             return;
         }


### PR DESCRIPTION
After using the `autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` I've noticed that the function has a typo

This PR includes a typo fix along with a job application.

LinkedIn: https://www.linkedin.com/in/josip-volarevic/
GitHub: https://github.com/josip-volarevic
GitHub org: https://github.com/open-sauce-labs
Personal website: http://josip-volarevic.com (might take a while to load initially)

Role: https://boards.greenhouse.io/solanafoundation/jobs/4697213004 (or any other role that you have for a full stack developer)

[resume.pdf](https://github.com/solana-mobile/mobile-wallet-adapter/files/9900861/resume.pdf)
