### PR TITLE
Refactor RN walletlib build scripts

### DIFF
--- a/js/packages/mobile-wallet-adapter-walletlib/README.md
+++ b/js/packages/mobile-wallet-adapter-walletlib/README.md
@@ -1,9 +1,16 @@
 # `@solana-mobile/mobile-wallet-adapter-walletlib`
 
-This is a package that provides React Native bridge for the native `mobile-wallet-adapter-walletlib` library and it is designed for *Wallet apps* built in React Native. It provides an API to implement the wallet endpoint of the [mobile wallet adapter protocol](https://github.com/solana-mobile/mobile-wallet-adapter/blob/main/spec/spec.md)
+This is a package that provides React Native bridge for the native `mobile-wallet-adapter-walletlib` library and it is designed for *Wallet apps* built in React Native. It provides an API to implement the wallet endpoint of the [mobile wallet adapter protocol](https://github.com/solana-mobile/mobile-wallet-adapter/blob/main/spec/spec.md).
+
+Deep dive and read the full Mobile Wallet Adapter protocol [specification](https://solana-mobile.github.io/mobile-wallet-adapter/spec/spec.html#mobile-wallet-adapter-specification).
+
+## TODO
+- Implement dApp identity verification/reauthorization
+- Separate bottom sheet signing experience or make optional
 
 ## Note
 This package is still in alpha and is not production ready. However, the API is stable and will not change drastically, so you can begin integration with your wallet.
+
 
 ## Quickstart
 

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -1,50 +1,69 @@
 {
-  "name": "@solana-mobile/mobile-wallet-adapter-walletlib",
-  "description": "A React Native wrapper of the Solana Mobile, Mobile Wallet Adapter Wallet Library. Wallet apps can use this to handle dapp requests for signing and sending.",
-  "version": "0.0.6",
-  "author": "Michael Sulistio <mike.sulistio@solanamobile.com>",
-  "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
-  "license": "Apache-2.0",
-  "type": "module",
-  "sideEffects": false,
-  "main": "lib/cjs/index.js",
-  "react-native": "lib/cjs/index.native.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/types/index.d.ts",
-  "browser": {
-      "./lib/cjs/index.js": "./lib/cjs/index.browser.js",
-      "./lib/esm/index.js": "./lib/esm/index.browser.js"
-  },
-  "exports": {
-      "./package.json": "./package.json",
-      ".": {
-          "import": "./lib/esm/index.js",
-          "require": "./lib/cjs/index.js"
+    "name": "@solana-mobile/mobile-wallet-adapter-walletlib",
+    "description": "A React Native wrapper of the Solana Mobile, Mobile Wallet Adapter Wallet Library. Wallet apps can use this to handle dapp requests for signing and sending.",
+    "version": "1.0.0",
+    "author": "Michael Sulistio <mike.sulistio@solanamobile.com>",
+    "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
+    "license": "Apache-2.0",
+    "type": "module",
+    "sideEffects": false,
+    "react-native": "src/index",
+    "main": "lib/commonjs/index",
+    "module": "lib/module/index",
+    "types": "lib/typescript/index.d.ts",
+    "files": [
+        "android",
+        "!android/build",
+        "lib",
+        "src",
+        "LICENSE"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "typecheck": "tsc --noEmit",
+        "lint": "eslint \"**/*.{js,ts,tsx}\"",
+        "prepack": "bob build",
+        "release": "release-it",
+        "example": "yarn --cwd example",
+        "bootstrap": "yarn example && yarn install && yarn example pods",
+        "clean": "shx rm -rf lib/*"
+    },
+    "devDependencies": {
+        "@release-it/conventional-changelog": "^5.0.0",
+        "@solana/web3.js": "^1.58.0",
+        "@types/react-native": "^0.69.3",
+        "react-native-builder-bob": "^0.20.4",
+        "release-it": "^15.0.0"
+    },
+    "peerDependencies": {
+        "react-native": ">0.69"
+    },
+    "release-it": {
+        "git": {
+          "commitMessage": "chore: release ${version}",
+          "tagName": "v${version}"
+        },
+        "npm": {
+          "publish": true
+        },
+        "github": {
+          "release": true
+        },
+        "plugins": {
+          "@release-it/conventional-changelog": {
+            "preset": "angular"
+          }
+        }
+      },
+    "react-native-builder-bob": {
+        "source": "src",
+        "output": "lib",
+        "targets": [
+          "commonjs",
+          "module",
+          "typescript"
+        ]
       }
-  },
-  "files": [
-      "android",
-      "!android/build",
-      "lib",
-      "LICENSE"
-  ],
-  "publishConfig": {
-      "access": "public"
-  },
-  "scripts": {
-      "clean": "shx rm -rf lib/*",
-      "build": "yarn clean && rollup --config ../../rollup.config.ts --configPlugin rollup-plugin-ts",
-      "build:watch": "yarn clean && rollup --config ../../rollup.config.ts --configPlugin rollup-plugin-ts --watch",
-      "postbuild": "cross-env echo {\\\"type\\\":\\\"commonjs\\\"} | npx json > lib/cjs/package.json && echo {\\\"type\\\":\\\"module\\\"} | npx json > lib/esm/package.json",
-      "prepublishOnly": "agadoo"
-  },
-  "devDependencies": {
-      "@solana/web3.js": "^1.58.0",
-      "@types/react-native": "^0.69.3",
-      "agadoo": "^2.0.0",
-      "cross-env": "^7.0.3"
-  },
-  "peerDependencies": {
-      "react-native": ">0.69"
-  }
 }

--- a/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
@@ -1,4 +1,4 @@
-import { TransactionVersion } from '@solana/web3.js';
+import type { TransactionVersion } from '@solana/web3.js';
 import { useEffect } from 'react';
 import { Linking, NativeEventEmitter, NativeModules, Platform } from 'react-native';
 

--- a/js/packages/mobile-wallet-adapter-walletlib/tsconfig.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/tsconfig.json
@@ -1,8 +1,29 @@
 {
-    "extends": "../../tsconfig.json",
-    "include": ["src"],
     "compilerOptions": {
-        "declarationDir": "./lib/types",
-        "outDir": "lib/esm"
+      "baseUrl": "./",
+      "paths": {
+        "react-native-test-library": ["./src/index"]
+      },
+      "allowUnreachableCode": false,
+      "allowUnusedLabels": false,
+      "esModuleInterop": true,
+      "importsNotUsedAsValues": "error",
+      "forceConsistentCasingInFileNames": true,
+      "jsx": "react",
+      "lib": ["esnext"],
+      "module": "esnext",
+      "moduleResolution": "node",
+      "noFallthroughCasesInSwitch": true,
+      "noImplicitReturns": true,
+      "noImplicitUseStrict": false,
+      "noStrictGenericChecks": false,
+      "noUncheckedIndexedAccess": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "resolveJsonModule": true,
+      "skipLibCheck": true,
+      "strict": true,
+      "target": "esnext"
     }
-}
+  }
+  


### PR DESCRIPTION
This PR refactors the scripts in the `package.json` of RN walletlib. Previously, the library was using the `rollup.config.ts` script to create esm/cjs for browser/node/react-native environments.

For this library, we only need to support react native environment. 

Changes:
- Added a dev dependency to `https://github.com/callstack/react-native-builder-bob`. This library provides convenient scripts to output a build `lib` for publishing.
- Refactor the `package.json` to use `react-native-builder-bob` rather than the `rollup` config.
- Add a README TODO list