### PR TITLE
mark @react-native-async-storage/async-storage as optional dependency

### DIFF
--- a/js/packages/wallet-adapter-mobile/package.json
+++ b/js/packages/wallet-adapter-mobile/package.json
@@ -40,11 +40,13 @@
         "@solana/web3.js": "^1.58.0"
     },
     "dependencies": {
-        "@react-native-async-storage/async-storage": "^1.17.7",
         "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.0.1",
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-standard-features": "^1.1.0",
         "js-base64": "^3.7.2"
+    },
+    "optionalDependencies": {
+        "@react-native-async-storage/async-storage": "^1.17.7"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.58.0",


### PR DESCRIPTION
## TL;DR

This PR marks `@react-native-async-storage/async-storage` as optional dependency.

## Why

When following the [setup instructions for solana's wallet adapter for dApps](https://github.com/solana-labs/wallet-adapter/blob/master/APP.md) it suggests to run the following command in order to install all the required packages:

```
npm install --save \
    @solana/wallet-adapter-base \
    @solana/wallet-adapter-react \
    @solana/wallet-adapter-react-ui \
    @solana/wallet-adapter-wallets \
    @solana/web3.js \
    react
```

The problem is that npm after version 7 will always install all peer dependencies which causes `react-native` to be installed and with it roughly 900 more package (🤯 ...). The only workaround right now is to use `--use-legacy-peer-deps` which is really not recommended and will hit webapp project maintainers.

Since users that use this in a react-native app will already have react-native in their `package.json` this should not be a problem and the version restriction will still be in effect.

You can check this by creating a new folder, running `npm init` (with a recent npm version) and the above `npm install ...` command. You will see `react-native` being installed with many more packages. You can then use `npm explain react-native` to see why it is installed. You can also try the install with `--use-legacy-peer-deps` to see the difference.