### PR TITLE
fix bug with null statement in siws payload

### DIFF
--- a/android/common/src/main/java/com/solana/mobilewalletadapter/common/signin/SignInWithSolana.java
+++ b/android/common/src/main/java/com/solana/mobilewalletadapter/common/signin/SignInWithSolana.java
@@ -210,9 +210,11 @@ public class SignInWithSolana {
 
             final String suffix = String.join("\n", suffixArray);
 
-            prefix = String.join("\n\n", prefix, statement);
             if (statement != null) {
+                prefix = String.join("\n\n", prefix, statement);
                 prefix += "\n";
+            } else {
+                prefix += "\n\n";
             }
 
             return String.join("\n", prefix, suffix);

--- a/android/common/src/test/java/com/solana/mobilewalletadapter/common/signin/PayloadTest.java
+++ b/android/common/src/test/java/com/solana/mobilewalletadapter/common/signin/PayloadTest.java
@@ -54,6 +54,39 @@ public class PayloadTest {
     }
 
     @Test
+    public void testPayloadPrepareMessageNoStatement() {
+        // given
+        SignInWithSolana.Payload payload = new SignInWithSolana.Payload(
+                "service.org",
+                "43h6BNKzvoV43qBLje5dxn7vhcChZjVEAn8PQLZvMiqj",
+                null,
+                Uri.parse("https://service.org/login"),
+                "1",
+                1,
+                "32832457",
+                "2021-01-11T11:15:23.000Z",
+                null,
+                null,
+                null,
+                null
+        );
+
+        String expectedMessage = "service.org wants you to sign in with your Solana account:" +
+                "\n43h6BNKzvoV43qBLje5dxn7vhcChZjVEAn8PQLZvMiqj" +
+                "\n\n\nURI: https://service.org/login" +
+                "\nVersion: 1" +
+                "\nChain ID: 1" +
+                "\nNonce: 32832457" +
+                "\nIssued At: 2021-01-11T11:15:23.000Z";
+
+        // when
+        String message = payload.prepareMessage();
+
+        // then
+        assertEquals(expectedMessage, message);
+    }
+
+    @Test
     public void testPayloadFromJson() throws JSONException {
         // given
         JSONObject payloadJson = new JSONObject(


### PR DESCRIPTION
fixes a small bug in the SIWS impl where a null `statement` would show up as the text "null" in the sign in message. this change ensures that a null `statement` results in no statement text being added in the output message