### PR TITLE
`fakedapp` Versioned Transactions Support

### DIFF
--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
@@ -6,6 +6,9 @@ package com.solana.mobilewalletadapter.fakedapp
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -49,6 +52,10 @@ class MainActivity : AppCompatActivity() {
                         viewBinding.btnSignAndSendTxnX3.isEnabled = isAuthorized
                         viewBinding.btnSignAndSendTxnX20.isEnabled = isAuthorized
                         viewBinding.cbHasAuthToken.isChecked = isAuthorized
+                    }
+
+                    viewModel.supportedTxnVersions.indexOf(uiState.txnVersion).let { spinnerPos ->
+                        if (spinnerPos > 0) viewBinding.spinnerTxnVer.setSelection(spinnerPos)
                     }
 
                     viewBinding.tvAccountName.text =
@@ -108,6 +115,29 @@ class MainActivity : AppCompatActivity() {
         viewBinding.btnAuthorizeSign.setOnClickListener {
             viewModel.authorizeAndSignTransactions(intentSender)
         }
+
+        viewBinding.spinnerTxnVer.adapter =
+            ArrayAdapter(this, android.R.layout.simple_spinner_item,
+                // mapping from view model txn version to localized UI string
+                viewModel.supportedTxnVersions.map { txnVersion ->
+                    getString(when (txnVersion) {
+                        "v0" -> R.string.label_txn_version_v0
+                        else -> R.string.label_txn_version_legacy
+                    })
+                }
+            )
+
+        viewBinding.spinnerTxnVer.onItemSelectedListener =
+            object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(parent: AdapterView<*>?, selected: View?,
+                                            index: Int, id: Long) {
+                    viewModel.setTransactionVersion(viewModel.supportedTxnVersions[index])
+                }
+
+                override fun onNothingSelected(parent: AdapterView<*>?) {
+                    // nothing to do
+                }
+            }
 
         viewBinding.btnSignMsgX1.setOnClickListener {
             viewModel.signMessages(intentSender, 1)

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.solana.mobilewalletadapter.fakedapp.databinding.ActivityMainBinding
+import com.solana.mobilewalletadapter.fakedapp.usecase.MemoTransactionVersion
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
@@ -121,8 +122,8 @@ class MainActivity : AppCompatActivity() {
                 // mapping from view model txn version to localized UI string
                 viewModel.supportedTxnVersions.map { txnVersion ->
                     getString(when (txnVersion) {
-                        "v0" -> R.string.label_txn_version_v0
-                        else -> R.string.label_txn_version_legacy
+                        MemoTransactionVersion.Legacy -> R.string.string_txn_version_legacy
+                        MemoTransactionVersion.V0 -> R.string.string_txn_version_v0
                     })
                 }
             )

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
@@ -37,11 +37,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _uiState = MutableStateFlow(UiState())
     val uiState = _uiState.asStateFlow()
 
-    // should probably make an enum or similar abstraction but this is fine for now
-    val supportedTxnVersions = listOf("legacy", "v0")
+    val supportedTxnVersions = listOf(MemoTransactionVersion.Legacy, MemoTransactionVersion.V0)
     val transactionUseCase get() = when(_uiState.value.txnVersion) {
-        "v0" -> MemoTransactionV0UseCase
-        else -> MemoTransactionLegacyUseCase
+        MemoTransactionVersion.Legacy -> MemoTransactionLegacyUseCase
+        MemoTransactionVersion.V0 -> MemoTransactionV0UseCase
     }
 
     private val mobileWalletAdapterClientSem = Semaphore(1) // allow only a single MWA connection at a time
@@ -101,7 +100,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    fun setTransactionVersion(txnVersion: String) {
+    fun setTransactionVersion(txnVersion: MemoTransactionVersion) {
         _uiState.update { it.copy(txnVersion = txnVersion) }
     }
 
@@ -584,7 +583,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val accountLabel: String? = null,
         val walletUriBase: Uri? = null,
         val messages: List<String> = emptyList(),
-        val txnVersion: String = "legacy"
+        val txnVersion: MemoTransactionVersion = MemoTransactionVersion.Legacy
     ) {
         val hasAuthToken: Boolean get() = (authToken != null)
 

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/MemoTransactionUseCase.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/MemoTransactionUseCase.kt
@@ -9,9 +9,13 @@ import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
 import kotlin.random.Random
 
+enum class MemoTransactionVersion {
+    Legacy, V0
+}
+
 // NOTE: this is just a minimal implementation of this Solana transaction, for testing purposes. It
 // is NOT suitable for production use.
-abstract class MemoTransactionUseCase {
+sealed class MemoTransactionUseCase {
     private val TAG = MemoTransactionUseCase::class.simpleName
 
     fun create(publicKey: ByteArray, latestBlockhash: ByteArray): ByteArray {

--- a/android/fakedapp/src/main/res/layout/activity_main.xml
+++ b/android/fakedapp/src/main/res/layout/activity_main.xml
@@ -45,11 +45,31 @@
         app:layout_constraintTop_toBottomOf="@id/btn_deauthorize"
         android:text="@string/label_request_airdrop" />
 
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/label_txn_ver"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="12dp"
+        android:textAppearance="?textAppearanceBody1"
+        app:layout_constraintTop_toBottomOf="@id/btn_request_airdrop"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/spinner_txn_ver"
+        android:text="@string/label_txn_version" />
+
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/spinner_txn_ver"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="@id/label_txn_ver"
+        app:layout_constraintBottom_toBottomOf="@id/label_txn_ver"
+        app:layout_constraintStart_toEndOf="@id/label_txn_ver"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_sign_txn_x1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/btn_request_airdrop"
+        app:layout_constraintTop_toBottomOf="@id/label_txn_ver"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/btn_sign_txn_x3"
         android:text="@string/label_sign_txn_x1" />

--- a/android/fakedapp/src/main/res/values/strings.xml
+++ b/android/fakedapp/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <string name="label_sign_msg_x1">Sign msg x1</string>
     <string name="label_sign_msg_x3">x3</string>
     <string name="label_sign_msg_x20">x20</string>
+    <string name="label_txn_version">Transaction Version:</string>
+    <string name="label_txn_version_legacy">Legacy</string>
+    <string name="label_txn_version_v0">V0</string>
     <string name="label_sign_and_send_txn_x1">Sign and send txn x1</string>
     <string name="label_sign_and_send_txn_x3">x3</string>
     <string name="label_sign_and_send_txn_x20">x20</string>

--- a/android/fakedapp/src/main/res/values/strings.xml
+++ b/android/fakedapp/src/main/res/values/strings.xml
@@ -25,8 +25,8 @@
     <string name="label_sign_msg_x3">x3</string>
     <string name="label_sign_msg_x20">x20</string>
     <string name="label_txn_version">Transaction Version:</string>
-    <string name="label_txn_version_legacy">Legacy</string>
-    <string name="label_txn_version_v0">V0</string>
+    <string name="string_txn_version_legacy">Legacy</string>
+    <string name="string_txn_version_v0">V0</string>
     <string name="label_sign_and_send_txn_x1">Sign and send txn x1</string>
     <string name="label_sign_and_send_txn_x3">x3</string>
     <string name="label_sign_and_send_txn_x20">x20</string>


### PR DESCRIPTION
## Task
- Add support for versioned transactions in the `fakedapp`
- https://github.com/solana-mobile/mobile-wallet-adapter/issues/344

## Work Completed
- created abstract `MemoTransactionUseCase`  with common memo transaction code
- created both `MemoTransactionLegacyUseCase`  and  `MemoTransactionV0UseCase`  with relevant transaction templates
- added "Transaction Version" drop down spinner to the activity and connected everything in the vm

## `fakewallet` changes
- added support for versioned transactions in the fake wallet (checks transaction message bit flag and reads version) 

## Testing
### `fakewallet`
- verified signing both legacy and v0 transactions with the fake wallet completes without error
- verified signing and sending both legacy and v0 transactions to testnet ([legacy](https://solscan.io/tx/5pCZzohoz7RVKnnPEskf5jj7HXRHWaWNDBDqyzn19RNZ6DVDfXHjxtqJUDsX62fdWNf98o8V2sSFChXGxhkkuxEf?cluster=testnet) and [v0](https://solscan.io/tx/2K8W3zeWtEiWonDRNbyvxUbpZGetGDV2TL6vYoQTU1LZEfD5FVBL87PMEuhK5gxxReVcmJ8edn9gK3GP2HWRnqcq?cluster=testnet))

### Phantom
- with seed vault:
  - verified signing both legacy and v0 transactions with Phantom completes without error
  - verified signing and sending both legacy and v0 transactions to testnet
- with internal Phantom wallet
  - verified signing both legacy and v0 transactions with Phantom completes without error
  - ~signing and sending both legacy and v0 transactions to testnet~ FAIL: Phantom returns error "User did not authorize signing"

### Solflare
- with seed vault:
  - verified signing both legacy and v0 transactions with Solflare completes without error
  - cannot sign and send transactions: Solflare returns error "method 'sign_and_send_transactions' not available"