### PR TITLE
Add `identity` to the method signature of `reauthorize`

### DIFF
--- a/examples/example-react-native-app/utils/useAuthorization.tsx
+++ b/examples/example-react-native-app/utils/useAuthorization.tsx
@@ -87,6 +87,7 @@ export default function useAuthorization() {
       const authorizationResult = await (authorization
         ? wallet.reauthorize({
             auth_token: authorization.authToken,
+            identity: APP_IDENTITY,
           })
         : wallet.authorize({
             cluster: 'devnet',

--- a/examples/example-react-native-app/yarn.lock
+++ b/examples/example-react-native-app/yarn.lock
@@ -1342,14 +1342,14 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@solana-mobile/mobile-wallet-adapter-protocol-web3js@file:../../js/packages/mobile-wallet-adapter-protocol-web3js":
-  version "0.9.1"
+  version "1.0.0"
   dependencies:
-    "@solana-mobile/mobile-wallet-adapter-protocol" "^0.9.1"
+    "@solana-mobile/mobile-wallet-adapter-protocol" "^1.0.0"
     bs58 "^5.0.0"
     js-base64 "^3.7.2"
 
-"@solana-mobile/mobile-wallet-adapter-protocol@^0.9.1", "@solana-mobile/mobile-wallet-adapter-protocol@file:../../js/packages/mobile-wallet-adapter-protocol":
-  version "0.9.1"
+"@solana-mobile/mobile-wallet-adapter-protocol@^1.0.0", "@solana-mobile/mobile-wallet-adapter-protocol@file:../../js/packages/mobile-wallet-adapter-protocol":
+  version "1.0.0"
 
 "@solana/buffer-layout@^4.0.0":
   version "4.0.0"

--- a/examples/example-web-app/yarn.lock
+++ b/examples/example-web-app/yarn.lock
@@ -360,7 +360,16 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@solana-mobile/mobile-wallet-adapter-protocol-web3js@^0.9.7":
+"@solana-mobile/mobile-wallet-adapter-protocol-web3js@^0.9.9":
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-0.9.9.tgz#ef4040abef66e4c080ebf2a0db109f31ef95652d"
+  integrity sha512-JzlNjZ/Uog56iP/z8QtNrIOgQwmaoicpr9768s0QVF4xuvNbyWHOaDtsngzNneNTMfLSgd0tueboKUrkvto/Wg==
+  dependencies:
+    "@solana-mobile/mobile-wallet-adapter-protocol" "^0.9.9"
+    bs58 "^5.0.0"
+    js-base64 "^3.7.2"
+
+"@solana-mobile/mobile-wallet-adapter-protocol-web3js@^1.0.0":
   version "0.0.0"
   uid ""
 
@@ -368,7 +377,12 @@
   version "0.0.0"
   uid ""
 
-"@solana-mobile/mobile-wallet-adapter-protocol@^0.9.7":
+"@solana-mobile/mobile-wallet-adapter-protocol@^0.9.9":
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/@solana-mobile/mobile-wallet-adapter-protocol/-/mobile-wallet-adapter-protocol-0.9.9.tgz#8b8e3f94f609e0e8c1149c0dbf1548adf18bfd4b"
+  integrity sha512-Jxd3O3txeUiAXLIo6YfWhTs7UTVMlnIgz/xgdYmf99TSE4IaUhWGEVC2/OcOA7eAA85y0/XItU5OhHhXSPva8g==
+
+"@solana-mobile/mobile-wallet-adapter-protocol@^1.0.0":
   version "0.0.0"
   uid ""
 
@@ -377,8 +391,14 @@
   uid ""
 
 "@solana-mobile/wallet-adapter-mobile@^0.9.7":
-  version "0.0.0"
-  uid ""
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/@solana-mobile/wallet-adapter-mobile/-/wallet-adapter-mobile-0.9.9.tgz#5d65a1983a422ad56ff95fe9efaedef4c87d6436"
+  integrity sha512-nmxTEbKgkuI37zMpI3GWWn6DvAd/lgl6GF1lGbYSObXyZDun0bfCIQ8rBVEcvwZLyekp+i/nLW8JdSccN4i3zw==
+  dependencies:
+    "@react-native-async-storage/async-storage" "^1.17.7"
+    "@solana-mobile/mobile-wallet-adapter-protocol-web3js" "^0.9.9"
+    "@solana/wallet-adapter-base" "^0.9.17"
+    js-base64 "^3.7.2"
 
 "@solana-mobile/wallet-adapter-mobile@link:../../js/packages/wallet-adapter-mobile":
   version "0.0.0"

--- a/js/packages/mobile-wallet-adapter-protocol/README.md
+++ b/js/packages/mobile-wallet-adapter-protocol/README.md
@@ -45,7 +45,7 @@ try {
                 e.code === SolanaMobileWalletAdapterProtocolErrorCode.ERROR_REAUTHORIZE
             ) {
                 console.error('The auth token has gone stale');
-                await wallet.reauthorize({auth_token});
+                await wallet.reauthorize({auth_token, identity});
                 // Retry...
             }
             throw e;

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -78,7 +78,7 @@ export interface GetCapabilitiesAPI {
     >;
 }
 export interface ReauthorizeAPI {
-    reauthorize(params: { auth_token: AuthToken }): Promise<AuthorizationResult>;
+    reauthorize(params: { auth_token: AuthToken; identity: AppIdentity }): Promise<AuthorizationResult>;
 }
 export interface SignMessagesAPI {
     signMessages(params: {

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -246,6 +246,7 @@ export class SolanaMobileWalletAdapter extends BaseMessageSignerWalletAdapter {
         try {
             const authorizationResult = await wallet.reauthorize({
                 auth_token: authToken,
+                identity: this._appIdentity,
             });
             // TODO: Evaluate whether there's any threat to not `awaiting` this expression
             Promise.all([


### PR DESCRIPTION
## Summary

This part of the JS implementation was not in compliance with the spec. This probably explains bad behavior some have been noting with certain wallets. If a wallet is particularly strict about receiving an `identity` through `reauthorize`, we have _not_ been sending it. This would cause `ERROR_AUTHORIZATION_FAILED` or `-32602` in all cases.

## Change

In this PR, we update the type to include the `identity` param. This is a breaking change for clients using `mobile-wallet-adapter-protocol` or `mobile-wallet-adapter-protocol-web3js` that aren't already supplying it.

## Test plan

Tested sending multiple transactions with the web and React Native sample apps.