### PR TITLE
fix(walletlib): check values for null

### DIFF
--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -270,13 +270,13 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
         final Uri iconUri;
         final String identityName;
         if (ident != null) {
-            identityUri = ident.has(ProtocolContract.PARAMETER_IDENTITY_URI) ?
+            identityUri = ident.has(ProtocolContract.PARAMETER_IDENTITY_URI) && !ident.isNull(ProtocolContract.PARAMETER_IDENTITY_URI) ?
                     Uri.parse(ident.optString(ProtocolContract.PARAMETER_IDENTITY_URI)) : null;
             if (identityUri != null && (!identityUri.isAbsolute() || !identityUri.isHierarchical())) {
                 handleRpcError(id, ERROR_INVALID_PARAMS, "When specified, identity.uri must be an absolute, hierarchical URI", null);
                 return;
             }
-            iconUri = ident.has(ProtocolContract.PARAMETER_IDENTITY_ICON) ?
+            iconUri = ident.has(ProtocolContract.PARAMETER_IDENTITY_ICON) && !ident.isNull(ProtocolContract.PARAMETER_IDENTITY_ICON) ?
                     Uri.parse(ident.optString(ProtocolContract.PARAMETER_IDENTITY_ICON)) : null;
             if (iconUri != null && !iconUri.isRelative()) {
                 handleRpcError(id, ERROR_INVALID_PARAMS, "When specified, identity.icon must be a relative URI", null);
@@ -349,13 +349,13 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
         final Uri iconUri;
         final String identityName;
         if (ident != null) {
-            identityUri = ident.has(ProtocolContract.PARAMETER_IDENTITY_URI) ?
+            identityUri = ident.has(ProtocolContract.PARAMETER_IDENTITY_URI) && !ident.isNull(ProtocolContract.PARAMETER_IDENTITY_URI) ?
                     Uri.parse(ident.optString(ProtocolContract.PARAMETER_IDENTITY_URI)) : null;
             if (identityUri != null && (!identityUri.isAbsolute() || !identityUri.isHierarchical())) {
                 handleRpcError(id, ERROR_INVALID_PARAMS, "When specified, identity.uri must be an absolute, hierarchical URI", null);
                 return;
             }
-            iconUri = ident.has(ProtocolContract.PARAMETER_IDENTITY_ICON) ?
+            iconUri = ident.has(ProtocolContract.PARAMETER_IDENTITY_ICON) && !ident.isNull(ProtocolContract.PARAMETER_IDENTITY_ICON) ?
                     Uri.parse(ident.optString(ProtocolContract.PARAMETER_IDENTITY_ICON)) : null;
             if (iconUri != null && !iconUri.isRelative()) {
                 handleRpcError(id, ERROR_INVALID_PARAMS, "When specified, identity.icon must be a relative URI", null);


### PR DESCRIPTION
I suspect that the `.has(...)` function returns true even if the value is null.
```json
{
  "identity": {
    "uri": null,
    ...
  }
}
```

The clientlib does not seem to omit null values, rather it fills in the field with a null value. We can optimize the clientlib as well, but for the sake of robustness, let's add these checks in walletlib.

```
11-03 14:15:10.645 11273 13214 D JsonRpc20Server: Responding with error for id=1 (code=-32603, message=Error while processing authorization request: 'Attempt to invoke virtual method 'java.lang.String android.net.Uri.toString()' on a null object reference')
11-03 14:15:10.649 11424 13220 V JsonRpc20Client: JSON-RPC 2.0 message received
11-03 14:15:10.654 11424 13171 E MainViewModel: com.solana.mobilewalletadapter.clientlib.protocol.JsonRpc20Client$JsonRpc20RemoteException: -32603/Error while processing authorization request: 'Attempt to invoke virtual method 'java.lang.String android.net.Uri.toString()' on a null object reference'
```
