### PR TITLE
MWA 2.0 Auth Repository

### DIFF
--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -117,8 +117,8 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
                 val keypair = getApplication<FakeWalletApplication>().keyRepository.generateKeypair()
                 val publicKey = keypair.public as Ed25519PublicKeyParameters
                 Log.d(TAG, "Generated a new keypair (pub=${publicKey.encoded.contentToString()}) for authorize request")
-                val accounts = arrayOf(buildAccount(publicKey.encoded, "fakewallet"))
-                request.request.completeWithAuthorize(accounts, null,
+                val account = buildAccount(publicKey.encoded, "fakewallet")
+                request.request.completeWithAuthorize(account, null,
                     request.sourceVerificationState.authorizationScope.encodeToByteArray(), null)
             } else {
                 request.request.completeWithDecline()
@@ -174,8 +174,8 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
                 val signInResult = SignInResult(publicKey.encoded,
                     siwsMessage.encodeToByteArray(), signResult.signature, "ed25519")
 
-                val accounts = arrayOf(buildAccount(publicKey.encoded, "fakewallet"))
-                request.request.completeWithAuthorize(accounts, null,
+                val account = buildAccount(publicKey.encoded, "fakewallet")
+                request.request.completeWithAuthorize(account, null,
                     request.sourceVerificationState.authorizationScope.encodeToByteArray(), signInResult)
             } else {
                 request.request.completeWithDecline()

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecord.java
@@ -1,0 +1,41 @@
+package com.solana.mobilewalletadapter.walletlib.authorization;
+
+import android.net.Uri;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/* package */ class AccountRecord {
+    @IntRange(from = 1)
+    final int id;
+
+    @NonNull
+    final byte[] publicKeyRaw;
+
+    @Nullable
+    final String accountLabel;
+
+    @Nullable
+    final Uri icon;
+
+    @Nullable
+    final String[] chains;
+
+    @Nullable
+    final String[] features;
+
+    AccountRecord(@IntRange(from = 1) int id,
+                  @NonNull byte[] publicKeyRaw,
+                  @Nullable String accountLabel,
+                  @Nullable Uri icon,
+                  @Nullable String[] chains,
+                  @Nullable String[] features) {
+        this.id = id;
+        this.publicKeyRaw = publicKeyRaw;
+        this.accountLabel = accountLabel;
+        this.icon = icon;
+        this.chains = chains;
+        this.features = features;
+    }
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsDao.java
@@ -68,12 +68,12 @@ public class AccountRecordsDao extends DbContentProvider<AccountRecord>
 
     @Override
     public void deleteUnreferencedAccounts() {
-        final SQLiteStatement deleteUnreferencedPublicKeys = super.compileStatement(
+        final SQLiteStatement deleteUnreferencedAccounts = super.compileStatement(
                 "DELETE FROM " + TABLE_ACCOUNTS +
                         " WHERE " + COLUMN_ACCOUNTS_ID + " NOT IN " +
                         "(SELECT DISTINCT " + AuthorizationsSchema.COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
                         " FROM " + AuthorizationsSchema.TABLE_AUTHORIZATIONS + ')');
-        deleteUnreferencedPublicKeys.executeUpdateDelete();
+        deleteUnreferencedAccounts.executeUpdateDelete();
     }
 
     // using a long alphanumeric divider reduces the chance of an array element matching the divider

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsDao.java
@@ -1,0 +1,99 @@
+package com.solana.mobilewalletadapter.walletlib.authorization;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteCursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class AccountRecordsDao extends DbContentProvider<AccountRecord>
+        implements AccountRecordsDaoInterface, AccountRecordsSchema {
+
+    public AccountRecordsDao(SQLiteDatabase db) { super(db); }
+
+    @NonNull
+    @Override
+    protected AccountRecord cursorToEntity(@NonNull Cursor cursor) {
+        final int publicKeyId = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_ACCOUNTS_ID));
+        final byte[] publicKey = cursor.getBlob(cursor.getColumnIndexOrThrow(COLUMN_ACCOUNTS_PUBLIC_KEY_RAW));
+        final String accountLabel = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_ACCOUNTS_LABEL));
+        final String accountIconStr = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_ACCOUNTS_ICON));
+        final String chainsString = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_ACCOUNTS_CHAINS));
+        final String featuresString = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_ACCOUNTS_FEATURES));
+        final Uri accountIcon = Uri.parse(accountIconStr);
+        final String[] chains = deserialize(chainsString);
+        final String[] features = deserialize(featuresString);
+        return new AccountRecord(publicKeyId, publicKey, accountLabel, accountIcon, chains, features);
+    }
+
+    @Override
+    public long insert(@NonNull byte[] publicKey,
+                       @Nullable String accountLabel,
+                       @Nullable Uri accountIcon,
+                       @Nullable String[] chains,
+                       @Nullable String[] features) {
+        final ContentValues accountContentValues = new ContentValues(4);
+        accountContentValues.put(COLUMN_ACCOUNTS_PUBLIC_KEY_RAW, publicKey);
+        accountContentValues.put(COLUMN_ACCOUNTS_LABEL, accountLabel);
+        accountContentValues.put(COLUMN_ACCOUNTS_ICON, accountIcon != null ? accountIcon.toString() : null);
+        accountContentValues.put(COLUMN_ACCOUNTS_CHAINS, chains != null ? serialize(chains) : null);
+        accountContentValues.put(COLUMN_ACCOUNTS_FEATURES, features != null ? serialize(features) : null);
+        return super.insert(TABLE_ACCOUNTS, accountContentValues);
+    }
+
+    @Nullable
+    @Override
+    public AccountRecord query(@NonNull byte[] publicKey) {
+        final SQLiteDatabase.CursorFactory accountCursorFactory = (db1, masterQuery, editTable, query) -> {
+            query.bindBlob(1, publicKey);
+            return new SQLiteCursor(masterQuery, editTable, query);
+        };
+        try (final Cursor cursor = super.queryWithFactory(accountCursorFactory,
+                TABLE_ACCOUNTS,
+                ACCOUNTS_COLUMNS,
+                COLUMN_ACCOUNTS_PUBLIC_KEY_RAW + "=?",
+                null)) {
+            if (!cursor.moveToNext()) {
+                return null;
+            }
+            return cursorToEntity(cursor);
+        }
+    }
+
+    @Override
+    public void deleteUnreferencedAccounts() {
+        final SQLiteStatement deleteUnreferencedPublicKeys = super.compileStatement(
+                "DELETE FROM " + TABLE_ACCOUNTS +
+                        " WHERE " + COLUMN_ACCOUNTS_ID + " NOT IN " +
+                        "(SELECT DISTINCT " + AuthorizationsSchema.COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
+                        " FROM " + AuthorizationsSchema.TABLE_AUTHORIZATIONS + ')');
+        deleteUnreferencedPublicKeys.executeUpdateDelete();
+    }
+
+    // using a long alphanumeric divider reduces the chance of an array element matching the divider
+    private static final String ARRAY_DIVIDER = "#a1r2ra5yd2iv1i9der";
+
+    private String serialize(String[] content){ return TextUtils.join(ARRAY_DIVIDER, content); }
+
+    private static String[] deserialize(String content){
+        return content.split(ARRAY_DIVIDER);
+    }
+
+    /*package*/ static AccountRecord buildAccountRecordFromRaw(@IntRange(from = 1) int id,
+                                                               @NonNull byte[] publicKeyRaw,
+                                                               @Nullable String accountLabel,
+                                                               @Nullable String iconStr,
+                                                               @Nullable String chainsStr,
+                                                               @Nullable String featuresStr) {
+        final Uri icon = iconStr != null ? Uri.parse(iconStr) : null;
+        final String[] chains = chainsStr != null ? deserialize(chainsStr) : null;
+        final String[] features = featuresStr != null ? deserialize(featuresStr) : null;
+        return new AccountRecord(id, publicKeyRaw, accountLabel, icon, chains, features);
+    }
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsDaoInterface.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsDaoInterface.java
@@ -1,0 +1,19 @@
+package com.solana.mobilewalletadapter.walletlib.authorization;
+
+import android.net.Uri;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/*package*/ interface AccountRecordsDaoInterface {
+
+    @IntRange(from = -1)
+    long insert(@NonNull byte[] publicKey, @Nullable String accountLabel, @Nullable Uri accountIcon,
+                @Nullable String[] chains, @Nullable String[] features);
+
+    @Nullable
+    AccountRecord query(@NonNull byte[] publicKey);
+
+    void deleteUnreferencedAccounts();
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsSchema.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsSchema.java
@@ -1,0 +1,29 @@
+package com.solana.mobilewalletadapter.walletlib.authorization;
+
+/*package*/ interface AccountRecordsSchema {
+    String TABLE_ACCOUNTS = "accounts";
+    String COLUMN_ACCOUNTS_ID = "id"; // type: long
+    String COLUMN_ACCOUNTS_PUBLIC_KEY_RAW = "public_key_raw"; // type: byte[]
+    String COLUMN_ACCOUNTS_LABEL = "label"; // type: String
+    String COLUMN_ACCOUNTS_ICON = "icon"; // type: String
+    String COLUMN_ACCOUNTS_CHAINS = "chains"; // type: String
+    String COLUMN_ACCOUNTS_FEATURES = "features"; // type: String
+
+    String CREATE_TABLE_ACCOUNTS =
+            "CREATE TABLE " + TABLE_ACCOUNTS + " (" +
+                    COLUMN_ACCOUNTS_ID + " INTEGER NOT NULL PRIMARY KEY," +
+                    COLUMN_ACCOUNTS_PUBLIC_KEY_RAW + " BLOB NOT NULL," +
+                    COLUMN_ACCOUNTS_LABEL + " TEXT," +
+                    COLUMN_ACCOUNTS_ICON + " TEXT," +
+                    COLUMN_ACCOUNTS_CHAINS + " TEXT," +
+                    COLUMN_ACCOUNTS_FEATURES + " TEXT)";
+
+    String[] ACCOUNTS_COLUMNS = new String[]{
+            COLUMN_ACCOUNTS_ID,
+            COLUMN_ACCOUNTS_PUBLIC_KEY_RAW,
+            COLUMN_ACCOUNTS_LABEL,
+            COLUMN_ACCOUNTS_ICON,
+            COLUMN_ACCOUNTS_CHAINS,
+            COLUMN_ACCOUNTS_FEATURES
+    };
+}

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
@@ -64,6 +64,11 @@ import java.util.List;
                     final long accountId = accountRecordsDao.insert(publicKey.publicKeyRaw,
                             publicKey.accountLabel, null, null, null);
 
+                    // the public keys will be sorted by their id, and the new account ID will
+                    // always be >= the existing public key ID so it is safe to update these values
+                    // in place. For publicKey.id p(n) and accountId a(n), p(n) > p(n-1) and
+                    // a(n) >= p(n), therefore a(n) > p(n-1). So the 'WHERE account_id = p(n)'
+                    // condition here will not collide with previously updated entries.
                     db.execSQL("UPDATE " + AuthorizationsSchema.TABLE_AUTHORIZATIONS +
                             " SET " + AuthorizationsSchema.COLUMN_AUTHORIZATIONS_ACCOUNT_ID + " = " + accountId +
                             " WHERE " + AuthorizationsSchema.COLUMN_AUTHORIZATIONS_ACCOUNT_ID + " = " + publicKey.id);

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
@@ -57,7 +57,6 @@ import java.util.List;
             if (!publicKeys.isEmpty()) {
                 AccountRecordsDao accountRecordsDao = new AccountRecordsDao(db);
                 for (PublicKey publicKey : publicKeys) {
-                    Log.d(TAG, "migrating Public Key: " + publicKey.accountLabel + " (" + Base64.encodeToString(publicKey.publicKeyRaw, Base64.NO_WRAP) + ")");
                     accountRecordsDao.insert(publicKey.publicKeyRaw, publicKey.accountLabel,
                             null, null, null);
                 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
@@ -4,17 +4,17 @@
 
 package com.solana.mobilewalletadapter.walletlib.authorization;
 
+import static com.solana.mobilewalletadapter.walletlib.authorization.AuthorizationsSchema.COLUMN_AUTHORIZATIONS_ACCOUNT_ID;
+import static com.solana.mobilewalletadapter.walletlib.authorization.AuthorizationsSchema.COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID;
+import static com.solana.mobilewalletadapter.walletlib.authorization.AuthorizationsSchema.TABLE_AUTHORIZATIONS;
+
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.util.Base64;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import com.solana.mobilewalletadapter.common.util.JsonPack;
-
-import java.util.Arrays;
 import java.util.List;
 
 /*package*/ class AuthDatabase extends SQLiteOpenHelper {
@@ -44,21 +44,27 @@ import java.util.List;
         if (oldVersion < 5) {
             Log.w(TAG, "Old database schema detected; pre-v1.0.0, no DB schema backward compatibility is implemented");
             db.execSQL("DROP TABLE IF EXISTS " + IdentityRecordSchema.TABLE_IDENTITIES);
-            db.execSQL("DROP TABLE IF EXISTS " + AuthorizationsSchema.TABLE_AUTHORIZATIONS);
+            db.execSQL("DROP TABLE IF EXISTS " + TABLE_AUTHORIZATIONS);
             db.execSQL("DROP TABLE IF EXISTS " + PublicKeysSchema.TABLE_PUBLIC_KEYS);
             db.execSQL("DROP TABLE IF EXISTS " + WalletUriBaseSchema.TABLE_WALLET_URI_BASE);
             onCreate(db);
         } else {
             Log.w(TAG, "Old database schema detected; pre-v2.0.0, migrating public keys to account records");
+            db.execSQL(AccountRecordsSchema.CREATE_TABLE_ACCOUNTS);
+            db.execSQL("ALTER TABLE " + TABLE_AUTHORIZATIONS +
+                    " RENAME COLUMN " + COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID + " TO " + COLUMN_AUTHORIZATIONS_ACCOUNT_ID);
+
             final PublicKeysDao publicKeysDao = new PublicKeysDao(db);
             final List<PublicKey> publicKeys = publicKeysDao.getAuthorizedPublicKeys();
-
-            db.execSQL(AccountRecordsSchema.CREATE_TABLE_ACCOUNTS);
             if (!publicKeys.isEmpty()) {
                 AccountRecordsDao accountRecordsDao = new AccountRecordsDao(db);
                 for (PublicKey publicKey : publicKeys) {
-                    accountRecordsDao.insert(publicKey.publicKeyRaw, publicKey.accountLabel,
-                            null, null, null);
+                    final long accountId = accountRecordsDao.insert(publicKey.publicKeyRaw,
+                            publicKey.accountLabel, null, null, null);
+
+                    db.execSQL("UPDATE " + TABLE_AUTHORIZATIONS +
+                            " SET " + COLUMN_AUTHORIZATIONS_ACCOUNT_ID + " = " + accountId +
+                            " WHERE " + COLUMN_AUTHORIZATIONS_ACCOUNT_ID + " = " + publicKey.id);
                 }
             }
 

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthDatabase.java
@@ -7,14 +7,20 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.util.Base64;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.solana.mobilewalletadapter.common.util.JsonPack;
+
+import java.util.Arrays;
+import java.util.List;
+
 /*package*/ class AuthDatabase extends SQLiteOpenHelper {
     private static final String TAG = AuthDatabase.class.getSimpleName();
     private static final String DATABASE_NAME_SUFFIX = "-solana-wallet-lib-auth.db";
-    private static final int DATABASE_SCHEMA_VERSION = 5;
+    private static final int DATABASE_SCHEMA_VERSION = 6;
 
     AuthDatabase(@NonNull Context context, @NonNull AuthIssuerConfig authIssuerConfig) {
         super(context, getDatabaseName(authIssuerConfig), null, DATABASE_SCHEMA_VERSION);
@@ -29,18 +35,36 @@ import androidx.annotation.NonNull;
     public void onCreate(SQLiteDatabase db) {
         db.execSQL(IdentityRecordSchema.CREATE_TABLE_IDENTITIES);
         db.execSQL(AuthorizationsSchema.CREATE_TABLE_AUTHORIZATIONS);
-        db.execSQL(PublicKeysSchema.CREATE_TABLE_PUBLIC_KEYS);
+        db.execSQL(AccountRecordsSchema.CREATE_TABLE_ACCOUNTS);
         db.execSQL(WalletUriBaseSchema.CREATE_TABLE_WALLET_URI_BASE);
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        Log.w(TAG, "Old database schema detected; pre-v1.0.0, no DB schema backward compatibility is implemented");
-        db.execSQL("DROP TABLE IF EXISTS " + IdentityRecordSchema.TABLE_IDENTITIES);
-        db.execSQL("DROP TABLE IF EXISTS " + AuthorizationsSchema.TABLE_AUTHORIZATIONS);
-        db.execSQL("DROP TABLE IF EXISTS " + PublicKeysSchema.TABLE_PUBLIC_KEYS);
-        db.execSQL("DROP TABLE IF EXISTS " + WalletUriBaseSchema.TABLE_WALLET_URI_BASE);
-        onCreate(db);
+        if (oldVersion < 5) {
+            Log.w(TAG, "Old database schema detected; pre-v1.0.0, no DB schema backward compatibility is implemented");
+            db.execSQL("DROP TABLE IF EXISTS " + IdentityRecordSchema.TABLE_IDENTITIES);
+            db.execSQL("DROP TABLE IF EXISTS " + AuthorizationsSchema.TABLE_AUTHORIZATIONS);
+            db.execSQL("DROP TABLE IF EXISTS " + PublicKeysSchema.TABLE_PUBLIC_KEYS);
+            db.execSQL("DROP TABLE IF EXISTS " + WalletUriBaseSchema.TABLE_WALLET_URI_BASE);
+            onCreate(db);
+        } else {
+            Log.w(TAG, "Old database schema detected; pre-v2.0.0, migrating public keys to account records");
+            final PublicKeysDao publicKeysDao = new PublicKeysDao(db);
+            final List<PublicKey> publicKeys = publicKeysDao.getAuthorizedPublicKeys();
+
+            db.execSQL(AccountRecordsSchema.CREATE_TABLE_ACCOUNTS);
+            if (!publicKeys.isEmpty()) {
+                AccountRecordsDao accountRecordsDao = new AccountRecordsDao(db);
+                for (PublicKey publicKey : publicKeys) {
+                    Log.d(TAG, "migrating Public Key: " + publicKey.accountLabel + " (" + Base64.encodeToString(publicKey.publicKeyRaw, Base64.NO_WRAP) + ")");
+                    accountRecordsDao.insert(publicKey.publicKeyRaw, publicKey.accountLabel,
+                            null, null, null);
+                }
+            }
+
+            db.execSQL("DROP TABLE IF EXISTS " + PublicKeysSchema.TABLE_PUBLIC_KEYS);
+        }
     }
 
     @NonNull

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
@@ -10,6 +10,8 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.solana.mobilewalletadapter.walletlib.scenario.AuthorizedAccount;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -26,16 +28,14 @@ public class AuthRecord {
     @IntRange(from = 0)
     public final long expires;
 
-    @Deprecated
     @NonNull
     public final byte[] publicKey;
 
-    @Deprecated
     @Nullable
     public final String accountLabel;
 
     @NonNull
-    public final AccountRecord account;
+    public final AccountRecord accountRecord;
 
     @NonNull
     public final String chain;
@@ -58,36 +58,9 @@ public class AuthRecord {
 
     private boolean mRevoked;
 
-//    /*package*/ AuthRecord(@IntRange(from = 1) int id,
-//                           @NonNull IdentityRecord identity,
-//                           @NonNull byte[] publicKey,
-//                           @Nullable String accountLabel,
-//                           @NonNull String chain,
-//                           @NonNull byte[] scope,
-//                           @Nullable Uri walletUriBase,
-//                           @IntRange(from = 1) int publicKeyId,
-//                           @IntRange(from = 1) int walletUriBaseId,
-//                           @IntRange(from = 0) long issued,
-//                           @IntRange(from = 0) long expires) {
-//        // N.B. This is a package-visibility constructor; these values will all be validated by
-//        // other components within this package.
-//        this.id = id;
-//        this.identity = identity;
-//        this.publicKey = publicKey;
-//        this.accountLabel = accountLabel;
-//        this.chain = chain;
-//        this.cluster = chain;
-//        this.scope = scope;
-//        this.walletUriBase = walletUriBase;
-//        this.publicKeyId = publicKeyId;
-//        this.walletUriBaseId = walletUriBaseId;
-//        this.issued = issued;
-//        this.expires = expires;
-//    }
-
     /*package*/ AuthRecord(@IntRange(from = 1) int id,
                            @NonNull IdentityRecord identity,
-                           @NonNull AccountRecord account,
+                           @NonNull AccountRecord accountRecord,
                            @NonNull String chain,
                            @NonNull byte[] scope,
                            @Nullable Uri walletUriBase,
@@ -99,7 +72,7 @@ public class AuthRecord {
         // other components within this package.
         this.id = id;
         this.identity = identity;
-        this.account = account;
+        this.accountRecord = accountRecord;
         this.chain = chain;
         this.cluster = chain;
         this.scope = scope;
@@ -109,8 +82,13 @@ public class AuthRecord {
         this.issued = issued;
         this.expires = expires;
 
-        this.publicKey = account.publicKeyRaw;
-        this.accountLabel = account.accountLabel;
+        this.publicKey = accountRecord.publicKeyRaw;
+        this.accountLabel = accountRecord.accountLabel;
+    }
+
+    public AuthorizedAccount authorizedAccount() {
+        return new AuthorizedAccount(accountRecord.publicKeyRaw, accountRecord.accountLabel,
+                accountRecord.icon, accountRecord.chains, accountRecord.features);
     }
 
     public boolean isExpired() {

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
@@ -26,16 +26,22 @@ public class AuthRecord {
     @IntRange(from = 0)
     public final long expires;
 
+    @Deprecated
     @NonNull
     public final byte[] publicKey;
 
+    @Deprecated
     @Nullable
     public final String accountLabel;
 
     @NonNull
+    public final AccountRecord account;
+
+    @NonNull
     public final String chain;
 
-    @NonNull @Deprecated
+    @Deprecated
+    @NonNull
     public final String cluster;
 
     @NonNull
@@ -45,21 +51,47 @@ public class AuthRecord {
     public final Uri walletUriBase;
 
     @IntRange(from = 1)
-    /*package*/ final int publicKeyId;
+    /*package*/ final int accountId;
 
     @IntRange(from = 1)
     /*package*/ final int walletUriBaseId;
 
     private boolean mRevoked;
 
+//    /*package*/ AuthRecord(@IntRange(from = 1) int id,
+//                           @NonNull IdentityRecord identity,
+//                           @NonNull byte[] publicKey,
+//                           @Nullable String accountLabel,
+//                           @NonNull String chain,
+//                           @NonNull byte[] scope,
+//                           @Nullable Uri walletUriBase,
+//                           @IntRange(from = 1) int publicKeyId,
+//                           @IntRange(from = 1) int walletUriBaseId,
+//                           @IntRange(from = 0) long issued,
+//                           @IntRange(from = 0) long expires) {
+//        // N.B. This is a package-visibility constructor; these values will all be validated by
+//        // other components within this package.
+//        this.id = id;
+//        this.identity = identity;
+//        this.publicKey = publicKey;
+//        this.accountLabel = accountLabel;
+//        this.chain = chain;
+//        this.cluster = chain;
+//        this.scope = scope;
+//        this.walletUriBase = walletUriBase;
+//        this.publicKeyId = publicKeyId;
+//        this.walletUriBaseId = walletUriBaseId;
+//        this.issued = issued;
+//        this.expires = expires;
+//    }
+
     /*package*/ AuthRecord(@IntRange(from = 1) int id,
                            @NonNull IdentityRecord identity,
-                           @NonNull byte[] publicKey,
-                           @Nullable String accountLabel,
+                           @NonNull AccountRecord account,
                            @NonNull String chain,
                            @NonNull byte[] scope,
                            @Nullable Uri walletUriBase,
-                           @IntRange(from = 1) int publicKeyId,
+                           @IntRange(from = 1) int accountId,
                            @IntRange(from = 1) int walletUriBaseId,
                            @IntRange(from = 0) long issued,
                            @IntRange(from = 0) long expires) {
@@ -67,16 +99,18 @@ public class AuthRecord {
         // other components within this package.
         this.id = id;
         this.identity = identity;
-        this.publicKey = publicKey;
-        this.accountLabel = accountLabel;
+        this.account = account;
         this.chain = chain;
         this.cluster = chain;
         this.scope = scope;
         this.walletUriBase = walletUriBase;
-        this.publicKeyId = publicKeyId;
+        this.accountId = accountId;
         this.walletUriBaseId = walletUriBaseId;
         this.issued = issued;
         this.expires = expires;
+
+        this.publicKey = account.publicKeyRaw;
+        this.accountLabel = account.accountLabel;
     }
 
     public boolean isExpired() {

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepository.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepository.java
@@ -5,6 +5,8 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.solana.mobilewalletadapter.walletlib.scenario.AuthorizedAccount;
+
 import java.util.List;
 
 public interface AuthRepository {
@@ -19,12 +21,22 @@ public interface AuthRepository {
     @NonNull
     String toAuthToken(@NonNull AuthRecord authRecord);
 
+    @Deprecated
     @NonNull
     AuthRecord issue(@NonNull String name,
                      @NonNull Uri uri,
                      @NonNull Uri relativeIconUri,
                      @NonNull byte[] publicKey,
                      @Nullable String accountLabel,
+                     @NonNull String cluster,
+                     @Nullable Uri walletUriBase,
+                     @Nullable byte[] scope);
+
+    @NonNull
+    AuthRecord issue(@NonNull String name,
+                     @NonNull Uri uri,
+                     @NonNull Uri relativeIconUri,
+                     @NonNull AuthorizedAccount account,
                      @NonNull String cluster,
                      @Nullable Uri walletUriBase,
                      @Nullable byte[] scope);

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepositoryImpl.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepositoryImpl.java
@@ -427,7 +427,7 @@ public class AuthRepositoryImpl implements AuthRepository {
         } else {
             final int id = (int) mAuthorizationsDao.insert(authRecord.identity.getId(), now,
                     authRecord.accountId, authRecord.chain, authRecord.walletUriBaseId, authRecord.scope);
-            reissued = new AuthRecord(id, authRecord.identity, authRecord.account,
+            reissued = new AuthRecord(id, authRecord.identity, authRecord.accountRecord,
                     authRecord.chain, authRecord.scope, authRecord.walletUriBase,
                     authRecord.accountId, authRecord.walletUriBaseId, now,
                     now + mAuthIssuerConfig.authorizationValidityMs);

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepositoryImpl.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepositoryImpl.java
@@ -18,6 +18,8 @@ import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.solana.mobilewalletadapter.walletlib.scenario.AuthorizedAccount;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -69,7 +71,9 @@ public class AuthRepositoryImpl implements AuthRepository {
     private IdentityRecordDao mIdentityRecordDao;
     private AuthorizationsDao mAuthorizationsDao;
     private WalletUriBaseDao mWalletUriBaseDao;
+    @Deprecated
     private PublicKeysDao mPublicKeysDao;
+    private AccountRecordsDao mAccountsDao;
 
     public AuthRepositoryImpl(@NonNull Context context, @NonNull AuthIssuerConfig authIssuerConfig) {
         mContext = context;
@@ -105,6 +109,7 @@ public class AuthRepositoryImpl implements AuthRepository {
             mAuthorizationsDao = new AuthorizationsDao(database, mAuthIssuerConfig);
             mWalletUriBaseDao = new WalletUriBaseDao(database);
             mPublicKeysDao = new PublicKeysDao(database);
+            mAccountsDao = new AccountRecordsDao(database);
             mInitialized = true;
         }
     }
@@ -293,6 +298,7 @@ public class AuthRepositoryImpl implements AuthRepository {
         return revoke;
     }
 
+    @Deprecated
     @NonNull
     @Override
     public synchronized AuthRecord issue(@NonNull String name,
@@ -303,6 +309,20 @@ public class AuthRepositoryImpl implements AuthRepository {
                                          @NonNull String cluster,
                                          @Nullable Uri walletUriBase,
                                          @Nullable byte[] scope) {
+        return issue(name, uri, relativeIconUri,
+                new AuthorizedAccount(publicKey, accountLabel, null, null, null),
+                cluster, walletUriBase, scope);
+    }
+
+    @NonNull
+    @Override
+    public AuthRecord issue(@NonNull String name,
+                            @NonNull Uri uri,
+                            @NonNull Uri relativeIconUri,
+                            @NonNull AuthorizedAccount account,
+                            @NonNull String cluster,
+                            @Nullable Uri walletUriBase,
+                            @Nullable byte[] scope) {
         ensureStarted();
 
         if (scope == null) {
@@ -343,15 +363,18 @@ public class AuthRepositoryImpl implements AuthRepository {
         }
 
 
-        // Next, try and look up the public key
-        final PublicKey pk = mPublicKeysDao.query(publicKey);
+        // Next, try and look up the account
+        final AccountRecord accountRecordQueried = mAccountsDao.query(account.publicKey);
 
-        final int publicKeyId;
-        // If no matching public key exists, create one
-        if (pk == null) {
-            publicKeyId = (int) mPublicKeysDao.insert(publicKey, accountLabel);
+        final int accountId;
+        final AccountRecord accountRecord;
+        // If no matching account exists, create one
+        if (accountRecordQueried == null) {
+            accountId = (int) mAccountsDao.insert(account.publicKey, account.accountLabel, account.icon, account.chains, account.features);
+            accountRecord = new AccountRecord(accountId, account.publicKey, account.accountLabel, account.icon, account.chains, account.features);
         } else {
-            publicKeyId = pk.id;
+            accountId = accountRecordQueried.id;
+            accountRecord = accountRecordQueried;
         }
 
         // Next, try and look up the wallet URI base
@@ -367,7 +390,7 @@ public class AuthRepositoryImpl implements AuthRepository {
 
         final long now = System.currentTimeMillis();
 
-        final int id = (int) mAuthorizationsDao.insert(identityRecord.getId(), now, publicKeyId, cluster, walletUriBaseId, scope);
+        final int id = (int) mAuthorizationsDao.insert(identityRecord.getId(), now, accountId, cluster, walletUriBaseId, scope);
 
         // If needed, purge oldest entries for this identity
         final int purgeCount = mAuthorizationsDao.purgeOldestEntries(identityRecord.getId());
@@ -375,12 +398,12 @@ public class AuthRepositoryImpl implements AuthRepository {
             Log.v(TAG, "Purged " + purgeCount + " oldest authorizations for identity: " + identityRecord);
             // Note: we only purge if we exceeded the max outstanding authorizations per identity. We
             // thus know that the identity remains referenced; no need to purge unused identities.
-            deleteUnreferencedPublicKeys();
+            deleteUnreferencedAccounts();
             deleteUnreferencedWalletUriBase();
         }
 
-        return new AuthRecord(id, identityRecord, publicKey, accountLabel, cluster, scope,
-                walletUriBase, publicKeyId, walletUriBaseId, now,
+        return new AuthRecord(id, identityRecord, accountRecord, cluster, scope,
+                walletUriBase, accountId, walletUriBaseId, now,
                 now + mAuthIssuerConfig.authorizationValidityMs);
     }
 
@@ -403,11 +426,11 @@ public class AuthRepositoryImpl implements AuthRepository {
             reissued = authRecord;
         } else {
             final int id = (int) mAuthorizationsDao.insert(authRecord.identity.getId(), now,
-                    authRecord.publicKeyId, authRecord.cluster, authRecord.walletUriBaseId, authRecord.scope);
-            reissued = new AuthRecord(id, authRecord.identity, authRecord.publicKey,
-                    authRecord.accountLabel, authRecord.cluster, authRecord.scope,
-                    authRecord.walletUriBase, authRecord.publicKeyId, authRecord.walletUriBaseId,
-                    now, now + mAuthIssuerConfig.authorizationValidityMs);
+                    authRecord.accountId, authRecord.chain, authRecord.walletUriBaseId, authRecord.scope);
+            reissued = new AuthRecord(id, authRecord.identity, authRecord.account,
+                    authRecord.chain, authRecord.scope, authRecord.walletUriBase,
+                    authRecord.accountId, authRecord.walletUriBaseId, now,
+                    now + mAuthIssuerConfig.authorizationValidityMs);
             Log.d(TAG, "Reissued AuthRecord: " + reissued);
             revoke(authRecord);
             // Note: reissue is net-neutral on the number of authorizations per identity, so there's
@@ -428,7 +451,7 @@ public class AuthRepositoryImpl implements AuthRepository {
 
         // There may now be unreferenced authorization data; if so, delete them
         deleteUnreferencedIdentities();
-        deleteUnreferencedPublicKeys();
+        deleteUnreferencedAccounts();
         deleteUnreferencedWalletUriBase();
 
         return (deleteCount != 0);
@@ -444,7 +467,7 @@ public class AuthRepositoryImpl implements AuthRepository {
         final int deleteCount = mIdentityRecordDao.deleteById(identityRecord.getId());
 
         // There may now be unreferenced authorization data; if so, delete them
-        deleteUnreferencedPublicKeys();
+        deleteUnreferencedAccounts();
         deleteUnreferencedWalletUriBase();
 
         return (deleteCount != 0);
@@ -456,8 +479,8 @@ public class AuthRepositoryImpl implements AuthRepository {
     }
 
     @GuardedBy("this")
-    private void deleteUnreferencedPublicKeys() {
-        mPublicKeysDao.deleteUnreferencedPublicKeys();
+    private void deleteUnreferencedAccounts() {
+        mAccountsDao.deleteUnreferencedAccounts();
     }
 
     @GuardedBy("this")

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsDao.java
@@ -62,7 +62,7 @@ import java.util.List;
         contentValues.put(COLUMN_AUTHORIZATIONS_IDENTITY_ID, id);
         contentValues.put(COLUMN_AUTHORIZATIONS_ISSUED, timeStamp);
         contentValues.put(COLUMN_AUTHORIZATIONS_ACCOUNT_ID, accountId);
-        contentValues.put(COLUMN_AUTHORIZATIONS_CLUSTER, cluster);
+        contentValues.put(COLUMN_AUTHORIZATIONS_CHAIN, cluster);
         contentValues.put(COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID, walletUriBaseId);
         contentValues.put(COLUMN_AUTHORIZATIONS_SCOPE, scope);
         return super.insert(TABLE_AUTHORIZATIONS, contentValues);
@@ -96,7 +96,7 @@ import java.util.List;
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_SCOPE +
-                        ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_CLUSTER +
+                        ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_CHAIN +
                         ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_PUBLIC_KEY_RAW +
                         ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_LABEL +
                         ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_ICON +
@@ -129,7 +129,7 @@ import java.util.List;
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_SCOPE +
-                        ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_CLUSTER +
+                        ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_CHAIN +
                         ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_PUBLIC_KEY_RAW +
                         ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_LABEL +
                         ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_ICON +

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsDaoInterface.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsDaoInterface.java
@@ -13,7 +13,7 @@ import java.util.List;
 /*package*/ interface AuthorizationsDaoInterface {
 
     @IntRange(from = -1)
-    long insert(@IntRange(from = 1) int id, long timeStamp, @IntRange(from = 1) int publicKeyId, @NonNull String cluster, @IntRange(from = 1) int walletUriBaseId, @Nullable byte[] scope);
+    long insert(@IntRange(from = 1) int id, long timeStamp, @IntRange(from = 1) int accountId, @NonNull String cluster, @IntRange(from = 1) int walletUriBaseId, @Nullable byte[] scope);
 
     @IntRange(from = 0)
     int deleteByAuthRecordId(@IntRange(from = 1) int authRecordId);

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsSchema.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsSchema.java
@@ -12,10 +12,12 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
     String COLUMN_AUTHORIZATIONS_ACCOUNT_ID = "account_id"; // type: long
     String COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID = "wallet_uri_base_id"; // type: long
     String COLUMN_AUTHORIZATIONS_SCOPE = "scope"; // type: byte[]
-    String COLUMN_AUTHORIZATIONS_CLUSTER = "cluster"; // type: String
+    String COLUMN_AUTHORIZATIONS_CHAIN = "chain"; // type: String
 
     @Deprecated
     String COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID = "public_key_id"; // type: long
+    @Deprecated
+    String COLUMN_AUTHORIZATIONS_CLUSTER = "cluster"; // type: String
 
     String CREATE_TABLE_AUTHORIZATIONS =
             "CREATE TABLE " + TABLE_AUTHORIZATIONS + " (" +
@@ -25,5 +27,5 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
                     COLUMN_AUTHORIZATIONS_ACCOUNT_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_SCOPE + " BLOB NOT NULL," +
-                    COLUMN_AUTHORIZATIONS_CLUSTER + " TEXT NOT NULL)";
+                    COLUMN_AUTHORIZATIONS_CHAIN + " TEXT NOT NULL)";
 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsSchema.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsSchema.java
@@ -9,10 +9,13 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
     String COLUMN_AUTHORIZATIONS_ID = "id"; // type: int
     String COLUMN_AUTHORIZATIONS_IDENTITY_ID = "identity_id"; // type: long
     String COLUMN_AUTHORIZATIONS_ISSUED = "issued"; // type: long
-    String COLUMN_AUTHORIZATIONS_ACCOUNT_ID = "public_key_id"; // type: long
+    String COLUMN_AUTHORIZATIONS_ACCOUNT_ID = "account_id"; // type: long
     String COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID = "wallet_uri_base_id"; // type: long
     String COLUMN_AUTHORIZATIONS_SCOPE = "scope"; // type: byte[]
     String COLUMN_AUTHORIZATIONS_CLUSTER = "cluster"; // type: String
+
+    @Deprecated
+    String COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID = "public_key_id"; // type: long
 
     String CREATE_TABLE_AUTHORIZATIONS =
             "CREATE TABLE " + TABLE_AUTHORIZATIONS + " (" +

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsSchema.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsSchema.java
@@ -9,7 +9,7 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
     String COLUMN_AUTHORIZATIONS_ID = "id"; // type: int
     String COLUMN_AUTHORIZATIONS_IDENTITY_ID = "identity_id"; // type: long
     String COLUMN_AUTHORIZATIONS_ISSUED = "issued"; // type: long
-    String COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID = "public_key_id"; // type: long
+    String COLUMN_AUTHORIZATIONS_ACCOUNT_ID = "public_key_id"; // type: long
     String COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID = "wallet_uri_base_id"; // type: long
     String COLUMN_AUTHORIZATIONS_SCOPE = "scope"; // type: byte[]
     String COLUMN_AUTHORIZATIONS_CLUSTER = "cluster"; // type: String
@@ -19,7 +19,7 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
                     COLUMN_AUTHORIZATIONS_ID + " INTEGER NOT NULL PRIMARY KEY," +
                     COLUMN_AUTHORIZATIONS_IDENTITY_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_ISSUED + " INTEGER NOT NULL," +
-                    COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID + " INTEGER NOT NULL," +
+                    COLUMN_AUTHORIZATIONS_ACCOUNT_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_SCOPE + " BLOB NOT NULL," +
                     COLUMN_AUTHORIZATIONS_CLUSTER + " TEXT NOT NULL)";

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKey.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKey.java
@@ -8,6 +8,7 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+@Deprecated
 /*package*/ class PublicKey {
     @IntRange(from = 1)
     final int id;
@@ -18,6 +19,7 @@ import androidx.annotation.Nullable;
     @Nullable
     final String accountLabel;
 
+    @Deprecated
     PublicKey(@IntRange(from = 1) int id, @NonNull byte[] publicKeyRaw, @Nullable String accountLabel) {
         this.id = id;
         this.publicKeyRaw = publicKeyRaw;

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysDao.java
@@ -66,7 +66,7 @@ public class PublicKeysDao extends DbContentProvider<PublicKey> implements Publi
         final SQLiteStatement deleteUnreferencedPublicKeys = super.compileStatement(
                 "DELETE FROM " + TABLE_PUBLIC_KEYS +
                         " WHERE " + COLUMN_PUBLIC_KEYS_ID + " NOT IN " +
-                        "(SELECT DISTINCT " + AuthorizationsSchema.COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
+                        "(SELECT DISTINCT " + AuthorizationsSchema.COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID +
                         " FROM " + AuthorizationsSchema.TABLE_AUTHORIZATIONS + ')');
         deleteUnreferencedPublicKeys.executeUpdateDelete();
     }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysDao.java
@@ -14,6 +14,10 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@Deprecated
 public class PublicKeysDao extends DbContentProvider<PublicKey> implements PublicKeysDaoInterface, PublicKeysSchema {
 
     PublicKeysDao(SQLiteDatabase db) {
@@ -62,8 +66,23 @@ public class PublicKeysDao extends DbContentProvider<PublicKey> implements Publi
         final SQLiteStatement deleteUnreferencedPublicKeys = super.compileStatement(
                 "DELETE FROM " + TABLE_PUBLIC_KEYS +
                         " WHERE " + COLUMN_PUBLIC_KEYS_ID + " NOT IN " +
-                        "(SELECT DISTINCT " + AuthorizationsSchema.COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID +
+                        "(SELECT DISTINCT " + AuthorizationsSchema.COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
                         " FROM " + AuthorizationsSchema.TABLE_AUTHORIZATIONS + ')');
         deleteUnreferencedPublicKeys.executeUpdateDelete();
+    }
+
+    @NonNull
+    public List<PublicKey> getAuthorizedPublicKeys() {
+        final ArrayList<PublicKey> publicKeys = new ArrayList<>();
+        try (final Cursor c = super.query(TABLE_PUBLIC_KEYS,
+                PUBLIC_KEYS_COLUMNS,
+                null,
+                null,
+                COLUMN_PUBLIC_KEYS_RAW)) {
+            while (c.moveToNext()) {
+                publicKeys.add(cursorToEntity(c));
+            }
+        }
+        return publicKeys;
     }
 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysDao.java
@@ -72,13 +72,13 @@ public class PublicKeysDao extends DbContentProvider<PublicKey> implements Publi
     }
 
     @NonNull
-    public List<PublicKey> getAuthorizedPublicKeys() {
+    /*package*/ List<PublicKey> getPublicKeys() {
         final ArrayList<PublicKey> publicKeys = new ArrayList<>();
         try (final Cursor c = super.query(TABLE_PUBLIC_KEYS,
                 PUBLIC_KEYS_COLUMNS,
                 null,
                 null,
-                COLUMN_PUBLIC_KEYS_RAW)) {
+                COLUMN_PUBLIC_KEYS_ID)) {
             while (c.moveToNext()) {
                 publicKeys.add(cursorToEntity(c));
             }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysDaoInterface.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysDaoInterface.java
@@ -8,6 +8,7 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+@Deprecated
 /*package*/ interface PublicKeysDaoInterface {
 
     @IntRange(from = -1)

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysSchema.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/PublicKeysSchema.java
@@ -4,6 +4,7 @@
 
 package com.solana.mobilewalletadapter.walletlib.authorization;
 
+@Deprecated
 /*package*/ interface PublicKeysSchema {
 
     String TABLE_PUBLIC_KEYS = "public_keys";

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -234,23 +234,21 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             final JSONObject o = new JSONObject();
             try {
                 o.put(ProtocolContract.RESULT_AUTH_TOKEN, result.authToken);
-                final JSONArray accounts = new JSONArray();
-                for (AuthorizedAccount aa : result.accounts) {
-                    final String publicKeyBase64 = Base64.encodeToString(aa.publicKey, Base64.NO_WRAP);
-                    final JSONObject account = new JSONObject();
-                    account.put(ProtocolContract.RESULT_ACCOUNTS_ADDRESS, publicKeyBase64);
-                    if (aa.displayAddress != null && aa.displayAddressFormat != null) {
-                        account.put(ProtocolContract.RESULT_ACCOUNTS_DISPLAY_ADDRESS, aa.displayAddress);
-                        account.put(ProtocolContract.RESULT_ACCOUNTS_DISPLAY_ADDRESS_FORMAT, aa.displayAddressFormat);
-                    }
-                    if (aa.accountLabel != null) {
-                        account.put(ProtocolContract.RESULT_ACCOUNTS_LABEL, aa.accountLabel);
-                    }
-                    if (aa.icon != null) {
-                        account.put(ProtocolContract.RESULT_ACCOUNTS_ICON, aa.icon);
-                    }
-                    accounts.put(account);
+                final AuthorizedAccount aa = result.account;
+                final String publicKeyBase64 = Base64.encodeToString(aa.publicKey, Base64.NO_WRAP);
+                final JSONObject account = new JSONObject();
+                account.put(ProtocolContract.RESULT_ACCOUNTS_ADDRESS, publicKeyBase64);
+                if (aa.displayAddress != null && aa.displayAddressFormat != null) {
+                    account.put(ProtocolContract.RESULT_ACCOUNTS_DISPLAY_ADDRESS, aa.displayAddress);
+                    account.put(ProtocolContract.RESULT_ACCOUNTS_DISPLAY_ADDRESS_FORMAT, aa.displayAddressFormat);
                 }
+                if (aa.accountLabel != null) {
+                    account.put(ProtocolContract.RESULT_ACCOUNTS_LABEL, aa.accountLabel);
+                }
+                if (aa.icon != null) {
+                    account.put(ProtocolContract.RESULT_ACCOUNTS_ICON, aa.icon);
+                }
+                final JSONArray accounts = new JSONArray().put(account); // TODO(#44): support multiple accounts
                 o.put(ProtocolContract.RESULT_ACCOUNTS, accounts);
                 o.put(ProtocolContract.RESULT_WALLET_URI_BASE, result.walletUriBase); // OK if null
                 if (result.signInResult != null) {
@@ -348,8 +346,10 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
         @Nullable
         public final Uri walletUriBase;
 
-        @NonNull @Size(min = 1)
-        public final AuthorizedAccount[] accounts;
+//        @NonNull @Size(min = 1)
+//        public final AuthorizedAccount[] accounts;
+        @NonNull
+        public final AuthorizedAccount account;
 
         @Nullable
         public final SignInResult signInResult;
@@ -364,20 +364,22 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             this.accountLabel = accountLabel;
             this.walletUriBase = walletUriBase;
             this.signInResult = null;
-            this.accounts = new AuthorizedAccount[] {
-                    new AuthorizedAccount(publicKey, accountLabel, null, null, null) };
+//            this.accounts = new AuthorizedAccount[] {
+//                    new AuthorizedAccount(publicKey, accountLabel, null, null, null) };
+            this.account = new AuthorizedAccount(publicKey, accountLabel, null, null, null);
         }
 
         public AuthorizationResult(@NonNull String authToken,
-                                   @NonNull @Size(min = 1) AuthorizedAccount[] accounts,
+                                   @NonNull @Size(min = 1) AuthorizedAccount account,
                                    @Nullable Uri walletUriBase,
                                    @Nullable SignInResult signInResult) {
             this.authToken = authToken;
             this.walletUriBase = walletUriBase;
-            this.accounts = accounts;
+//            this.accounts = accounts;
+            this.account = account;
             this.signInResult = signInResult;
-            this.publicKey = accounts[0].publicKey;
-            this.accountLabel = accounts[0].accountLabel;
+            this.publicKey = account.publicKey;
+            this.accountLabel = account.accountLabel;
         }
 
         @NonNull
@@ -386,7 +388,8 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             return "AuthorizeResult{" +
                     "authToken=<REDACTED>" +
                     ", walletUriBase=" + walletUriBase +
-                    ", accounts=" + Arrays.toString(accounts) +
+//                    ", accounts=" + Arrays.toString(accounts) +
+                    ", account=" + account +
                     '}';
         }
     }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -346,8 +346,6 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
         @Nullable
         public final Uri walletUriBase;
 
-//        @NonNull @Size(min = 1)
-//        public final AuthorizedAccount[] accounts;
         @NonNull
         public final AuthorizedAccount account;
 
@@ -364,8 +362,6 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             this.accountLabel = accountLabel;
             this.walletUriBase = walletUriBase;
             this.signInResult = null;
-//            this.accounts = new AuthorizedAccount[] {
-//                    new AuthorizedAccount(publicKey, accountLabel, null, null, null) };
             this.account = new AuthorizedAccount(publicKey, accountLabel, null, null, null);
         }
 
@@ -375,7 +371,6 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
                                    @Nullable SignInResult signInResult) {
             this.authToken = authToken;
             this.walletUriBase = walletUriBase;
-//            this.accounts = accounts;
             this.account = account;
             this.signInResult = signInResult;
             this.publicKey = account.publicKey;
@@ -388,7 +383,6 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             return "AuthorizeResult{" +
                     "authToken=<REDACTED>" +
                     ", walletUriBase=" + walletUriBase +
-//                    ", accounts=" + Arrays.toString(accounts) +
                     ", account=" + account +
                     '}';
         }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizeRequest.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizeRequest.java
@@ -117,11 +117,11 @@ public class AuthorizeRequest
         mRequest.complete(new Result(accounts, walletUriBase, scope, null));
     }
 
-    public void completeWithAuthorize(@NonNull AuthorizedAccount[] accounts,
+    public void completeWithAuthorize(@NonNull AuthorizedAccount account, // TODO(#44): support multiple addresses
                                       @Nullable Uri walletUriBase,
                                       @Nullable byte[] scope,
                                       @Nullable SignInResult signInResult) {
-        mRequest.complete(new Result(accounts, walletUriBase, scope, signInResult));
+        mRequest.complete(new Result(new AuthorizedAccount[] { account }, walletUriBase, scope, signInResult));
     }
 
     public void completeWithDecline() {

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalScenario.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalScenario.java
@@ -221,11 +221,9 @@ public abstract class LocalScenario implements Scenario {
                         final String name = request.identityName != null ? request.identityName : "";
                         final Uri uri = request.identityUri != null ? request.identityUri : Uri.EMPTY;
                         final Uri relativeIconUri = request.iconUri != null ? request.iconUri : Uri.EMPTY;
-                        final AuthorizedAccount account = authorize.accounts[0]; // TODO(#44): support multiple addresses
-                        final AuthRecord authRecord = mAuthRepository.issue(
-                                name, uri, relativeIconUri, account.publicKey,
-                                account.accountLabel, chain, authorize.walletUriBase,
-                                authorize.scope);
+                        final AuthRecord authRecord = mAuthRepository.issue(name, uri,
+                                relativeIconUri, authorize.accounts[0], // TODO(#44): support multiple addresses
+                                chain, authorize.walletUriBase, authorize.scope);
                         Log.d(TAG, "Authorize request completed successfully; issued auth: " + authRecord);
                         synchronized (mLock) {
                             mActiveAuthorization = authRecord;
@@ -233,7 +231,7 @@ public abstract class LocalScenario implements Scenario {
 
                         final String authToken = mAuthRepository.toAuthToken(authRecord);
                         request.complete(new MobileWalletAdapterServer.AuthorizationResult(
-                                authToken, authorize.accounts,
+                                authToken, authorize.accounts[0], // TODO(#44): support multiple addresses
                                 authorize.walletUriBase, authorize.signInResult));
                     } else {
                         request.completeExceptionally(new MobileWalletAdapterServer.RequestDeclinedException(

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalScenario.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalScenario.java
@@ -305,8 +305,8 @@ public abstract class LocalScenario implements Scenario {
 
                     mIoHandler.post(() -> request.complete(
                             new MobileWalletAdapterServer.AuthorizationResult(
-                                    authToken, authRecord.publicKey, authRecord.accountLabel,
-                                    authRecord.walletUriBase)));
+                                    authToken, authRecord.authorizedAccount(),
+                                    authRecord.walletUriBase, null)));
                 } catch (ExecutionException e) {
                     final Throwable cause = e.getCause();
                     assert(cause instanceof Exception); // expected to always be an Exception


### PR DESCRIPTION
Updates the `walletlib` `AuthDatabase` to store new authorized account parameters (account icon, chains, features). Updates the database schema version from 5>6 and handles database migration. 

This PR does not address multiple authorized accounts per auth token. those changes got too complex and will come in a future PR. 

Testing database migration:
- clean installed `fakewallet` built from v1.x branch
- initiated several authorizations from `fakedapp` to fill the auth repository 
- upgraded `fakewallet` with build form this branch
- verified that auth records were successfully migrated (using SQLiteDatabaseBrowser)