### PR TITLE
Expose MWA 2.0 stuff in Fakedapp 

### DIFF
--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.solana.mobilewalletadapter.fakedapp.databinding.ActivityMainBinding
+import com.solana.mobilewalletadapter.fakedapp.usecase.Base58EncodeUseCase
 import com.solana.mobilewalletadapter.fakedapp.usecase.MemoTransactionVersion
 import com.solana.mobilewalletadapter.fakedapp.usecase.MobileWalletAdapterUseCase.StartMobileWalletAdapterActivity
 import kotlinx.coroutines.launch
@@ -54,11 +55,17 @@ class MainActivity : AppCompatActivity() {
                         if (spinnerPos > 0) viewBinding.spinnerTxnVer.setSelection(spinnerPos)
                     }
 
-                    viewBinding.tvAccountName.text =
-                        uiState.accountLabel ?: getString(R.string.string_no_account_name)
+                    viewBinding.spinnerAccounts.adapter =
+                        ArrayAdapter(this@MainActivity, android.R.layout.simple_spinner_item,
+                            uiState.accounts?.map { account ->
+                                account.accountLabel ?: Base58EncodeUseCase.invoke(account.publicKey)
+                            } ?: listOf()
+                        )
+
                     viewBinding.tvWalletUriPrefix.text =
