### PR TITLE
[RN Walletlib] Add resolve(), response types, and hook

### DIFF
--- a/js/packages/mobile-wallet-adapter-walletlib/src/mwaSessionEvents.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/mwaSessionEvents.ts
@@ -1,0 +1,75 @@
+/**
+ * Mobile Wallet Adapter Session Events are notifications and events
+ * about the underlying session between the wallet and the dApp.
+ */
+export enum MWASessionEventType {
+    SessionStartEvent,
+    SessionReadyEvent,
+    SessionTerminatedEvent,
+    SessionServingClientsEvent,
+    SessionServingCompleteEvent,
+    SessionCompleteEvent,
+    SessionErrorEvent,
+    SessionTeardownCompleteEvent,
+    LowPowerNoConnectionEvent,
+}
+export interface IMWASessionEvent {
+    __type: MWASessionEventType;
+    sessionId: string;
+}
+
+export type SessionStartEvent = Readonly<{
+    __type: MWASessionEventType.SessionStartEvent;
+}> &
+    IMWASessionEvent;
+
+export type SessionReadyEvent = Readonly<{
+    __type: MWASessionEventType.SessionReadyEvent;
+}> &
+    IMWASessionEvent;
+
+export type SessionTerminatedEvent = Readonly<{
+    __type: MWASessionEventType.SessionTerminatedEvent;
+}> &
+    IMWASessionEvent;
+
+export type SessionServingClientsEvent = Readonly<{
+    __type: MWASessionEventType.SessionServingClientsEvent;
+}> &
+    IMWASessionEvent;
+
+export type SessionServingCompleteEvent = Readonly<{
+    __type: MWASessionEventType.SessionServingCompleteEvent;
+}> &
+    IMWASessionEvent;
+
+export type SessionCompleteEvent = Readonly<{
+    __type: MWASessionEventType.SessionCompleteEvent;
+}> &
+    IMWASessionEvent;
+
+export type SessionErrorEvent = Readonly<{
+    __type: MWASessionEventType.SessionErrorEvent;
+}> &
+    IMWASessionEvent;
+
+export type SessionTeardownCompleteEvent = Readonly<{
+    __type: MWASessionEventType.SessionTeardownCompleteEvent;
+}> &
+    IMWASessionEvent;
+
+export type LowPowerNoConnectionEvent = Readonly<{
+    __type: MWASessionEventType.LowPowerNoConnectionEvent;
+}> &
+    IMWASessionEvent;
+
+export type MWASessionEvent =
+    | SessionStartEvent
+    | SessionReadyEvent
+    | SessionTerminatedEvent
+    | SessionServingClientsEvent
+    | SessionServingCompleteEvent
+    | SessionCompleteEvent
+    | SessionErrorEvent
+    | SessionTeardownCompleteEvent
+    | LowPowerNoConnectionEvent;

