### PR TITLE
Update fakewallet's text size

### DIFF
--- a/android/fakewallet/src/main/res/layout/fragment_authorize_dapp.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_authorize_dapp.xml
@@ -19,7 +19,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize_dapp"
-        android:textSize="12pt"
+        android:textSize="14sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatImageView
@@ -40,7 +40,7 @@
         app:layout_constraintBottom_toBottomOf="@id/image_icon"
         app:layout_constraintStart_toEndOf="@id/image_icon"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_uri"
@@ -49,7 +49,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/image_icon"
         app:layout_constraintStart_toStartOf="parent"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_cluster"
@@ -59,7 +59,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_uri"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_cluster"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_cluster"
@@ -70,7 +70,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toEndOf="@id/label_cluster"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_verification_state"
@@ -80,7 +80,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_verification_state"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_verification_state"
@@ -91,7 +91,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_verification_state"
         app:layout_constraintStart_toEndOf="@id/label_verification_state"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_verification_scope"
@@ -101,7 +101,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_verification_state"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_verification_scope"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_verification_scope"
@@ -112,7 +112,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_verification_scope"
         app:layout_constraintStart_toEndOf="@id/label_verification_scope"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_authorize"
@@ -122,7 +122,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_verification_scope"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_decline"
@@ -132,7 +132,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_verification_scope"
         app:layout_constraintEnd_toEndOf="parent"
         android:text="@string/label_decline"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_cluster_not_supported"
@@ -143,7 +143,7 @@
         android:layout_marginBottom="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_authorize"
         android:text="@string/label_simulate_cluster_not_supported"
-        android:textSize="10pt"
+        android:textSize="12sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -153,7 +153,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_cluster_not_supported"
         android:text="@string/label_simulate_internal_error"
-        android:textSize="10pt"
+        android:textSize="12sp"
         android:minLines="2" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/fakewallet/src/main/res/layout/fragment_authorize_dapp.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_authorize_dapp.xml
@@ -19,7 +19,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize_dapp"
-        android:textSize="18sp"
+        android:textSize="24sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatImageView
@@ -40,7 +40,7 @@
         app:layout_constraintBottom_toBottomOf="@id/image_icon"
         app:layout_constraintStart_toEndOf="@id/image_icon"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_uri"
@@ -49,7 +49,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/image_icon"
         app:layout_constraintStart_toStartOf="parent"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_cluster"
@@ -59,7 +59,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_uri"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_cluster"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_cluster"
@@ -70,7 +70,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toEndOf="@id/label_cluster"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_verification_state"
@@ -80,7 +80,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_verification_state"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_verification_state"
@@ -91,7 +91,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_verification_state"
         app:layout_constraintStart_toEndOf="@id/label_verification_state"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_verification_scope"
@@ -101,7 +101,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_verification_state"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_verification_scope"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_verification_scope"
@@ -112,7 +112,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_verification_scope"
         app:layout_constraintStart_toEndOf="@id/label_verification_scope"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_authorize"
@@ -122,7 +122,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_verification_scope"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_decline"
@@ -132,7 +132,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_verification_scope"
         app:layout_constraintEnd_toEndOf="parent"
         android:text="@string/label_decline"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_cluster_not_supported"
@@ -143,7 +143,7 @@
         android:layout_marginBottom="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_authorize"
         android:text="@string/label_simulate_cluster_not_supported"
-        android:textSize="16sp"
+        android:textSize="22sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -153,7 +153,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_cluster_not_supported"
         android:text="@string/label_simulate_internal_error"
-        android:textSize="16sp"
+        android:textSize="22sp"
         android:minLines="2" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/fakewallet/src/main/res/layout/fragment_authorize_dapp.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_authorize_dapp.xml
@@ -19,7 +19,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize_dapp"
-        android:textSize="14sp"
+        android:textSize="18sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatImageView
@@ -40,7 +40,7 @@
         app:layout_constraintBottom_toBottomOf="@id/image_icon"
         app:layout_constraintStart_toEndOf="@id/image_icon"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_uri"
@@ -49,7 +49,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/image_icon"
         app:layout_constraintStart_toStartOf="parent"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_cluster"
@@ -59,7 +59,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_uri"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_cluster"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_cluster"
@@ -70,7 +70,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toEndOf="@id/label_cluster"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_verification_state"
@@ -80,7 +80,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_verification_state"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_verification_state"
@@ -91,7 +91,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_verification_state"
         app:layout_constraintStart_toEndOf="@id/label_verification_state"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_verification_scope"
@@ -101,7 +101,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_verification_state"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_verification_scope"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_verification_scope"
@@ -112,7 +112,7 @@
         app:layout_constraintBottom_toBottomOf="@id/label_verification_scope"
         app:layout_constraintStart_toEndOf="@id/label_verification_scope"
         app:layout_constraintEnd_toEndOf="parent"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_authorize"
