### PR TITLE
Fix walletlib src path

### DIFF
--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "type": "module",
     "sideEffects": false,
-    "react-native": "src/index",
+    "react-native": "lib/commonjs/index",
     "main": "lib/commonjs/index",
     "module": "lib/module/index",
     "types": "lib/typescript/index.d.ts",


### PR DESCRIPTION
walletlib-rn doesn't look for its src files correctly (after bob builder changes). This fixes the `react-native` path to look in `commonjs/index`. 

verified that it now builds correctly.