### PR TITLE
New improved API for sign_messages

### DIFF
--- a/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/AdapterOperations.kt
+++ b/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/AdapterOperations.kt
@@ -8,7 +8,13 @@ interface AdapterOperations {
     suspend fun reauthorize(identityUri: Uri, iconUri: Uri, identityName: String, authToken: String): MobileWalletAdapterClient.AuthorizationResult
     suspend fun deauthorize(authToken: String)
     suspend fun getCapabilities(): MobileWalletAdapterClient.GetCapabilitiesResult
+    @Deprecated(
+        "Replaced by signMessagesDetached, which returns the improved MobileWalletAdapterClient.SignMessagesResult type",
+        replaceWith = ReplaceWith("signMessagesDetached(messages, addresses)"),
+        DeprecationLevel.WARNING
+    )
     suspend fun signMessages(messages: Array<ByteArray>, addresses: Array<ByteArray>): MobileWalletAdapterClient.SignPayloadsResult
+    suspend fun signMessagesDetached(messages: Array<ByteArray>, addresses: Array<ByteArray>): MobileWalletAdapterClient.SignMessagesResult
     suspend fun signTransactions(transactions: Array<ByteArray>): MobileWalletAdapterClient.SignPayloadsResult
     suspend fun signAndSendTransactions(transactions: Array<ByteArray>, params: TransactionParams = DefaultTransactionParams): MobileWalletAdapterClient.SignAndSendTransactionsResult
 }

--- a/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/LocalAdapterOperations.kt
+++ b/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/LocalAdapterOperations.kt
@@ -56,6 +56,14 @@ class LocalAdapterOperations(
         }
     }
 
+    override suspend fun signMessagesDetached(messages: Array<ByteArray>, addresses: Array<ByteArray>): MobileWalletAdapterClient.SignMessagesResult {
+        return withContext(ioDispatcher) {
+            @Suppress("BlockingMethodInNonBlockingContext")
+            client?.signMessagesDetached(messages, addresses)?.get()
+                ?: throw InvalidObjectException("Provide a client before performing adapter operations")
+        }
+    }
+
     override suspend fun signTransactions(transactions: Array<ByteArray>): MobileWalletAdapterClient.SignPayloadsResult {
         return withContext(ioDispatcher) {
             @Suppress("BlockingMethodInNonBlockingContext")

--- a/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/RxMobileWalletAdapterClient.java
+++ b/android/clientlib-rxjava/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/RxMobileWalletAdapterClient.java
@@ -13,6 +13,8 @@ import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClie
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.DeauthorizeFuture;
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignAndSendTransactionsFuture;
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignAndSendTransactionsResult;
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignMessagesFuture;
+import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignMessagesResult;
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignPayloadsFuture;
 import com.solana.mobilewalletadapter.clientlib.protocol.MobileWalletAdapterClient.SignPayloadsResult;
 
@@ -83,6 +85,12 @@ public class RxMobileWalletAdapterClient {
         }
     }
 
+    /**
+     * @deprecated Consumers of {@link #signMessages(byte[][], byte[][])} should migrate to
+     *             {@link #signMessagesDetached(byte[][], byte[][])}, which offers an improved
+     *             return type, separating the message from the signatures
+     */
+    @Deprecated
     @CheckResult
     @NonNull
     public Single<SignPayloadsResult> signMessages(@NonNull @Size(min = 1) byte[][] messages,
@@ -90,6 +98,18 @@ public class RxMobileWalletAdapterClient {
         try {
             SignPayloadsFuture signPayloadsFuture = mMobileWalletAdapterClient.signMessages(messages, addresses);
             return Single.fromFuture(signPayloadsFuture);
+        } catch (Exception e) {
+            return Single.error(e);
+        }
+    }
+
+    @CheckResult
+    @NonNull
+    public Single<SignMessagesResult> signMessagesDetached(@NonNull @Size(min = 1) byte[][] messages,
+                                                           @NonNull @Size(min = 1) byte[][] addresses) {
+        try {
+            SignMessagesFuture signMessagesFuture = mMobileWalletAdapterClient.signMessagesDetached(messages, addresses);
+            return Single.fromFuture(signMessagesFuture);
         } catch (Exception e) {
             return Single.error(e);
         }

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/OffChainMessageSigningUseCase.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/OffChainMessageSigningUseCase.kt
@@ -1,0 +1,23 @@
+package com.solana.mobilewalletadapter.fakedapp.usecase
+
+import android.util.Log
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+
+object OffChainMessageSigningUseCase {
+    private val TAG = OffChainMessageSigningUseCase::class.java.simpleName
+
+    fun verify(signedMessage: ByteArray, signature: ByteArray, publicKey: ByteArray, originalMessage: ByteArray) {
+        if (!(signedMessage contentEquals originalMessage)) {
+            Log.w(TAG, "Signed message differs from original message. Verifying provided signature on signed message.")
+        }
+
+        val publicKeyParams = Ed25519PublicKeyParameters(publicKey, 0)
+        val signer = Ed25519Signer()
+        signer.init(false, publicKeyParams)
+        signer.update(signedMessage, 0, signedMessage.size)
+        val verified = signer.verifySignature(signature)
+        require(verified) { "Message signature is invalid" }
+        Log.d(TAG, "Verified message signature with publicKey(base58)=${Base58EncodeUseCase(publicKey)}")
+    }
+}


### PR DESCRIPTION
Verified with both FakeWallet (which returns signed messages of the form `M || sig(M)`, per the MWA spec), and another wallet (which returns only `sig(M)`). Both returned `SignMessageResult` objects with the appropriate signature, address, and message components populated.

I also tested the Kotlin and RxJava samples, and both worked as expected.