### PR TITLE
feat: constrain the connection interface of `sendTransaction()` to only that which is required

### DIFF
--- a/js/packages/wallet-adapter-mobile/package.json
+++ b/js/packages/wallet-adapter-mobile/package.json
@@ -42,7 +42,7 @@
     "dependencies": {
         "@react-native-async-storage/async-storage": "^1.17.7",
         "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.0.1",
-        "@solana/wallet-adapter-base": "^0.9.17",
+        "@solana/wallet-adapter-base": "^0.9.24",
         "js-base64": "^3.7.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Related to the soon-to-be-released https://github.com/solana-labs/wallet-adapter/pull/848.