### PR TITLE
Fix Spec Display Names

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mobile Wallet Adapter specification
+title: Mobile Wallet Adapter 2.0-DRAFT specification
 ---
 
 {%- comment -%}

--- a/spec/spec1.0.md
+++ b/spec/spec1.0.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Mobile Wallet Adapter specification
+title: Mobile Wallet Adapter 1.0 specification
 ---
 
 {%- comment -%}


### PR DESCRIPTION
Currently the 2 spec files have the same title, and get displayed on the web like so:
![image](https://github.com/solana-mobile/mobile-wallet-adapter/assets/29258246/1a0ba133-25a1-4b4e-84a4-3883601702b1)

This PR changes their names to:
- Mobile Wallet Adapter 2.0-DRAFT specification 
- Mobile Wallet Adapter 1.0 specification

(DRAFT will be removed when we formally rev the spec to 2.0.0) 