-                        uiState.walletUriBase?.toString()
-                            ?: getString(R.string.string_no_wallet_uri_prefix)
+                        uiState.walletUriBase?.toString() ?: getString(R.string.string_no_wallet_uri_prefix)
+                    viewBinding.tvSessionVersion.text =
+                        uiState.sessionProtocolVersion?.toString() ?: getString(R.string.string_no_session_version)
 
                     if (uiState.messages.isNotEmpty()) {
                         val message = uiState.messages.first()

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
+import com.solana.mobilewalletadapter.common.protocol.SessionProperties
 import com.solana.mobilewalletadapter.fakedapp.databinding.ActivityMainBinding
 import com.solana.mobilewalletadapter.fakedapp.usecase.Base58EncodeUseCase
 import com.solana.mobilewalletadapter.fakedapp.usecase.MemoTransactionVersion
@@ -65,7 +66,12 @@ class MainActivity : AppCompatActivity() {
                     viewBinding.tvWalletUriPrefix.text =
                         uiState.walletUriBase?.toString() ?: getString(R.string.string_no_wallet_uri_prefix)
                     viewBinding.tvSessionVersion.text =
-                        uiState.sessionProtocolVersion?.toString() ?: getString(R.string.string_no_session_version)
+                        getString(uiState.sessionProtocolVersion?.let {
+                            when (it) {
+                                SessionProperties.ProtocolVersion.LEGACY -> R.string.string_session_version_legacy
+                                SessionProperties.ProtocolVersion.V1 -> R.string.string_session_version_v1
+                            }
+                        } ?: R.string.string_no_session_version)
 
                     if (uiState.messages.isNotEmpty()) {
                         val message = uiState.messages.first()

--- a/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/MobileWalletAdapterUseCase.kt
+++ b/android/fakedapp/src/main/java/com/solana/mobilewalletadapter/fakedapp/usecase/MobileWalletAdapterUseCase.kt
@@ -21,6 +21,7 @@ import com.solana.mobilewalletadapter.clientlib.scenario.LocalAssociationIntentC
 import com.solana.mobilewalletadapter.clientlib.scenario.LocalAssociationScenario
 import com.solana.mobilewalletadapter.clientlib.scenario.Scenario
 import com.solana.mobilewalletadapter.common.ProtocolContract
+import com.solana.mobilewalletadapter.common.protocol.SessionProperties
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -317,13 +318,13 @@ object MobileWalletAdapterUseCase {
     suspend fun <T> localAssociateAndExecute(
         intentLauncher: ActivityResultLauncher<StartMobileWalletAdapterActivity.CreateParams>,
         uriPrefix: Uri? = null,
-        action: suspend (Client) -> T
+        action: suspend (Client, SessionProperties) -> T
     ): T = localAssociateAndExecuteAsync(intentLauncher, uriPrefix, action).await()
 
     suspend fun <T> localAssociateAndExecuteAsync(
         intentLauncher: ActivityResultLauncher<StartMobileWalletAdapterActivity.CreateParams>,
         uriPrefix: Uri? = null,
-        action: suspend (Client) -> T
+        action: suspend (Client, SessionProperties) -> T
     ): Deferred<T> = coroutineScope {
         // Use async to launch in a new Job, for proper cancellation semantics
         async {
@@ -373,7 +374,8 @@ object MobileWalletAdapterUseCase {
 
                         contract.onMobileWalletAdapterClientConnected(this)
 
-                        action(Client(mobileWalletAdapterClient))
+                        action(Client(mobileWalletAdapterClient),
+                            localAssociation.session.sessionProperties)
                     } finally {
                         @Suppress("BlockingMethodInNonBlockingContext") // running in Dispatchers.IO; blocking is appropriate
                         localAssociation.close()

--- a/android/fakedapp/src/main/res/layout/activity_main.xml
+++ b/android/fakedapp/src/main/res/layout/activity_main.xml
@@ -187,26 +187,25 @@
         android:enabled="false" />
 
     <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/label_account_name"
+        android:id="@+id/label_accounts"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
-        app:layout_constraintTop_toTopOf="@id/tv_account_name"
-        app:layout_constraintBottom_toBottomOf="@id/tv_account_name"
+        app:layout_constraintTop_toTopOf="@id/spinner_accounts"
+        app:layout_constraintBottom_toBottomOf="@id/spinner_accounts"
         app:layout_constraintStart_toStartOf="parent"
-        android:text="@string/label_account_name"
+        android:text="@string/label_accounts"
         android:textAppearance="?textAppearanceBody1"
         android:textStyle="bold" />
 
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/tv_account_name"
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/spinner_accounts"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         app:layout_constraintTop_toBottomOf="@id/label_has_auth_token"
-        app:layout_constraintStart_toEndOf="@id/label_account_name"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:textAppearance="?textAppearanceBody1" />
+        app:layout_constraintStart_toEndOf="@id/label_accounts"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/label_wallet_uri_prefix"
@@ -225,7 +224,29 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
-        app:layout_constraintTop_toBottomOf="@id/label_account_name"
+        app:layout_constraintTop_toBottomOf="@id/spinner_accounts"
+        app:layout_constraintStart_toEndOf="@id/label_wallet_uri_prefix"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:textAppearance="?textAppearanceBody1" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/label_session_version"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        app:layout_constraintTop_toTopOf="@id/tv_session_version"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_session_version"
+        app:layout_constraintStart_toStartOf="parent"
+        android:text="@string/label_session_version"
+        android:textAppearance="?textAppearanceBody1"
+        android:textStyle="bold" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tv_session_version"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        app:layout_constraintTop_toBottomOf="@id/label_wallet_uri_prefix"
         app:layout_constraintStart_toEndOf="@id/label_wallet_uri_prefix"
         app:layout_constraintEnd_toEndOf="parent"
         android:textAppearance="?textAppearanceBody1" />

--- a/android/fakedapp/src/main/res/values/strings.xml
+++ b/android/fakedapp/src/main/res/values/strings.xml
@@ -38,4 +38,6 @@
     <string name="string_no_wallet_uri_prefix">&lt;none&gt;</string>
     <string name="label_session_version">Protocol Version:</string>
     <string name="string_no_session_version">&lt;none&gt;</string>
+    <string name="string_session_version_legacy">Legacy</string>
+    <string name="string_session_version_v1">MWA 2.0</string>
 </resources>

--- a/android/fakedapp/src/main/res/values/strings.xml
+++ b/android/fakedapp/src/main/res/values/strings.xml
@@ -33,8 +33,9 @@
     <string name="label_sign_and_send_txn_x3">x3</string>
     <string name="label_sign_and_send_txn_x20">x20</string>
     <string name="label_has_auth_token">Has auth token?</string>
-    <string name="label_account_name">Account name:</string>
-    <string name="string_no_account_name">&lt;none&gt;</string>
+    <string name="label_accounts">Accounts:</string>
     <string name="label_wallet_uri_prefix">Wallet URI prefix:</string>
     <string name="string_no_wallet_uri_prefix">&lt;none&gt;</string>
+    <string name="label_session_version">Protocol Version:</string>
+    <string name="string_no_session_version">&lt;none&gt;</string>
 </resources>

--- a/android/fakewallet/build.gradle
+++ b/android/fakewallet/build.gradle
@@ -60,13 +60,11 @@ android {
     productFlavors {
         v1 {
             dimension "protocol_version"
-            applicationId "com.solana.mobilewalletadapter.fakewallet"
             buildConfigField "com.solana.mobilewalletadapter.common.protocol.SessionProperties.ProtocolVersion",
                     "PROTOCOL_VERSION", "com.solana.mobilewalletadapter.common.protocol.SessionProperties.ProtocolVersion.V1"
         }
         legacy {
             dimension "protocol_version"
-            applicationId "com.solana.mobilewalletadapter.fakewallet.legacy"
             resValue "string", "app_name", "Fake Wallet App (Legacy)"
             buildConfigField "com.solana.mobilewalletadapter.common.protocol.SessionProperties.ProtocolVersion",
                     "PROTOCOL_VERSION", "com.solana.mobilewalletadapter.common.protocol.SessionProperties.ProtocolVersion.LEGACY"

--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -58,30 +58,34 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
             associationUri
         )
 
-        val config = MobileWalletAdapterConfig(
-            10,
-            10,
-            arrayOf(MobileWalletAdapterConfig.LEGACY_TRANSACTION_VERSION, 0),
-            LOW_POWER_NO_CONNECTION_TIMEOUT_MS,
-            arrayOf(ProtocolContract.FEATURE_ID_SIGN_TRANSACTIONS)
-        )
-
         scenario = if (BuildConfig.PROTOCOL_VERSION == SessionProperties.ProtocolVersion.LEGACY) {
             // manually create the scenario here so we can override the association protocol version
             // this forces ProtocolVersion.LEGACY to simulate a wallet using walletlib 1.x (for testing)
             LocalWebSocketServerScenario(
                 getApplication<FakeWalletApplication>().applicationContext,
-                config,
+                MobileWalletAdapterConfig(
+                    true,
+                    10,
+                    10,
+                    arrayOf(MobileWalletAdapterConfig.LEGACY_TRANSACTION_VERSION, 0),
+                    LOW_POWER_NO_CONNECTION_TIMEOUT_MS
+                ),
                 AuthIssuerConfig("fakewallet"),
                 MobileWalletAdapterScenarioCallbacks(),
                 associationUri.associationPublicKey,
-                listOf(SessionProperties.ProtocolVersion.LEGACY),
+                listOf(),
                 associationUri.port,
             )
         } else {
             associationUri.createScenario(
                 getApplication<FakeWalletApplication>().applicationContext,
-                config,
+                MobileWalletAdapterConfig(
+                    10,
+                    10,
+                    arrayOf(MobileWalletAdapterConfig.LEGACY_TRANSACTION_VERSION, 0),
+                    LOW_POWER_NO_CONNECTION_TIMEOUT_MS,
+                    arrayOf(ProtocolContract.FEATURE_ID_SIGN_TRANSACTIONS)
+                ),
                 AuthIssuerConfig("fakewallet"),
                 MobileWalletAdapterScenarioCallbacks()
             )

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterConfig.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterConfig.java
@@ -45,8 +45,7 @@ public class MobileWalletAdapterConfig {
                                      @NonNull @Size(min = 1) Object[] supportedTransactionVersions,
                                      @IntRange(from = 0) long noConnectionWarningTimeoutMs) {
         this(maxTransactionsPerSigningRequest, maxMessagesPerSigningRequest,
-                supportedTransactionVersions, noConnectionWarningTimeoutMs,
-                new String[] { ProtocolContract.FEATURE_ID_SIGN_TRANSACTIONS });
+                supportedTransactionVersions, noConnectionWarningTimeoutMs, new String[] {});
         if (!supportsSignAndSendTransactions)
             throw new IllegalArgumentException("signAndSendTransactions is required in MWA 2.0");
     }


### PR DESCRIPTION
There is more to be done here but so far:
- fakedapp ~~will~~ can now display multiple account labels returned
  - allowing the user to choose which account is actually used for requests will come in a future PR
- fakedapp now displays the protocol version ("Legacy" or "MWA 2.0") of the established session 
- fakewallet can be deployed using the V1 or Legacy flavor. Legacy attempts to mimic a legacy wallet, tho the most complete way to test this is to build fakewallet from the [v1.x branch](https://github.com/solana-mobile/mobile-wallet-adapter/tree/v1.x).   