--- a/js/packages/mobile-wallet-adapter-walletlib/src/resolve.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/resolve.ts
@@ -1,0 +1,184 @@
+import { NativeModules, Platform } from 'react-native';
+
+const LINKING_ERROR =
+    `The package 'solana-mobile-wallet-adapter-walletlib' doesn't seem to be linked. Make sure: \n\n` +
+    '- You rebuilt the app after installing the package\n' +
+    '- If you are using Lerna workspaces\n' +
+    '  - You have added `@solana-mobile/mobile-wallet-adapter-walletlib` as an explicit dependency, and\n' +
+    '  - You have added `@solana-mobile/mobile-wallet-adapter-walletlib` to the `nohoist` section of your package.json\n' +
+    '- You are not using Expo managed workflow\n';
+
+const SolanaMobileWalletAdapterWalletLib =
+    Platform.OS === 'android' && NativeModules.SolanaMobileWalletAdapterWalletLib
+        ? NativeModules.SolanaMobileWalletAdapterWalletLib
+        : new Proxy(
+              {},
+              {
+                  get() {
+                      throw new Error(
+                          Platform.OS !== 'android'
+                              ? 'The package `solana-mobile-wallet-adapter-walletlib` is only compatible with React Native Android'
+                              : LINKING_ERROR,
+                      );
+                  },
+              },
+          );
+
+type AppIdentity = Readonly<{
+    identityUri?: string;
+    iconRelativeUri?: string;
+    identityName?: string;
+}>;
+
+/**
+ * Mobile Wallet Adapter Requests are remote requests coming from
+ * the dApp for authorization, signing, and sending services.
+ */
+
+export type MWARequest =
+    | SignMessagesRequest
+    | SignTransactionsRequest
+    | SignAndSendTransactionsRequest
+    | AuthorizeDappRequest;
+
+export enum MWARequestType {
+    AuthorizeDappRequest,
+    ReauthorizeDappRequest,
+    DeauthorizeDappRequest,
+    SignMessagesRequest,
+    SignTransactionsRequest,
+    SignAndSendTransactionsRequest,
+}
+interface IMWARequest {
+    __type: MWARequestType;
+    requestId: string;
+    sessionId: string;
+    cluster: string;
+    authorizationScope: Uint8Array;
+    appIdentity?: AppIdentity;
+}
+
+export type AuthorizeDappRequest = Readonly<{
+    __type: MWARequestType.AuthorizeDappRequest;
+}> &
+    IMWARequest;
+
+export type ReauthorizeDappRequest = Readonly<{
+    __type: MWARequestType.ReauthorizeDappRequest;
+}> &
+    IMWARequest;
+
+export type DeauthorizeDappRequest = Readonly<{
+    __type: MWARequestType.DeauthorizeDappRequest;
+}> &
+    IMWARequest;
+
+export type SignMessagesRequest = Readonly<{
+    __type: MWARequestType.SignMessagesRequest;
+    payloads: Uint8Array[];
+}> &
+    IMWARequest;
+
+export type SignTransactionsRequest = Readonly<{
+    __type: MWARequestType.SignTransactionsRequest;
+    payloads: Uint8Array[];
+}> &
+    IMWARequest;
+
+export type SignAndSendTransactionsRequest = Readonly<{
+    __type: MWARequestType.SignAndSendTransactionsRequest;
+    payloads: Uint8Array[];
+}> &
+    IMWARequest;
+
+/**
+ * MWA Request Responses
+ */
+
+export type MWAResponse =
+    | AuthorizeDappResponse
+    | SignMessagesResponse
+    | SignTransactionsResponse
+    | SignAndSendTransactionsResponse;
+
+/* Failure Responses */
+export enum MWARequestFailReason {
+    UserDeclined = 'USER_DECLINED',
+    TooManyPayloads = 'TOO_MANY_PAYLOADS',
+    InvalidSignatures = 'INVALID_SIGNATURES',
+    AuthorizationNotValid = 'AUTHORIZATION_NOT_VALID',
+}
+
+export type UserDeclinedResponse = Readonly<{
+    failReason: MWARequestFailReason.UserDeclined;
+}>;
+
+export type TooManyPayloadsResponse = Readonly<{
+    failReason: MWARequestFailReason.TooManyPayloads;
+}>;
+
+export type AuthorizationNotValid = Readonly<{
+    failReason: MWARequestFailReason.AuthorizationNotValid;
+}>;
+
+export type InvalidSignaturesResponse = Readonly<{
+    failReason: MWARequestFailReason.InvalidSignatures;
+    valid: boolean[];
+}>;
+
+/* Authorize Dapp */
+export type AuthorizeDappCompleteResponse = Readonly<{
+    publicKey: Uint8Array;
+    accountLabel?: string;
+    walletUriBase?: string;
+    authorizationScope?: Uint8Array;
+}>;
+export type AuthorizeDappResponse = AuthorizeDappCompleteResponse | UserDeclinedResponse;
+
+/* Sign Transactions/Messages */
+export type SignPayloadsCompleteResponse = Readonly<{ signedPayloads: Uint8Array[] }>;
+export type SignPayloadsFailResponse =
+    | UserDeclinedResponse
+    | TooManyPayloadsResponse
+    | AuthorizationNotValid
+    | InvalidSignaturesResponse;
+
+export type SignTransactionsResponse = SignPayloadsCompleteResponse | SignPayloadsFailResponse;
+export type SignMessagesResponse = SignPayloadsCompleteResponse | SignPayloadsFailResponse;
+
+/* Sign and Send Transaction */
+export type SignAndSendTransactionsCompleteResponse = Readonly<{ signedTransactions: Uint8Array[] }>;
+export type SignAndSendTransactionsResponse =
+    | SignAndSendTransactionsCompleteResponse
+    | UserDeclinedResponse
+    | TooManyPayloadsResponse
+    | AuthorizationNotValid
+    | InvalidSignaturesResponse;
+
+export function resolve(request: AuthorizeDappRequest, response: AuthorizeDappResponse): void;
+export function resolve(request: SignMessagesRequest, response: SignMessagesResponse): void;
+export function resolve(request: SignTransactionsRequest, response: SignTransactionsResponse): void;
+export function resolve(request: SignAndSendTransactionsRequest, response: SignAndSendTransactionsResponse): void;
+export function resolve(request: MWARequest, response: MWAResponse): void {
+    switch (request.__type) {
+        case MWARequestType.AuthorizeDappRequest:
+            // Optionally pre-process the response, which is now nicely typed.
+            SolanaMobileWalletAdapterWalletLib.onResolve(request, response as AuthorizeDappResponse);
+            break;
+        case MWARequestType.SignMessagesRequest:
+            // Optionally pre-process the response, which is now nicely typed.
+            SolanaMobileWalletAdapterWalletLib.onResolve(request, response as SignMessagesResponse);
+            break;
+        case MWARequestType.SignTransactionsRequest:
+            // Optionally pre-process the response, which is now nicely typed.
+            SolanaMobileWalletAdapterWalletLib.onResolve(request, response as SignTransactionsResponse);
+            break;
+        case MWARequestType.SignAndSendTransactionsRequest:
+            // Optionally pre-process the response, which is now nicely typed.
+            SolanaMobileWalletAdapterWalletLib.onResolve(request, response as SignAndSendTransactionsResponse);
+            break;
+        default:
+            console.warn('Unsupported request type');
+            break;
+    }
+}

