### PR TITLE
React Native Clientlib MWA 2.0

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/android/build.gradle
+++ b/js/packages/mobile-wallet-adapter-protocol/android/build.gradle
@@ -132,7 +132,7 @@ def kotlin_version = getExtOrDefault('kotlinVersion')
 dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
-  implementation "com.solanamobile:mobile-wallet-adapter-clientlib:1.2.0"
+  implementation "com.solanamobile:mobile-wallet-adapter-clientlib:2.0.0-alpha5"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 }

--- a/js/packages/mobile-wallet-adapter-protocol/android/gradle/wrapper/gradle-wrapper.properties
+++ b/js/packages/mobile-wallet-adapter-protocol/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Nov 21 15:17:20 PST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -132,6 +132,10 @@ export interface SignAndSendTransactionsAPI {
     signAndSendTransactions(params: {
         options?: Readonly<{
             min_context_slot?: number;
+            commitment?: string;
+            skip_preflight?: boolean;
+            max_retries?: number;
+            wait_for_commitment_to_send_next_transaction?: boolean;
         }>;
         payloads: Base64EncodedTransaction[];
     }): Promise<Readonly<{ signatures: Base64EncodedSignature[] }>>;

--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -48,17 +48,36 @@ type Base64EncodedSignedTransaction = string;
 
 export type Base64EncodedTransaction = string;
 
+/**
+ * @deprecated Replaced by the 'chain' parameter, which adds multi-chain capability as per MWA 2.0 spec.
+ */
 export type Cluster = 'devnet' | 'testnet' | 'mainnet-beta';
 
 export type Finality = 'confirmed' | 'finalized' | 'processed';
+
+export type Chain = string;
+
+export type Feature = string;
 
 export type WalletAssociationConfig = Readonly<{
     baseUri?: string;
 }>;
 
 export interface AuthorizeAPI {
+    authorize(params: {
+        chain: Chain;
+        identity: AppIdentity;
+        auth_token?: AuthToken;
+        features?: Feature[];
+        addresses?: Base64EncodedAddress[];
+    }): Promise<AuthorizationResult>;
+
+    /**
+     * @deprecated Replaced by updated authorize() method, which adds MWA 2.0 spec support.
+     */
     authorize(params: { cluster: Cluster; identity: AppIdentity }): Promise<AuthorizationResult>;
 }
+
 export interface CloneAuthorizationAPI {
     cloneAuthorization(params: { auth_token: AuthToken }): Promise<Readonly<{ auth_token: AuthToken }>>;
 }
@@ -80,12 +99,30 @@ export interface GetCapabilitiesAPI {
 export interface ReauthorizeAPI {
     reauthorize(params: { auth_token: AuthToken; identity: AppIdentity }): Promise<AuthorizationResult>;
 }
+
+/**
+ * @deprecated Replaced by signMessagesDetached, which returns the improved MobileWalletAdapterClient.SignMessagesResult type
+ */
 export interface SignMessagesAPI {
     signMessages(params: {
         addresses: Base64EncodedAddress[];
         payloads: Base64EncodedMessage[];
     }): Promise<Readonly<{ signed_payloads: Base64EncodedSignedMessage[] }>>;
 }
+
+export interface SignMessagesDetachedAPI {
+    signMessagesDetached(params: { addresses: Base64EncodedAddress[]; messages: Base64EncodedMessage[] }): Promise<
+        Readonly<{
+            messages: Base64EncodedMessage[];
+            signatures: Base64EncodedSignature[][];
+            addresses: Base64EncodedAddress[][];
+        }>
+    >;
+}
+
+/**
+ * @deprecated signTransactions is deprecated in MWA 2.0, use signAndSendTransactions.
+ */
 export interface SignTransactionsAPI {
     signTransactions(params: {
         payloads: Base64EncodedTransaction[];
@@ -106,6 +143,7 @@ export interface MobileWallet
         DeauthorizeAPI,
         GetCapabilitiesAPI,
         ReauthorizeAPI,
+        SignMessagesDetachedAPI,
         SignMessagesAPI,
         SignTransactionsAPI,
         SignAndSendTransactionsAPI {}


### PR DESCRIPTION
**Description**

This PR aims to update the React Native MWA libraries to MWA 2.0 API. Updating example apps can happen in a separate PR.

Updated libraries:
- `@solana-mobile/mobile-wallet-adapter-protocol`
- `@solana-mobile/mobile-wallet-adapter-protocol-web3js`

### Changes
#### `@solana-mobile/mobile-wallet-adapter-protocol`
- Update `/android/` dependencies in `build.gradle` to use `com.solanamobile:mobile-wallet-adapter-clientlib:2.0.0-alpha5`
- Add deprecation warnings to `signTransactions`, `reauthorize`, and legacy `authorize` API
- Add new MWA 2.0 parameters to `options` in `signAndSendTransactions` API
- `signMessages` deprecation + new `signMessagesDetached` API (**TODO**: revert these changes)

#### `@solana-mobile/mobile-wallet-adapter-protocol-web3js`
- Add deprecation warning to `signTransactions`
- Add new MWA 2.0 parameters to `options` in `signAndSendTransactions` API
- `signMessages` deprecation + new `signMessagesDetached` API (**TODO**: revert these changes)


### Test Plan
To test the PR, I made local changes to the `example-react-native-app` repo and manually ran test cases.

**Setup**
1. Temporarily change the `package.json` of `@solana-mobile/mobile-wallet-adapter-protocol-web3js` to:
```
    "dependencies": {
        "@solana-mobile/mobile-wallet-adapter-protocol": "file:../mobile-wallet-adapter-protocol",
        ....
    }
```
2. In `/mobile-wallet-adapter-protocol/`, run `yarn build` to rebuild exported `lib/`
3. In `/mobile-wallet-adapter-protocol-web3js/`, run `rm -rf node_modules` and `yarn install` to ensure clean install of `mobile-wallet-adapter-protocol`
4. Now you can run `example-react-native-app` with `npx react-native start`


