### PR TITLE
Update SIWS spec

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -399,7 +399,7 @@ where:
 - `addresses`: (optional) if set, a list of base64 encoded account addresses that the dapp endpoint wishes to be included in the authorized scope. Defaults to `null`. 
 - `features`: (optional) if set, a list of [feature identifiers](#feature-identifiers) that the dapp endpoint intends to use in the session. Defaults to `null`. 
 - `auth_token`: (optional) an opaque string previously returned by a call to [`authorize`](#authorize), or [`clone_authorization`](#clone_authorization). When present, the wallet endpoint should attempt to reauthorize the dapp endpoint silently without prompting the user. 
-- `sign_in_payload`: (optional) a value object containing the payload portion of a [Sign In With Solana message](https://siws.web3auth.io/spec). If present, the wallet endpoint should present the SIWS message to the user and return the resulting signature and signed message, as described below.  
+- `sign_in_payload`: (optional) a value object containing the Sign-In input fields as described by the [Sign In With Solana specification](https://github.com/phantom/sign-in-with-solana?tab=readme-ov-file#sign-in-input-fields). If present, the wallet endpoint should present the SIWS message to the user and return the resulting signature and signed message, as described below.
 - `cluster`: (optional) an alias for `chain`. This parameter is maintained for backwards compatibility with previous versions of the spec, and will be ignored if the `chain` parameter is present. 
 
 ###### Result


### PR DESCRIPTION
Changed out the SIWS spec link and wording a bit. Originally I had based everything on the Web3Auth sign in spec. I have now pivoted to Phantoms spec. This spec is more flexible while still broadly supporting the stricter Web3Auth spec
- [phantom spec](https://github.com/phantom/sign-in-with-solana)
- [web3auth spec](https://siws.web3auth.io/spec)