### PR TITLE
Bump mwa-protocol-web3js version

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-protocol-web3js",
     "description": "A convenience wrapper that enables you to call Solana Mobile Stack protocol methods using objects from @solana/web3.js",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "author": "Steven Luscher <steven.luscher@solanamobile.com>",
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",


### PR DESCRIPTION
**Problem**
`@solana-mobile/mobile-wallet-adapter-protocol-web3js` is published on npm, but the hosted version is currently out of sync with what the repo shows (and its using an outdated dependency of `mobile-wallet-adapter-protocol`).

If you download the [tarball](https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-2.0.1.tgz) you'll see that the included `package.json` has the outdated `mobile-wallet-adapter-protocol` (using `1.0.0` rather than `2.0.0`).

This is causing a [bug](https://github.com/solana-mobile/mobile-wallet-adapter/issues/552) with expo apps.

**Fix**
After bumping this package I can publish a new version to npm, that will be synced to this repo and have a correct dependency. 