--- a/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
@@ -1,0 +1,76 @@
+import { TransactionVersion } from '@solana/web3.js';
+import { useEffect } from 'react';
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
+
+import { MWASessionEvent, MWASessionEventType } from './mwaSessionEvents.js';
+import { MWARequest, MWARequestType } from './resolve.js';
+
+const LINKING_ERROR =
+    `The package 'solana-mobile-wallet-adapter-walletlib' doesn't seem to be linked. Make sure: \n\n` +
+    '- You rebuilt the app after installing the package\n' +
+    '- If you are using Lerna workspaces\n' +
+    '  - You have added `@solana-mobile/mobile-wallet-adapter-walletlib` as an explicit dependency, and\n' +
+    '  - You have added `@solana-mobile/mobile-wallet-adapter-walletlib` to the `nohoist` section of your package.json\n' +
+    '- You are not using Expo managed workflow\n';
+
+const SolanaMobileWalletAdapterWalletLib =
+    Platform.OS === 'android' && NativeModules.SolanaMobileWalletAdapterWalletLib
+        ? NativeModules.SolanaMobileWalletAdapterWalletLib
+        : new Proxy(
+              {},
+              {
+                  get() {
+                      throw new Error(
+                          Platform.OS !== 'android'
+                              ? 'The package `solana-mobile-wallet-adapter-walletlib` is only compatible with React Native Android'
+                              : LINKING_ERROR,
+                      );
+                  },
+              },
+          );
+
+const MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME = 'MobileWalletAdapterServiceRequestBridge';
+
+export interface MobileWalletAdapterConfig {
+    supportsSignAndSendTransactions: boolean;
+    maxTransactionsPerSigningRequest: number;
+    maxMessagesPerSigningRequest: number;
+    supportedTransactionVersions: Array<TransactionVersion>;
+    noConnectionWarningTimeoutMs: number;
+}
+
+export function useMobileWalletAdapterSession(
+    walletName: string,
+    config: MobileWalletAdapterConfig,
+    handleRequest: (request: MWARequest) => void,
+    handleSessionEvent: (sessionEvent: MWASessionEvent) => void,
+) {
+    // Start native event listeners
+    useEffect(() => {
+        const mwaEventEmitter = new NativeEventEmitter();
+        mwaEventEmitter.addListener(MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME, (nativeEvent) => {
+            if (isMWARequest(nativeEvent)) {
+                handleRequest(nativeEvent as MWARequest);
+            } else if (isMWASessionEvent(nativeEvent)) {
+                handleSessionEvent(nativeEvent as MWASessionEvent);
+            } else {
+                console.warn('Unexpected native event type');
+            }
+        });
+
+        return () => {
+            mwaEventEmitter.removeAllListeners(MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME);
+        };
+    }, []);
+
+    // Initiate Scenario session with dapp
+    SolanaMobileWalletAdapterWalletLib.startScenario(walletName, config);
+}
+
+function isMWARequest(nativeEvent: any): boolean {
+    return Object.values(MWARequestType).includes(nativeEvent.type);
+}
+
+function isMWASessionEvent(nativeEvent: any) {
+    return Object.values(MWASessionEventType).includes(nativeEvent.type);
+}

