### PR TITLE
[TBD] Align with upcoming wallet-standard connect feature

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -375,7 +375,9 @@ authorize
         “icon”: “<dapp_icon_relative_path>”,
         “name”: “<dapp_name>”,
     },
-    "chain": "<chain>",
+    "chains": ["<chain>", ...],
+    "features": ["<feature_id>", ...],
+    "addresses": ["<address>", ...],
     “auth_token”: “<auth_token>”,
     "sign_in_payload": <sign_in_payload>,
     "cluster": "<cluster>"


### PR DESCRIPTION
This PR aligns the mwa `authorize` method with upcoming changes to wallet-standard `connect` feature, based on guidance from @jordansexton 

This change allows dapps to specify the chains, features, and any known account addresses that it wishes to be included in the authorized scope. 