### PR TITLE
MWA 2.0 Library RPC Changes

### DIFF
--- a/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
+++ b/android/clientlib/src/main/java/com/solana/mobilewalletadapter/clientlib/protocol/MobileWalletAdapterClient.java
@@ -239,7 +239,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
     public AuthorizationFuture authorize(@Nullable Uri identityUri,
                                          @Nullable Uri iconUri,
                                          @Nullable String identityName,
-                                         @Nullable String cluster)
+                                         @Nullable String chain)
             throws IOException {
         if (identityUri != null && (!identityUri.isAbsolute() || !identityUri.isHierarchical())) {
             throw new IllegalArgumentException("If non-null, identityUri must be an absolute, hierarchical Uri");
@@ -255,7 +255,7 @@ public class MobileWalletAdapterClient extends JsonRpc20Client {
             identity.put(ProtocolContract.PARAMETER_IDENTITY_NAME, identityName);
             authorize = new JSONObject();
             authorize.put(ProtocolContract.PARAMETER_IDENTITY, identity);
-            authorize.put(ProtocolContract.PARAMETER_CLUSTER, cluster); // null is OK
+            authorize.put(ProtocolContract.PARAMETER_CHAIN, chain); // null is OK
         } catch (JSONException e) {
             throw new UnsupportedOperationException("Failed to create authorize JSON params", e);
         }

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
@@ -28,12 +28,14 @@ public class ProtocolContract {
     // METHOD_CLONE_AUTHORIZATION returns a RESULT_AUTH_TOKEN
 
     public static final String METHOD_GET_CAPABILITIES = "get_capabilities";
-    public static final String RESULT_SUPPORTS_CLONE_AUTHORIZATION = "supports_clone_authorization"; // type: Boolean
-    public static final String RESULT_SUPPORTS_SIGN_AND_SEND_TRANSACTIONS = "supports_sign_and_send_transactions"; // type: Boolean
     public static final String RESULT_MAX_TRANSACTIONS_PER_REQUEST = "max_transactions_per_request"; // type: Number
     public static final String RESULT_MAX_MESSAGES_PER_REQUEST = "max_messages_per_request"; // type: Number
     public static final String RESULT_SUPPORTED_TRANSACTION_VERSIONS = "supported_transaction_versions"; // type: JSON array of any primitive datatype
     public static final String RESULT_SUPPORTED_FEATURES = "features"; // type: JSON array of String (feature identifiers)
+    @Deprecated
+    public static final String RESULT_SUPPORTS_CLONE_AUTHORIZATION = "supports_clone_authorization"; // type: Boolean
+    @Deprecated
+    public static final String RESULT_SUPPORTS_SIGN_AND_SEND_TRANSACTIONS = "supports_sign_and_send_transactions"; // type: Boolean
 
     public static final String METHOD_SIGN_TRANSACTIONS = "sign_transactions";
     // METHOD_SIGN_TRANSACTIONS takes a PARAMETER_PAYLOADS
@@ -96,6 +98,15 @@ public class ProtocolContract {
     public static final String CHAIN_SOLANA_DEVNET = "solana:devnet";
 
     public static final String NAMESPACE_SOLANA = "solana";
+
+    // Mandatory Features
+    public static final String FEATURE_ID_SIGN_MESSAGES = "solana:signAndSendTransaction";
+    public static final String FEATURE_ID_SIGN_TRANSACTIONS = "solana:signTransactions";
+
+    // Optional Features
+    public static final String FEATURE_ID_SIGN_AND_SEND_TRANSACTIONS = "solana:signAndSendTransaction";
+    public static final String FEATURE_ID_SIGN_IN_WITH_SOLANA = "solana:signInWithSolana";
+    public static final String FEATURE_ID_CLONE_AUTHORIZATION = "solana:cloneAuthorization";
 
     private ProtocolContract() {}
 }

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
@@ -7,7 +7,8 @@ package com.solana.mobilewalletadapter.common;
 public class ProtocolContract {
     public static final String METHOD_AUTHORIZE = "authorize";
     // METHOD_AUTHORIZE takes an optional PARAMETER_IDENTITY
-    public static final String PARAMETER_CLUSTER = "cluster"; // type: String (one of the CLUSTER_* values)
+    // METHOD_AUTHORIZE takes an optional PARAMETER_AUTH_TOKEN
+    // METHOD_AUTHORIZE takes an optional PARAMETER_CHAIN
     // METHOD_AUTHORIZE returns a RESULT_AUTH_TOKEN
     // METHOD_AUTHORIZE returns a RESULT_ACCOUNTS
     // METHOD_AUTHORIZE returns an optional RESULT_WALLET_URI_BASE
@@ -15,6 +16,7 @@ public class ProtocolContract {
     public static final String METHOD_DEAUTHORIZE = "deauthorize";
     // METHOD_DEAUTHORIZE takes a PARAMETER_AUTH_TOKEN
 
+    @Deprecated
     public static final String METHOD_REAUTHORIZE = "reauthorize";
     // METHOD_REAUTHORIZE takes an optional PARAMETER_IDENTITY
     // METHOD_REAUTHORIZE takes a PARAMETER_AUTH_TOKEN
@@ -31,6 +33,7 @@ public class ProtocolContract {
     public static final String RESULT_MAX_TRANSACTIONS_PER_REQUEST = "max_transactions_per_request"; // type: Number
     public static final String RESULT_MAX_MESSAGES_PER_REQUEST = "max_messages_per_request"; // type: Number
     public static final String RESULT_SUPPORTED_TRANSACTION_VERSIONS = "supported_transaction_versions"; // type: JSON array of any primitive datatype
+    public static final String RESULT_SUPPORTED_FEATURES = "features"; // type: JSON array of String (feature identifiers)
 
     public static final String METHOD_SIGN_TRANSACTIONS = "sign_transactions";
     // METHOD_SIGN_TRANSACTIONS takes a PARAMETER_PAYLOADS
@@ -51,6 +54,11 @@ public class ProtocolContract {
     public static final String PARAMETER_IDENTITY_URI = "uri"; // type: String (absolute URI)
     public static final String PARAMETER_IDENTITY_ICON = "icon"; // type: String (relative URI)
     public static final String PARAMETER_IDENTITY_NAME = "name"; // type: String
+
+    @Deprecated // alias for PARAMETER_CHAIN
+    public static final String PARAMETER_CLUSTER = "cluster"; // type: String (one of the CLUSTER_* values)
+
+    public static final String PARAMETER_CHAIN = "chain"; // type: String (one of the CHAIN_* values)
 
     public static final String PARAMETER_AUTH_TOKEN = "auth_token"; // type: String
 
@@ -82,6 +90,12 @@ public class ProtocolContract {
     public static final String CLUSTER_MAINNET_BETA = "mainnet-beta";
     public static final String CLUSTER_TESTNET = "testnet";
     public static final String CLUSTER_DEVNET = "devnet";
+
+    public static final String CHAIN_SOLANA_MAINNET = "solana:mainnet";
+    public static final String CHAIN_SOLANA_TESTNET = "solana:testnet";
+    public static final String CHAIN_SOLANA_DEVNET = "solana:devnet";
+
+    public static final String NAMESPACE_SOLANA = "solana";
 
     private ProtocolContract() {}
 }

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/ProtocolContract.java
@@ -70,6 +70,8 @@ public class ProtocolContract {
     public static final String RESULT_ACCOUNTS = "accounts"; // type: JSON array of Account
     public static final String RESULT_ACCOUNTS_ADDRESS = "address"; // type: String (base64-encoded addresses)
     public static final String RESULT_ACCOUNTS_LABEL = "label"; // type: String
+    public static final String RESULT_ACCOUNTS_CHAINS = "chains"; // type: String
+    // RESULT_ACCOUNTS optionally includes a RESULT_SUPPORTED_FEATURES
 
     public static final String RESULT_WALLET_URI_BASE = "wallet_uri_base"; // type: String (absolute URI)
 

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/util/Identifier.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/util/Identifier.java
@@ -2,6 +2,8 @@ package com.solana.mobilewalletadapter.common.util;
 
 import androidx.annotation.NonNull;
 
+import com.solana.mobilewalletadapter.common.ProtocolContract;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -13,6 +15,20 @@ public class Identifier {
     public static boolean isValidIdentifier(@NonNull String input) {
         Matcher matcher = namespacedIdentifierPattern.matcher(input);
         return matcher.find();
+    }
+
+    public static @NonNull String clusterToChainIdentifier(@NonNull String cluster)
+            throws IllegalArgumentException {
+        switch (cluster) {
+            case ProtocolContract.CLUSTER_MAINNET_BETA:
+                return ProtocolContract.CHAIN_SOLANA_MAINNET;
+            case ProtocolContract.CLUSTER_TESTNET:
+                return ProtocolContract.CHAIN_SOLANA_TESTNET;
+            case ProtocolContract.CLUSTER_DEVNET:
+                return ProtocolContract.CHAIN_SOLANA_DEVNET;
+            default:
+                throw new IllegalArgumentException("input is not a valid solana cluster");
+        }
     }
 
     private Identifier() {}

--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/util/Identifier.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/util/Identifier.java
@@ -1,0 +1,19 @@
+package com.solana.mobilewalletadapter.common.util;
+
+import androidx.annotation.NonNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Identifier {
+
+    // matches "{namespace}:{reference}", no whitespace
+    private static final Pattern namespacedIdentifierPattern = Pattern.compile("^\\S+:\\S+$");
+
+    public static boolean isValidIdentifier(@NonNull String input) {
+        Matcher matcher = namespacedIdentifierPattern.matcher(input);
+        return matcher.find();
+    }
+
+    private Identifier() {}
+}

--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -63,7 +63,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
                 10,
                 10,
                 arrayOf(MobileWalletAdapterConfig.LEGACY_TRANSACTION_VERSION, 0),
-                LOW_POWER_NO_CONNECTION_TIMEOUT_MS
+                LOW_POWER_NO_CONNECTION_TIMEOUT_MS,
             ),
             AuthIssuerConfig("fakewallet"),
             MobileWalletAdapterScenarioCallbacks()

--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -258,7 +258,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
             return
         }
 
-        Log.d(TAG, "Simulating transactions submitted on cluster=${request.request.cluster}")
+        Log.d(TAG, "Simulating transactions submitted on cluster=${request.request.chain}")
 
         request.request.completeWithSignatures(request.signatures!!)
     }
@@ -268,7 +268,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
             return
         }
 
-        Log.d(TAG, "Simulating transactions NOT submitted on cluster=${request.request.cluster}")
+        Log.d(TAG, "Simulating transactions NOT submitted on cluster=${request.request.chain}")
 
         val signatures = request.signatures!!
         val notSubmittedSignatures = Array(signatures.size) { i ->

--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -59,11 +59,11 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
         scenario = associationUri.createScenario(
             getApplication<FakeWalletApplication>().applicationContext,
             MobileWalletAdapterConfig(
+                true,
                 10,
                 10,
                 arrayOf(MobileWalletAdapterConfig.LEGACY_TRANSACTION_VERSION, 0),
-                LOW_POWER_NO_CONNECTION_TIMEOUT_MS,
-                arrayOf(ProtocolContract.FEATURE_ID_SIGN_AND_SEND_TRANSACTIONS)
+                LOW_POWER_NO_CONNECTION_TIMEOUT_MS
             ),
             AuthIssuerConfig("fakewallet"),
             MobileWalletAdapterScenarioCallbacks()
@@ -258,7 +258,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
             return
         }
 
-        Log.d(TAG, "Simulating transactions submitted on cluster=${request.request.chain}")
+        Log.d(TAG, "Simulating transactions submitted on cluster=${request.request.cluster}")
 
         request.request.completeWithSignatures(request.signatures!!)
     }
@@ -268,7 +268,7 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
             return
         }
 
-        Log.d(TAG, "Simulating transactions NOT submitted on cluster=${request.request.chain}")
+        Log.d(TAG, "Simulating transactions NOT submitted on cluster=${request.request.cluster}")
 
         val signatures = request.signatures!!
         val notSubmittedSignatures = Array(signatures.size) { i ->

--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -59,11 +59,11 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
         scenario = associationUri.createScenario(
             getApplication<FakeWalletApplication>().applicationContext,
             MobileWalletAdapterConfig(
-                true,
                 10,
                 10,
                 arrayOf(MobileWalletAdapterConfig.LEGACY_TRANSACTION_VERSION, 0),
                 LOW_POWER_NO_CONNECTION_TIMEOUT_MS,
+                arrayOf(ProtocolContract.FEATURE_ID_SIGN_AND_SEND_TRANSACTIONS)
             ),
             AuthIssuerConfig("fakewallet"),
             MobileWalletAdapterScenarioCallbacks()

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
@@ -33,6 +33,9 @@ public class AuthRecord {
     public final String accountLabel;
 
     @NonNull
+    public final String chain;
+
+    @NonNull @Deprecated
     public final String cluster;
 
     @NonNull
@@ -53,7 +56,7 @@ public class AuthRecord {
                            @NonNull IdentityRecord identity,
                            @NonNull byte[] publicKey,
                            @Nullable String accountLabel,
-                           @NonNull String cluster,
+                           @NonNull String chain,
                            @NonNull byte[] scope,
                            @Nullable Uri walletUriBase,
                            @IntRange(from = 1) int publicKeyId,
@@ -66,7 +69,8 @@ public class AuthRecord {
         this.identity = identity;
         this.publicKey = publicKey;
         this.accountLabel = accountLabel;
-        this.cluster = cluster;
+        this.chain = chain;
+        this.cluster = chain;
         this.scope = scope;
         this.walletUriBase = walletUriBase;
         this.publicKeyId = publicKeyId;
@@ -112,7 +116,7 @@ public class AuthRecord {
                 "id=" + id +
                 ", identity=" + identity +
                 ", publicKey=" + Arrays.toString(publicKey) +
-                ", cluster='" + cluster + '\'' +
+                ", chain='" + chain + '\'' +
                 ", scope=" + Arrays.toString(scope) +
                 ", walletUriBase='" + walletUriBase + '\'' +
                 ", issued=" + issued +

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterConfig.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterConfig.java
@@ -8,9 +8,13 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Size;
 
+import com.solana.mobilewalletadapter.common.ProtocolContract;
+import com.solana.mobilewalletadapter.common.util.Identifier;
+
 public class MobileWalletAdapterConfig {
     public static final String LEGACY_TRANSACTION_VERSION = "legacy";
 
+    @Deprecated
     public final boolean supportsSignAndSendTransactions;
 
     @IntRange(from = 0)
@@ -27,12 +31,36 @@ public class MobileWalletAdapterConfig {
     @Size(min = 1)
     public final Object[] supportedTransactionVersions;
 
+    @NonNull
+    public final String[] optionalFeatures;
+
+    @Deprecated
     public MobileWalletAdapterConfig(boolean supportsSignAndSendTransactions,
                                      @IntRange(from = 0) int maxTransactionsPerSigningRequest,
                                      @IntRange(from = 0) int maxMessagesPerSigningRequest,
                                      @NonNull @Size(min = 1) Object[] supportedTransactionVersions,
                                      @IntRange(from = 0) long noConnectionWarningTimeoutMs) {
         this.supportsSignAndSendTransactions = supportsSignAndSendTransactions;
+        this.maxTransactionsPerSigningRequest = maxTransactionsPerSigningRequest;
+        this.maxMessagesPerSigningRequest = maxMessagesPerSigningRequest;
+        this.noConnectionWarningTimeoutMs = noConnectionWarningTimeoutMs;
+        this.optionalFeatures = supportsSignAndSendTransactions
+                ? new String[] { ProtocolContract.FEATURE_ID_SIGN_AND_SEND_TRANSACTIONS } : new String[] {};
+
+        for (Object o : supportedTransactionVersions) {
+            if (!((o instanceof String) && LEGACY_TRANSACTION_VERSION.equals((String)o)) &&
+                    !((o instanceof Integer) && ((Integer)o >= 0))) {
+                throw new IllegalArgumentException("supportedTransactionVersions must be either the string \"legacy\" or a non-negative integer");
+            }
+        }
+        this.supportedTransactionVersions = supportedTransactionVersions;
+    }
+
+    public MobileWalletAdapterConfig(@IntRange(from = 0) int maxTransactionsPerSigningRequest,
+                                     @IntRange(from = 0) int maxMessagesPerSigningRequest,
+                                     @NonNull @Size(min = 1) Object[] supportedTransactionVersions,
+                                     @IntRange(from = 0) long noConnectionWarningTimeoutMs,
+                                     @NonNull String[] supportedFeatures) {
         this.maxTransactionsPerSigningRequest = maxTransactionsPerSigningRequest;
         this.maxMessagesPerSigningRequest = maxMessagesPerSigningRequest;
         this.noConnectionWarningTimeoutMs = noConnectionWarningTimeoutMs;
@@ -44,5 +72,18 @@ public class MobileWalletAdapterConfig {
             }
         }
         this.supportedTransactionVersions = supportedTransactionVersions;
+
+        boolean supportsSignAndSendTransactions = false;
+        for (String featureId : supportedFeatures) {
+            if (!Identifier.isValidIdentifier(featureId)) {
+                throw new IllegalArgumentException("supportedFeatures must be a valid namespaced feature identifier of the form '{namespace}:{reference}'");
+            }
+            if (featureId.equals(ProtocolContract.FEATURE_ID_SIGN_AND_SEND_TRANSACTIONS)) {
+                supportsSignAndSendTransactions = true;
+                break;
+            }
+        }
+        this.supportsSignAndSendTransactions = supportsSignAndSendTransactions;
+        this.optionalFeatures = supportedFeatures;
     }
 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -505,7 +505,6 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
         final JSONObject result = new JSONObject();
         try {
             result.put(ProtocolContract.RESULT_SUPPORTS_CLONE_AUTHORIZATION, false);
-            result.put(ProtocolContract.RESULT_SUPPORTS_SIGN_AND_SEND_TRANSACTIONS, mConfig.supportsSignAndSendTransactions);
             if (mConfig.maxTransactionsPerSigningRequest != 0) {
                 result.put(ProtocolContract.RESULT_MAX_TRANSACTIONS_PER_REQUEST, mConfig.maxTransactionsPerSigningRequest);
             }
@@ -513,6 +512,10 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
                 result.put(ProtocolContract.RESULT_MAX_MESSAGES_PER_REQUEST, mConfig.maxMessagesPerSigningRequest);
             }
             result.put(ProtocolContract.RESULT_SUPPORTED_TRANSACTION_VERSIONS, new JSONArray(mConfig.supportedTransactionVersions));
+            result.put(ProtocolContract.RESULT_SUPPORTED_FEATURES, new JSONArray(mConfig.optionalFeatures));
+
+            // retained for backwards compatibility
+            result.put(ProtocolContract.RESULT_SUPPORTS_SIGN_AND_SEND_TRANSACTIONS, mConfig.supportsSignAndSendTransactions);
         } catch (JSONException e) {
             throw new RuntimeException("Failed preparing get_capabilities response", e);
         }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizeRequest.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizeRequest.java
@@ -26,18 +26,18 @@ public class AuthorizeRequest
     protected final Uri mIconUri;
 
     @NonNull
-    protected final String mCluster;
+    protected final String mChain;
 
     /*package*/ AuthorizeRequest(@NonNull NotifyingCompletableFuture<Result> request,
                                  @Nullable String identityName,
                                  @Nullable Uri identityUri,
                                  @Nullable Uri iconUri,
-                                 @NonNull String cluster) {
+                                 @NonNull String chain) {
         super(request);
         mIdentityName = identityName;
         mIdentityUri = identityUri;
         mIconUri = iconUri;
-        mCluster = cluster;
+        mChain = chain;
     }
 
     @Nullable
@@ -55,9 +55,14 @@ public class AuthorizeRequest
         return mIconUri;
     }
 
-    @NonNull
+    @NonNull @Deprecated
     public String getCluster() {
-        return mCluster;
+        return mChain;
+    }
+
+    @NonNull
+    public String getChain() {
+        return mChain;
     }
 
     public void completeWithAuthorize(@NonNull byte[] publicKey,

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizeRequest.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizeRequest.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.Size;
 
 import com.solana.mobilewalletadapter.common.util.NotifyingCompletableFuture;
 import com.solana.mobilewalletadapter.walletlib.protocol.MobileWalletAdapterServer;
@@ -65,11 +66,20 @@ public class AuthorizeRequest
         return mChain;
     }
 
+    @Deprecated
     public void completeWithAuthorize(@NonNull byte[] publicKey,
                                       @Nullable String accountLabel,
                                       @Nullable Uri walletUriBase,
                                       @Nullable byte[] scope) {
-        mRequest.complete(new Result(publicKey, accountLabel, walletUriBase, scope));
+        AuthorizedAccount[] accounts = new AuthorizedAccount[] {
+                new AuthorizedAccount(publicKey, accountLabel, null, null)};
+        mRequest.complete(new Result(accounts, walletUriBase, scope));
+    }
+
+    public void completeWithAuthorize(@NonNull AuthorizedAccount[] accounts,
+                                      @Nullable Uri walletUriBase,
+                                      @Nullable byte[] scope) {
+        mRequest.complete(new Result(accounts, walletUriBase, scope));
     }
 
     public void completeWithDecline() {
@@ -82,21 +92,17 @@ public class AuthorizeRequest
     }
 
     /*package*/ static class Result {
-        @NonNull
-        /*package*/ final byte[] publicKey;
-        @Nullable
-        /*package*/ final String accountLabel;
+        @NonNull @Size(min = 1)
+        /*package*/ final AuthorizedAccount[] accounts;
         @Nullable
         /*package*/ final Uri walletUriBase;
         @Nullable
         /*package*/ final byte[] scope;
 
-        private Result(@NonNull byte[] publicKey,
-                       @Nullable String accountLabel,
+        private Result(@NonNull @Size(min = 1) AuthorizedAccount[] accounts,
                        @Nullable Uri walletUriBase,
                        @Nullable byte[] scope) {
-            this.publicKey = publicKey;
-            this.accountLabel = accountLabel;
+            this.accounts = accounts;
             this.walletUriBase = walletUriBase;
             this.scope = scope;
         }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizedAccount.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizedAccount.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Solana Mobile Inc.
+ */
+
+package com.solana.mobilewalletadapter.walletlib.scenario;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Arrays;
+
+public class AuthorizedAccount {
+    @NonNull
+    public final byte[] publicKey;
+    @Nullable
+    public final String accountLabel;
+    @Nullable
+    public final String[] chains;
+    @Nullable
+    public final String[] features;
+
+    public AuthorizedAccount(@NonNull byte[] publicKey,
+                      @Nullable String accountLabel,
+                      @Nullable String[] chains,
+                      @Nullable String[] features) {
+        this.publicKey = publicKey;
+        this.accountLabel = accountLabel;
+        this.chains = chains;
+        this.features = features;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AuthorizedAccount{" +
+                "publicKey=" + Arrays.toString(publicKey) +
+                ", accountLabel='" + accountLabel + '\'' +
+                ", chains=" + Arrays.toString(chains) +
+                ", features=" + Arrays.toString(features) +
+                '}';
+    }
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/BaseVerifiableIdentityRequest.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/BaseVerifiableIdentityRequest.java
@@ -25,7 +25,7 @@ import com.solana.mobilewalletadapter.common.util.NotifyingCompletableFuture;
     protected final Uri mIconUri;
 
     @NonNull
-    protected final String mCluster;
+    protected final String mChain;
 
     @NonNull
     protected final byte[] mAuthorizationScope;
@@ -34,14 +34,14 @@ import com.solana.mobilewalletadapter.common.util.NotifyingCompletableFuture;
                                             @Nullable String identityName,
                                             @Nullable Uri identityUri,
                                             @Nullable Uri iconUri,
-                                            @NonNull String cluster,
+                                            @NonNull String chain,
                                             @NonNull byte[] authorizationScope) {
         super(request);
         mIdentityName = identityName;
         mIdentityUri = identityUri;
         mIconUri = iconUri;
         mAuthorizationScope = authorizationScope;
-        mCluster = cluster;
+        mChain = chain;
     }
 
     @Nullable
@@ -59,9 +59,14 @@ import com.solana.mobilewalletadapter.common.util.NotifyingCompletableFuture;
         return mIconUri;
     }
 
-    @NonNull
+    @NonNull @Deprecated
     public String getCluster() {
-        return mCluster;
+        return mChain;
+    }
+
+    @NonNull
+    public String getChain() {
+        return mChain;
     }
 
     @NonNull

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalScenario.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalScenario.java
@@ -209,9 +209,10 @@ public abstract class LocalScenario implements Scenario {
                         final String name = request.identityName != null ? request.identityName : "";
                         final Uri uri = request.identityUri != null ? request.identityUri : Uri.EMPTY;
                         final Uri relativeIconUri = request.iconUri != null ? request.iconUri : Uri.EMPTY;
+                        final AuthorizedAccount account = authorize.accounts[0]; // TODO(#44): support multiple addresses
                         final AuthRecord authRecord = mAuthRepository.issue(
-                                name, uri, relativeIconUri, authorize.publicKey,
-                                authorize.accountLabel, chain, authorize.walletUriBase,
+                                name, uri, relativeIconUri, account.publicKey,
+                                account.accountLabel, chain, authorize.walletUriBase,
                                 authorize.scope);
                         Log.d(TAG, "Authorize request completed successfully; issued auth: " + authRecord);
                         synchronized (mLock) {
@@ -220,7 +221,7 @@ public abstract class LocalScenario implements Scenario {
 
                         final String authToken = mAuthRepository.toAuthToken(authRecord);
                         request.complete(new MobileWalletAdapterServer.AuthorizationResult(
-                                authToken, authorize.publicKey, authorize.accountLabel,
+                                authToken, authorize.accounts,
                                 authorize.walletUriBase));
                     } else {
                         request.completeExceptionally(new MobileWalletAdapterServer.RequestDeclinedException(

--- a/android/walletlib/src/test/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalWebSocketServerScenarioTest.java
+++ b/android/walletlib/src/test/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalWebSocketServerScenarioTest.java
@@ -37,11 +37,11 @@ public class LocalWebSocketServerScenarioTest {
         AuthIssuerConfig authConfig = new AuthIssuerConfig("Test");
 
         MobileWalletAdapterConfig config = new MobileWalletAdapterConfig(
-                false,
                 1,
                 1,
                 new Object[] { "legacy" },
-                noConnectionTimeout
+                noConnectionTimeout,
+                new String[] {}
         );
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -76,11 +76,11 @@ public class LocalWebSocketServerScenarioTest {
         AuthIssuerConfig authConfig = new AuthIssuerConfig("Test");
 
         MobileWalletAdapterConfig config = new MobileWalletAdapterConfig(
-                false,
                 1,
                 1,
                 new Object[] { "legacy" },
-                noConnectionTimeout
+                noConnectionTimeout,
+                new String[] {}
         );
 
         CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
Adds the RPC changes from the MWA 2.0 spec, excluding the Sign in With Solana feature. 

This PR begins to address issue #44 (support multiple authorized accounts), but does not completely flesh this out. The PR became way too big and I was struggling to get the SQL stuff working with multiple accounts per authorization in the auth repository. I have forked these changes and will open a separate PR. The new account metadata fields (`chains` and `features`) are not fully supported in this PR for the same reason (the scenario processes these params, but they are not stored in the auth repository). 

Apps (fakewallet/dapp) are unchanged because:
- smaller prs, apps will be updated separately 
- ensure that changes are fully backwards compatible with existing apps 

TODO: currently adding unit tests 