@@ -122,7 +122,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_verification_scope"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_decline"
@@ -132,7 +132,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_verification_scope"
         app:layout_constraintEnd_toEndOf="parent"
         android:text="@string/label_decline"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_cluster_not_supported"
@@ -143,7 +143,7 @@
         android:layout_marginBottom="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_authorize"
         android:text="@string/label_simulate_cluster_not_supported"
-        android:textSize="12sp"
+        android:textSize="16sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -153,7 +153,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_cluster_not_supported"
         android:text="@string/label_simulate_internal_error"
-        android:textSize="12sp"
+        android:textSize="16sp"
         android:minLines="2" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/fakewallet/src/main/res/layout/fragment_send_transaction.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_send_transaction.xml
@@ -17,7 +17,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toTopOf="parent"
         android:text="@string/label_send_transactions"
-        android:textSize="18sp"
+        android:textSize="24sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -28,7 +28,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_send_transaction"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_cluster"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_cluster"
@@ -38,7 +38,7 @@
         app:layout_constraintTop_toTopOf="@id/label_cluster"
         app:layout_constraintBottom_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toEndOf="@id/label_cluster"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_transactions_submitted"
@@ -49,7 +49,7 @@
         android:layout_marginHorizontal="8dp"
         app:layout_constraintTop_toBottomOf="@id/label_cluster"
         android:text="@string/label_simulate_transactions_submitted"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_transactions_not_submitted"
@@ -58,7 +58,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_transactions_submitted"
         android:text="@string/label_simulate_transactions_not_submitted"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_send_transaction_to_cluster"
@@ -67,6 +67,6 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_transactions_not_submitted"
         android:text="@string/label_send_transaction_to_cluster"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/fakewallet/src/main/res/layout/fragment_send_transaction.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_send_transaction.xml
@@ -17,7 +17,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toTopOf="parent"
         android:text="@string/label_send_transactions"
-        android:textSize="12pt"
+        android:textSize="14sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -28,7 +28,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_send_transaction"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_cluster"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_cluster"
@@ -38,7 +38,7 @@
         app:layout_constraintTop_toTopOf="@id/label_cluster"
         app:layout_constraintBottom_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toEndOf="@id/label_cluster"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_transactions_submitted"
@@ -49,7 +49,7 @@
         android:layout_marginHorizontal="8dp"
         app:layout_constraintTop_toBottomOf="@id/label_cluster"
         android:text="@string/label_simulate_transactions_submitted"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_transactions_not_submitted"
@@ -58,7 +58,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_transactions_submitted"
         android:text="@string/label_simulate_transactions_not_submitted"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_send_transaction_to_cluster"
@@ -67,6 +67,6 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_transactions_not_submitted"
         android:text="@string/label_send_transaction_to_cluster"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/fakewallet/src/main/res/layout/fragment_send_transaction.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_send_transaction.xml
@@ -17,7 +17,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toTopOf="parent"
         android:text="@string/label_send_transactions"
-        android:textSize="14sp"
+        android:textSize="18sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -28,7 +28,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_send_transaction"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_cluster"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_cluster"
@@ -38,7 +38,7 @@
         app:layout_constraintTop_toTopOf="@id/label_cluster"
         app:layout_constraintBottom_toBottomOf="@id/label_cluster"
         app:layout_constraintStart_toEndOf="@id/label_cluster"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_transactions_submitted"
@@ -49,7 +49,7 @@
         android:layout_marginHorizontal="8dp"
         app:layout_constraintTop_toBottomOf="@id/label_cluster"
         android:text="@string/label_simulate_transactions_submitted"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_transactions_not_submitted"
@@ -58,7 +58,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_transactions_submitted"
         android:text="@string/label_simulate_transactions_not_submitted"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_send_transaction_to_cluster"
@@ -67,6 +67,6 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_transactions_not_submitted"
         android:text="@string/label_send_transaction_to_cluster"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/fakewallet/src/main/res/layout/fragment_sign_payload.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_sign_payload.xml
@@ -17,7 +17,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        android:textSize="14sp"
+        android:textSize="18sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -28,7 +28,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_sign_payloads"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_num_txns"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_num_transactions"
@@ -38,7 +38,7 @@
         app:layout_constraintTop_toTopOf="@id/label_num_transactions"
         app:layout_constraintBottom_toBottomOf="@id/label_num_transactions"
         app:layout_constraintStart_toEndOf="@id/label_num_transactions"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_authorize"
@@ -48,7 +48,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_num_transactions"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_decline"
@@ -58,7 +58,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_num_transactions"
         app:layout_constraintEnd_toEndOf="parent"
         android:text="@string/label_decline"
-        android:textSize="12sp" />
+        android:textSize="16sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_authorization_failed"
@@ -69,7 +69,7 @@
         android:layout_marginBottom="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_authorize"
         android:text="@string/label_simulate_authorization_failed"
