### PR TITLE
Fix ActivityResultSender holding the lock when activity resolution fails

### DIFF
--- a/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/ActivityResultSender.kt
+++ b/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/ActivityResultSender.kt
@@ -1,5 +1,6 @@
 package com.solana.mobilewalletadapter.clientlib
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
@@ -23,7 +24,12 @@ class ActivityResultSender(
             callback = onActivityCompleteCallback
         }
 
-        activityResultLauncher.launch(intent)
+        try {
+            activityResultLauncher.launch(intent)
+        } catch (exception: ActivityNotFoundException) {
+            callback = null
+            throw exception
+        }
     }
 
     private fun onActivityComplete() {


### PR DESCRIPTION
Not using `resolveActivity` intentionally as this requires the package query permission starting sdk 30. 
Catching the error to clear callback and throwing the same exception back for clients to handle it appropriately. 

Fixes #383 