--- a/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
@@ -48,7 +48,7 @@ export function useMobileWalletAdapterSession(
     // Start native event listeners
     useEffect(() => {
         const mwaEventEmitter = new NativeEventEmitter();
-        mwaEventEmitter.addListener(MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME, (nativeEvent) => {
+        const listener = mwaEventEmitter.addListener(MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME, (nativeEvent) => {
             if (isMWARequest(nativeEvent)) {
                 handleRequest(nativeEvent as MWARequest);
             } else if (isMWASessionEvent(nativeEvent)) {
@@ -59,7 +59,7 @@ export function useMobileWalletAdapterSession(
         });
 
         return () => {
-            mwaEventEmitter.removeAllListeners(MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME);
+            listener.remove();
         };
     }, []);
 


### PR DESCRIPTION
This PR aims to establish the API for the library, with feedback from the previous PR. 
In this PR, I've implemented the Typescript side of the API and need feedback on that before implementing the Kotlin module.

New API at a high level:
- Expose a `resolve(MWARequest, MWAResponse)` as the interface for the developer to publish responses back to the kotlin module.
- Expose a `useMobileWalletAdapterSession` that takes in wallet config, `handleRequest`, `handleSessionEvent`
- Expose a `MWARequest` that is received immediately by the `handleRequest` callback 
     - Improvement from old API rather than waiting on state change
     - Each will have a `requestId` and `sessionId`
- Expose an `MWASessionEvent` that is received immediately by `handleSessionEvent` callback 

Example Usage: ([Typescript Playground](https://www.typescriptlang.org/play?module=1#code/CYUwxgNghgTiAEkoGdnwMoHtoDsoFlMAjASwhAHUoJyAXAQWCgAdaQYqaRaAZEo+AG8AUPHjJaUWiTDxMOAEohk2AG4gAFCHU5aALiHjlyEvICSwAxJgkcAcwA08OAEcArstoWrtG-fgAvk5wyMzyyCAGbjgA1jiYAO44AJQGqpgkwMIBwsK0AJ7MCPTMzBYguiQF8AC88EpQwPIQ+QA8ImJimRXSBQCqNgD8Pn52ANyinTLyStDS6gMkw+K+tuOTXaCVBQByUAC2IMvWaxMBAHwTwgD0AFS3orfwhKTk8Jx08IwsbDD1IO5PGhYAg4PtMGxnACPBI0GBMPs1vAAGYwBGPeC0AAWCGAJWYKMwfygbmxRJIAC8pKYcE4THYcGsnFAcMAjKykREYKoZMoAHSPa65EAADzCMFomMKCHwFHoSkBElqG3gAB8MCQGfhjFA7MoFTDaCr1ehNTgACowFnIKBgaThA2eY0ahn0VnoCrAS3W232nDIR0SZ30UlY8kUkAAERYzEDtCuovFkoqbn2zzlcfN0qEKpDZJsEejpTjDhVDVD4ajMZLKsjIBJ+cpVeL0M8pc6Lpw2tQuv1rYk7c6poZ3v9vppAf7tEHYmHODdwA9rNHNrtE5rOVsv2RtoQZll8qnOY7AH0TwUigYD5npRMO65Dd4VqM750IqgaU+TvZX2JIG4JHYEZThVBswwLal5HQeFL3gPotwADnoGArXyX94BjcptnyZZ8Sw3o0OyYUxSJSUL2KCsC2bWMjzqBomhwFp2hVM9yKvDMpyzIo+TzcCmyLGjFXjbJzngAAyFV9w4oSExIiUpSKf4wMrAS41qJSGKYjpOlY6V2MPISuJAPly0bQtqynM5RIkjspIMw1ZKTBSEDrZSqNU2iNOaNptLEXTYOvTjpT5VzKP4iyZJE8TJMCyLhETUjnM7bsbT1SchPU+jvOY09zz09N7M8Iy+TnFLe3ShyVWYKB8ggTBGmQAx4N0JCUJqgBtABdKzots2LKviuSyOzOcV3HB1PKyxifJYvKAukw1itGq0xzXCbIo7aravq4BGrgxDkNQrqepszo7LjRzEvIzsFyXL0VtXP0Ks8TL600mbcrYgqb24udbs9Ma1v9C6qpquqGqag62vyY6otOsRzss3I7geeAngPf4MqUUJwmUQViKc67Apx-0EBqYMwvMlsSYiZ1Sp1NLsbCUm6bNQGnqZ3HWddd0AYe8bgeUZmIiuO54AAMSgMg3Dgf4aeUNGhQS+SUzTfrPElsgGhUHBj06PouTrSBbBANk6gAcj6dAAFEFBPSNrYAYR4MwdmtyNzZneBzUwTB8BZfIAAUwZ2tALfNAB5COT3wegdgATRPQP6HjngI-oSN0E9yScFUahMjnKQZYVi3XYANXoF3IxPdAzAAcR2ehzT6BRrazr3ePDSCcB2CEy-zs34HN+g+nNAAJCOFDMAAtJuzAjnYTx2CPzRPCuq+znJBsJ7MDfYI2IBN4BOdJ17Gmy3yUSliBtfkfS401m-6x1vk95gA+j6sy75Oun2-YD4O20GonwiGfd6OVOg7i1s-O+30pyP1vjgPkf9-Y4CDiHBqX8CZXWzJ3CCfpe60H7ofQeU0tIqigU-FAsD1YSAQTApBeDKTd0IcQzIWDt44MUmYXOA9C60GLpOeWYCL4UOvog++8DxEML5DwvOJD+GCPQvIzIBgiC+3ICyWGFxRZPCYRGeAAlFacJ-rgym1FHYImYHQEAICyZeWmhAsQzA3BEEPmAAA0iAfIkMWqHRquhW08Joi8CgEQEAEBjirB-CqBI1A6CLAAEIoCOMBGJHY3LML9NBTARRljNVoK1VCWDlbDUUvo6idj1IVIEpY-Y1juC2KFrjNUcFDbgEPjgU2djdGdm9vzIGyBrhlTSsY0pSU5yAPBrtOpDS2BVLom9C+4gzSmymaHXxhT-Ew06oES4JiykIEmRg3a9DhHkw7OqN+H8unH2aSzS53tfaoPQUA3adiKZmRYX3Aezo5F8LNEXEIPTsGmMUstH0gyFmdnWQ1WZNiqkmjNLC050j5YTHGddemPZGb3NAXUY5bzkDwsaYimFJzkBnOFiADFQ0JnIopdCwl0ziVWIRXihASKGQospWi6lvS5wYVZBgT0-TIV+jGXSrFZp-rLgGU9El8yOUiMcYIFZDJTbswnJsopHVdk6IOfSnmi4+bivXMqi5nQuXzl5nKs14RFVNPls6a5HSj4fMeSggBjKOWfL4lSAhPySF-N4QowFAjgUcu-pKZE0QgZQhUBAdQGgHyeAMDUiKhpggcvTeYjy8tUjwHSOww1sacDxpCGoTQqaJAGGxalPsQls3yzrQyoldjC3FuALSpyZaK3KCrSmqcraRzyvNU2hN1KR04B5R2tIGRu2lrjRKytSbq3Dpura+69rBYTpCFOzdJq7WrQ5hyztC6e2JT7Sugda6h1CUkXunNcCC3zsyHrMQyAEhVDAFieA97DR8n8iAZIH6OyIBSXAwywUM0tgfSqcDnRrjXHgBHVgNJ4n5HgMwOAABaHDmAwDGExDiSduMnAJCxDIP9JA0DxASPARkRGWjOWAAKRDiHkPwEdjiMAMRCR-HhDgZERJEQFEGAhjjWBcAEGIGQSg8TuDfFYOwD43A+BED5DMW9yaa3TjI6fFAXw80WQLehDj8AiBwCgDEcznQwCQdobQJaZoRmNsNHoSTnGUNob9Jh7DeGCNEdQCR0EHKKNUd-fAWjjHEiMd5Cx8ibGvPgekyyWTrwFNcAYEwFTHBFO8H4FpxQOn11PuEUZ+t5UO12cQ1Z+stmUsOdAU5lzo6d3PVrSljsXHfMYZoFhnDIB8NomC2gbEYX5YReo9FujcWmMRKw0l9jFmhzYHSy8eTamcs-FUwVjTxXsaDr0826lGE0AQpPeasz3XOj1Zs7ViDLWFpFWCn9LdWr1oedu2IXr6H5D+aGyNwjxGJsGYiNNqLMX6PxeY0t6UyXVtrZk5t8g23lO-G2wd7TibdNTlOy0yrMqPtjomjdpHYh7uNYs6AHcbgID6B+4gcI2BjJxJgDgDQlt-RuFKKRU2UIMrkXNskR7HYqfoRyFvLjY8YyDakH+-dXMhNKnpF2Bm7mXp1BwPTiA534DRDiIkXWROtQa868JYQq7k1q7cxbpwaq1drIpQYdqXSGMFN1fkDQ7UACMTgABMTgADMnVkj6tF8jFDj9wcgCt6VjQtvzclkMJQiRUHDT0OoUg11xtbmBEj9bzQSecWa4HKn6R2fH2Z8ry-f5YaGRAuUE4FRlh4DtR3BACIEerg3BQ7L0o8vsSx+ECryUmSIxqW17r-Xhv6Mm7QLBwSA0i8aAn00idggXFuJkF4nxjGQAe6hqhH3-v4BB-gKH5IARI994ltfEfq-18p7VWnhh1eNa1-kK-dpeeBc34mCf3MRfyvmgSrwz0-zALr1DQLnDUEQLzGHgC41tgUEnks3ABJFAV4iqSaGUBwHNklCxCgHUBIxi0oWfDcDtGLnj1x00Gf3xwrygJoRezoS-yQXr1gMbwjWbyLQHld0727wQKQJQxQLQPCQcwAgomxBwMwDwIIPgCIJIOxDIIf2sEoO4OECAA))
```
// Happy path response
const signMessagesRequest = null as unknown as SignMessagesRequest;

resolve(signMessagesRequest, { signedPayloads: [new Uint8Array([1, 2, 3])] });

// Fail response
resolve(signMessagesRequest, { failReason: MWARequestFailReason.UserDeclined });
resolve(signMessagesRequest, { failReason: MWARequestFailReason.InvalidSignatures, valid: [false] });
```

Need feedback on:
- `resolve` function from a dev perspective, especially regarding `MWAResponse` and its subtypes.
    - How can I make it more clear what the "happy path" response structure looks like vs a "fail path" response structure?
    - How can I make it more clear what the "fail path" response structure looks like? e.g `UserDeclined` vs `InvalidSignatures` response
    - Currently using a bunch of subtyping + function overload, but wondering if there's a more elegant way.
 - `useMobileWalletAdapterSession` hook and how I distinguish native events. `isMWARequest` and `isMWASessionEvent`. Is there a better way?