-        android:textSize="12sp"
+        android:textSize="16sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -79,7 +79,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_authorization_failed"
         android:text="@string/label_simulate_invalid_payloads"
-        android:textSize="12sp"
+        android:textSize="16sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -89,7 +89,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_invalid_payloads"
         android:text="@string/label_simulate_too_many_payloads"
-        android:textSize="12sp"
+        android:textSize="16sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -99,7 +99,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_too_many_payloads"
         android:text="@string/label_simulate_internal_error"
-        android:textSize="12sp"
+        android:textSize="16sp"
         android:minLines="2" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/fakewallet/src/main/res/layout/fragment_sign_payload.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_sign_payload.xml
@@ -17,7 +17,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        android:textSize="18sp"
+        android:textSize="24sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -28,7 +28,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_sign_payloads"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_num_txns"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_num_transactions"
@@ -38,7 +38,7 @@
         app:layout_constraintTop_toTopOf="@id/label_num_transactions"
         app:layout_constraintBottom_toBottomOf="@id/label_num_transactions"
         app:layout_constraintStart_toEndOf="@id/label_num_transactions"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_authorize"
@@ -48,7 +48,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_num_transactions"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_decline"
@@ -58,7 +58,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_num_transactions"
         app:layout_constraintEnd_toEndOf="parent"
         android:text="@string/label_decline"
-        android:textSize="16sp" />
+        android:textSize="22sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_authorization_failed"
@@ -69,7 +69,7 @@
         android:layout_marginBottom="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_authorize"
         android:text="@string/label_simulate_authorization_failed"
-        android:textSize="16sp"
+        android:textSize="22sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -79,7 +79,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_authorization_failed"
         android:text="@string/label_simulate_invalid_payloads"
-        android:textSize="16sp"
+        android:textSize="22sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -89,7 +89,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_invalid_payloads"
         android:text="@string/label_simulate_too_many_payloads"
-        android:textSize="16sp"
+        android:textSize="22sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -99,7 +99,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_too_many_payloads"
         android:text="@string/label_simulate_internal_error"
-        android:textSize="16sp"
+        android:textSize="22sp"
         android:minLines="2" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/fakewallet/src/main/res/layout/fragment_sign_payload.xml
+++ b/android/fakewallet/src/main/res/layout/fragment_sign_payload.xml
@@ -17,7 +17,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        android:textSize="12pt"
+        android:textSize="14sp"
         android:textAllCaps="true"/>
 
     <androidx.appcompat.widget.AppCompatTextView
@@ -28,7 +28,7 @@
         app:layout_constraintTop_toBottomOf="@id/text_sign_payloads"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_num_txns"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/text_num_transactions"
@@ -38,7 +38,7 @@
         app:layout_constraintTop_toTopOf="@id/label_num_transactions"
         app:layout_constraintBottom_toBottomOf="@id/label_num_transactions"
         app:layout_constraintStart_toEndOf="@id/label_num_transactions"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_authorize"
@@ -48,7 +48,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_num_transactions"
         app:layout_constraintStart_toStartOf="parent"
         android:text="@string/label_authorize"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_decline"
@@ -58,7 +58,7 @@
         app:layout_constraintTop_toBottomOf="@id/label_num_transactions"
         app:layout_constraintEnd_toEndOf="parent"
         android:text="@string/label_decline"
-        android:textSize="10pt" />
+        android:textSize="12sp" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_simulate_authorization_failed"
@@ -69,7 +69,7 @@
         android:layout_marginBottom="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_authorize"
         android:text="@string/label_simulate_authorization_failed"
-        android:textSize="10pt"
+        android:textSize="12sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -79,7 +79,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_authorization_failed"
         android:text="@string/label_simulate_invalid_payloads"
-        android:textSize="10pt"
+        android:textSize="12sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -89,7 +89,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_invalid_payloads"
         android:text="@string/label_simulate_too_many_payloads"
-        android:textSize="10pt"
+        android:textSize="12sp"
         android:minLines="2" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -99,7 +99,7 @@
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/btn_simulate_too_many_payloads"
         android:text="@string/label_simulate_internal_error"
-        android:textSize="10pt"
+        android:textSize="12sp"
         android:minLines="2" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Hello! This small PR fixes a problem I encountered when testing the fake wallet — all text was almost invisible on my end. 
It is recommended on Android to use scalable pixels (sp) for specifying text size as well as there some recommendations for the size itself (say don't use anything less 12sp).

BEFORE:
![Screenshot_20230512_104820](https://github.com/solana-mobile/mobile-wallet-adapter/assets/1262098/39c63b20-2584-431c-975c-3cf047641644)
AFTER:
![Screenshot_20230512_105006](https://github.com/solana-mobile/mobile-wallet-adapter/assets/1262098/e1807da2-adc8-468a-ae88-bb9d769bea8c)
