### PR TITLE
feat: expose origin of connection

### DIFF
--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalWebSocketServerScenario.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalWebSocketServerScenario.java
@@ -7,6 +7,7 @@ package com.solana.mobilewalletadapter.walletlib.scenario;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.solana.mobilewalletadapter.common.WebSocketsTransportContract;
 import com.solana.mobilewalletadapter.walletlib.authorization.AuthIssuerConfig;
@@ -52,6 +53,14 @@ public class LocalWebSocketServerScenario extends Scenario {
             mWebSocketServer.close(); // this will close all MobileWalletAdapterSessions
             mCallbacks.onScenarioTeardownComplete();
         });
+    }
+
+    @Nullable
+    public String getOrigin() throws IllegalStateException {
+        if (mState != State.RUNNING) {
+            throw new IllegalStateException("Not running");
+        }
+        return mWebSocketServer.getOrigin();
     }
 
     @NonNull

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/transport/websockets/server/LocalWebSocketServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/transport/websockets/server/LocalWebSocketServer.java
@@ -7,6 +7,7 @@ package com.solana.mobilewalletadapter.walletlib.transport.websockets.server;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.solana.mobilewalletadapter.common.WebSocketsTransportContract;
 import com.solana.mobilewalletadapter.common.protocol.MessageReceiver;
@@ -20,6 +21,7 @@ import org.java_websocket.WebSocketServerFactory;
 import org.java_websocket.drafts.Draft;
 import org.java_websocket.drafts.Draft_6455;
 import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.handshake.ServerHandshakeBuilder;
 import org.java_websocket.protocols.Protocol;
 import org.java_websocket.server.WebSocketServer;
 
@@ -43,6 +45,8 @@ public class LocalWebSocketServer extends WebSocketServer {
     private final Callbacks mCallbacks;
     @NonNull
     private State mState = State.NOT_INITIALIZED;
+    @Nullable
+    private String mOrigin;
 
     public LocalWebSocketServer(@NonNull LocalWebSocketServerScenario scenario,
                                 @NonNull Callbacks callbacks) {
@@ -77,9 +81,23 @@ public class LocalWebSocketServer extends WebSocketServer {
         mState = State.STOPPED;
     }
 
+    @Nullable
+    public String getOrigin() {
+        return mOrigin;
+    }
+
     @Override
     public void onStart() {
         mCallbacks.onStarted();
+    }
+
+    @Override
+    public ServerHandshakeBuilder onWebsocketHandshakeReceivedAsServer(WebSocket conn, Draft draft, ClientHandshake request)  {
+        ServerHandshakeBuilder builder = super.onWebsocketHandshakeReceivedAsServer(conn, draft, request);
+        if (request.hasFieldValue("Origin")) {
+            mOrigin = request.getFieldValue("Origin");
+        }
+        return builder;
     }
 
     @Override


### PR DESCRIPTION
This PR exposes the `Origin` of a connection in the `LocalWebSocketServerScenario` class.
This capability allows wallets to enforce a more rigorous security policy, enabling them to enforce a constraint that if an origin is provided, it must match its claimed identity. This is in no way a replacement for a proper web dApp attestation schema, merely allowing us to create another security hurdle for malicious web dApps that aim to imitate legitimate web dApps.
This PR has not been tested yet.