### PR TITLE
Add autoconnect function to adapter

### DIFF
--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -150,7 +150,7 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
-    // For backward compatibility only
+    /** @deprecated Use `autoConnect()` instead. */
     async autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(): Promise<void> {
         return await this.autoConnect();
     }

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -150,7 +150,12 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
         }
     }
 
+    // For backward compatibility only
     async autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_FIRED(): Promise<void> {
+        return await this.autoConnect();
+    }
+
+    async autoConnect(): Promise<void> {
         if (this.connecting || this.connected) {
             return;
         }


### PR DESCRIPTION
## What

- This PR moves the implementation of autoconnect for the mobile adapter into a new function `autoConnect`
- `autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` calls autoConnect for backward compatibility

## Why

- In short I want to add custom autoConnect behaviour to other wallet adapters. Discussed with @steveluscher and he suggested this generalisation, since MWA already has custom autoConnect behaviour and special case code in `WalletProvider handleAutoConnectRequest` to call it
- I'm going to do that by adding an `autoConnect` function to the `WalletAdapterProps` interface in the wallet-adapter base package: https://github.com/solana-labs/wallet-adapter/blob/98be91396f1d586761451c23c80c4cf54c101567/packages/core/base/src/adapter.ts#L24 . This is the only place that makes sense in order to use `autoConnect` in `handleAutoConnectRequest` of the react package
- There's a tricky dependency path: `wallet-adapter-react` -> `mobile-wallet-adapter` -> `wallet-adapter-base`.  This means if I add anything to the `WalletAdapterProps` then I get errors in the react package because `SolanaMobileWalletAdapter` doesn't correctly implement that interface. Since wallet-adapter is a monorepo this blocks building that repo with the new method added
- I think the easiest way to untangle it is to add `autoConnect` to `SolanaMobileWalletAdapter` here, update the `wallet-adapter-react` package to use a version with that, and then update the interface

<details>
  <summary>Click for long detailed version</summary>
  
In `WalletProvider handleAutoConnectRequest` (which calls autoconnect_do_not_use and connect currently, is where we'd want to call autoconnect), the adapter is of type `WalletAdapter<string> | SolanaMobileWalletAdapter`

The only base of `WalletAdapter<string>` is this interface `WalletAdapterProps`  (and also EventEmitter, but that seems irrelevant here)

That interface is implemented by `BaseWalletAdapter` and then following that class hierarchy up you get to all the adapters, including `SolanaMobileWalletAdapter`

Then there's a bunch  more code in `WalletProvider` that uses this type: `export type Adapter = WalletAdapter | SignerWalletAdapter | MessageSignerWalletAdapter;` All of those base classes eventually implement the `WalletAdapterProps`  interface

But the `SolanaMobileWalletAdapter`  imported from the solana-mobile library doesn't match, I think because its dependency is on the current version of `BaseMessageSignerWalletAdapter` , which eventually implements the current version of `WalletAdapterProps` without the new method

So the error looks like:

```
packages/core/react/src/WalletProvider.tsx:76:81 - error TS2345: Argument of type 'SolanaMobileWalletAdapter | WalletAdapter<string>' is not assignable to parameter of type 'Adapter'.
  Type 'SolanaMobileWalletAdapter' is not assignable to type 'Adapter'.
    Type 'SolanaMobileWalletAdapter' is not assignable to type 'SignerWalletAdapter<string>'.
      Property 'autoconnect' is missing in type 'SolanaMobileWalletAdapter' but required in type 'WalletAdapterProps<string>'.

76         if (mobileWalletAdapter == null || adaptersWithStandardAdapters.indexOf(mobileWalletAdapter) !== -1) {
```                                                     

And it looks like the wallet-adapter code all needs to build together in eg the github workflow, so this react package failing to build I think stops me building and releasing a new version of wallet-adapter-base with the new method added
</details>

