### PR TITLE
FakeDApp offchain message signing should use non-random messages

### DIFF
--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainViewModel.kt
@@ -32,7 +32,6 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import kotlin.random.Random
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _uiState = MutableStateFlow(UiState())
@@ -186,8 +185,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun signMessages(sender: StartActivityForResultSender, numMessages: Int) = viewModelScope.launch {
-        val messages = Array(numMessages) {
-            Random.nextBytes(1232)
+        val messages = Array(numMessages) { i ->
+            when (i) {
+                1 -> ByteArray(1232) { j -> ('a' + (j % 10)).code.toByte() }
+                2 -> ByteArray(32768) { j -> j.toByte() }
+                else -> "A simple test message $i".encodeToByteArray()
+            }
         }
         val signedMessages = localAssociateAndExecute(sender, _uiState.value.walletUriBase) { client ->
             val authorized = doReauthorize(client)

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/OffChainMessageSigningUseCase.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/OffChainMessageSigningUseCase.kt
@@ -1,5 +1,6 @@
 package com.solana.mobilewalletadapter.fakedapp.usecase
 
+import android.util.Base64
 import android.util.Log
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
@@ -18,6 +19,8 @@ object OffChainMessageSigningUseCase {
         signer.update(signedMessage, 0, signedMessage.size)
         val verified = signer.verifySignature(signature)
         require(verified) { "Message signature is invalid" }
-        Log.d(TAG, "Verified message signature with publicKey(base58)=${Base58EncodeUseCase(publicKey)}")
+        Log.d(TAG, "Verified message signature with publicKey(base58)=${Base58EncodeUseCase(publicKey)}, "+
+                "sig(base58)=${Base58EncodeUseCase(signature)}, " +
+                "message(base64)=${Base64.encodeToString(signedMessage, Base64.NO_WRAP)}")
     }
 }


### PR DESCRIPTION
This improves both repeatability of tests, as well as comprehension of signing in wallets