### PR TITLE
Fix wallet select disambiguation cancellation crash

### DIFF
--- a/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/ActivityResultSender.kt
+++ b/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/ActivityResultSender.kt
@@ -1,7 +1,35 @@
 package com.solana.mobilewalletadapter.clientlib
 
 import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.GuardedBy
 
-interface ActivityResultSender {
-    fun launch(intent: Intent)
+class ActivityResultSender(
+    rootActivity: ComponentActivity
+) {
+    @GuardedBy("this")
+    private var callback: (() -> Unit)? = null
+
+    private val activityResultLauncher: ActivityResultLauncher<Intent> =
+        rootActivity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            onActivityComplete()
+        }
+
+    fun startActivityForResult(intent: Intent, onActivityCompleteCallback: () -> Unit) {
+        synchronized(this) {
+            check(callback == null) { "Received an activity start request while another is pending" }
+            callback = onActivityCompleteCallback
+        }
+
+        activityResultLauncher.launch(intent)
+    }
+
+    private fun onActivityComplete() {
+        synchronized(this) {
+            callback?.let { it() }
+            callback = null
+        }
+    }
 }

--- a/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/MobileWalletAdapter.kt
+++ b/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/MobileWalletAdapter.kt
@@ -7,9 +7,7 @@ import com.solana.mobilewalletadapter.clientlib.scenario.LocalAssociationIntentC
 import com.solana.mobilewalletadapter.clientlib.scenario.LocalAssociationScenario
 import com.solana.mobilewalletadapter.clientlib.scenario.Scenario
 import com.solana.mobilewalletadapter.common.ProtocolContract
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import java.io.IOException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
@@ -30,7 +28,12 @@ class MobileWalletAdapter(
                 val details = scenario.associationDetails()
 
                 val intent = LocalAssociationIntentCreator.createAssociationIntent(details.uriPrefix, details.port, details.session)
-                sender.launch(intent)
+                sender.startActivityForResult(intent) {
+                    launch {
+                        delay(5000)
+                        this@withContext.cancel()
+                    }
+                }
 
                 val client = try {
                     @Suppress("BlockingMethodInNonBlockingContext")

--- a/examples/example-clientlib-ktx-app/app/src/main/java/com/solanamobile/ktxclientsample/activity/MainActivity.kt
+++ b/examples/example-clientlib-ktx-app/app/src/main/java/com/solanamobile/ktxclientsample/activity/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.solanamobile.ktxclientsample.activity
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -14,9 +13,11 @@ import com.solanamobile.ktxclientsample.ui.theme.KtxClientSampleTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity(), ActivityResultSender {
+class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val sender = ActivityResultSender(this)
 
         setContent {
             KtxClientSampleTheme {
@@ -24,13 +25,9 @@ class MainActivity : ComponentActivity(), ActivityResultSender {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    SampleScreen(this)
+                    SampleScreen(sender)
                 }
             }
         }
-    }
-
-    override fun launch(intent: Intent) {
-        startActivityForResult(intent, 0)
     }
 }


### PR DESCRIPTION
Clientlib KTX unfortunately has had a bug all along where if you cancel the wallet selection disambiguation dialog, after the full socket connection timeout, the lib would crash.

We had initially implemented KTX MWA to propagate any exceptions to the conusmer, however this was a design flaw. As this is a convenience library, any underlying exceptions should not crash the consumer application.

The new design implements a returned sealed class hierarchy where if the transact operation was successful, the consumer gets a `Success`  object with a data payload. If there was an underlying failure, the consumer gets a `Failure` object with relevant error details. The consumer can decide if they want to parse/respond to certain errors. This sealed class hierarchy could be extended to have specific error types that we want to notify the user about.