### PR TITLE
Walletlib: Multi Account Auth Repo

### DIFF
--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecord.java
@@ -6,9 +6,14 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.Arrays;
+
 /* package */ class AccountRecord {
     @IntRange(from = 1)
     final int id;
+
+    @IntRange(from = 1)
+    final int parentId;
 
     @NonNull
     final byte[] publicKeyRaw;
@@ -26,16 +31,27 @@ import androidx.annotation.Nullable;
     final String[] features;
 
     AccountRecord(@IntRange(from = 1) int id,
+                  @IntRange(from = 1) int parentId,
                   @NonNull byte[] publicKeyRaw,
                   @Nullable String accountLabel,
                   @Nullable Uri icon,
                   @Nullable String[] chains,
                   @Nullable String[] features) {
         this.id = id;
+        this.parentId = parentId;
         this.publicKeyRaw = publicKeyRaw;
         this.accountLabel = accountLabel;
         this.icon = icon;
         this.chains = chains;
         this.features = features;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "AccountRecord{" +
+                "label=" + accountLabel +
+                ", publicKey=" + Arrays.toString(publicKeyRaw) +
+                '}';
     }
 }

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsDaoInterface.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsDaoInterface.java
@@ -6,11 +6,17 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.List;
+
 /*package*/ interface AccountRecordsDaoInterface {
 
     @IntRange(from = -1)
-    long insert(@NonNull byte[] publicKey, @Nullable String accountLabel, @Nullable Uri accountIcon,
+    long insert(@NonNull long parentId, @NonNull byte[] publicKey,
+                @Nullable String accountLabel, @Nullable Uri accountIcon,
                 @Nullable String[] chains, @Nullable String[] features);
+
+//    @Nullable
+//    List<AccountRecord> query(int parentId);
 
     @Nullable
     AccountRecord query(@NonNull byte[] publicKey);

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsSchema.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AccountRecordsSchema.java
@@ -3,6 +3,7 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
 /*package*/ interface AccountRecordsSchema {
     String TABLE_ACCOUNTS = "accounts";
     String COLUMN_ACCOUNTS_ID = "id"; // type: long
+    String COLUMN_ACCOUNTS_PARENT_ID = "parent_id"; // type: long
     String COLUMN_ACCOUNTS_PUBLIC_KEY_RAW = "public_key_raw"; // type: byte[]
     String COLUMN_ACCOUNTS_LABEL = "label"; // type: String
     String COLUMN_ACCOUNTS_ICON = "icon"; // type: String
@@ -12,6 +13,7 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
     String CREATE_TABLE_ACCOUNTS =
             "CREATE TABLE " + TABLE_ACCOUNTS + " (" +
                     COLUMN_ACCOUNTS_ID + " INTEGER NOT NULL PRIMARY KEY," +
+                    COLUMN_ACCOUNTS_PARENT_ID + " INTEGER NOT NULL," +
                     COLUMN_ACCOUNTS_PUBLIC_KEY_RAW + " BLOB NOT NULL," +
                     COLUMN_ACCOUNTS_LABEL + " TEXT," +
                     COLUMN_ACCOUNTS_ICON + " TEXT," +
@@ -20,6 +22,7 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
 
     String[] ACCOUNTS_COLUMNS = new String[]{
             COLUMN_ACCOUNTS_ID,
+            COLUMN_ACCOUNTS_PARENT_ID,
             COLUMN_ACCOUNTS_PUBLIC_KEY_RAW,
             COLUMN_ACCOUNTS_LABEL,
             COLUMN_ACCOUNTS_ICON,

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRecord.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.Size;
 
 import com.solana.mobilewalletadapter.walletlib.scenario.AuthorizedAccount;
 
@@ -28,14 +29,20 @@ public class AuthRecord {
     @IntRange(from = 0)
     public final long expires;
 
+    @Deprecated
     @NonNull
     public final byte[] publicKey;
 
+    @Deprecated
     @Nullable
     public final String accountLabel;
 
+    @Deprecated
     @NonNull
     public final AccountRecord accountRecord;
+
+    @Size(min = 1)
+    public final AccountRecord[] accounts;
 
     @NonNull
     public final String chain;
@@ -50,6 +57,7 @@ public class AuthRecord {
     @Nullable
     public final Uri walletUriBase;
 
+    @Deprecated
     @IntRange(from = 1)
     /*package*/ final int accountId;
 
@@ -60,11 +68,10 @@ public class AuthRecord {
 
     /*package*/ AuthRecord(@IntRange(from = 1) int id,
                            @NonNull IdentityRecord identity,
-                           @NonNull AccountRecord accountRecord,
+                           @NonNull AccountRecord[] accounts,
                            @NonNull String chain,
                            @NonNull byte[] scope,
                            @Nullable Uri walletUriBase,
-                           @IntRange(from = 1) int accountId,
                            @IntRange(from = 1) int walletUriBaseId,
                            @IntRange(from = 0) long issued,
                            @IntRange(from = 0) long expires) {
@@ -72,20 +79,36 @@ public class AuthRecord {
         // other components within this package.
         this.id = id;
         this.identity = identity;
-        this.accountRecord = accountRecord;
+        this.accounts = accounts;
         this.chain = chain;
         this.cluster = chain;
         this.scope = scope;
         this.walletUriBase = walletUriBase;
-        this.accountId = accountId;
         this.walletUriBaseId = walletUriBaseId;
         this.issued = issued;
         this.expires = expires;
 
+        this.accountRecord = accounts[0];
         this.publicKey = accountRecord.publicKeyRaw;
         this.accountLabel = accountRecord.accountLabel;
+        this.accountId = accountRecord.id;
     }
 
+    @Size(min = 1)
+    public AuthorizedAccount[] getAuthorizedAccounts() {
+        AuthorizedAccount[] authorizedAccounts = new AuthorizedAccount[accounts.length];
+        for (int i = 0; i < accounts.length; i++) {
+            AccountRecord accountRecord = accounts[i];
+            authorizedAccounts[i] = new AuthorizedAccount(
+                    accountRecord.publicKeyRaw, accountRecord.accountLabel,
+                    accountRecord.icon, accountRecord.chains, accountRecord.features
+            );
+        }
+        return authorizedAccounts;
+    }
+
+    @Deprecated
+    @NonNull
     public AuthorizedAccount authorizedAccount() {
         return new AuthorizedAccount(accountRecord.publicKeyRaw, accountRecord.accountLabel,
                 accountRecord.icon, accountRecord.chains, accountRecord.features);
@@ -127,7 +150,7 @@ public class AuthRecord {
         return "AuthRecord{" +
                 "id=" + id +
                 ", identity=" + identity +
-                ", publicKey=" + Arrays.toString(publicKey) +
+                ", accounts=" + Arrays.toString(accounts) +
                 ", chain='" + chain + '\'' +
                 ", scope=" + Arrays.toString(scope) +
                 ", walletUriBase='" + walletUriBase + '\'' +

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepository.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthRepository.java
@@ -32,11 +32,21 @@ public interface AuthRepository {
                      @Nullable Uri walletUriBase,
                      @Nullable byte[] scope);
 
+    @Deprecated
     @NonNull
     AuthRecord issue(@NonNull String name,
                      @NonNull Uri uri,
                      @NonNull Uri relativeIconUri,
                      @NonNull AuthorizedAccount account,
+                     @NonNull String cluster,
+                     @Nullable Uri walletUriBase,
+                     @Nullable byte[] scope);
+
+    @NonNull
+    AuthRecord issue(@NonNull String name,
+                     @NonNull Uri uri,
+                     @NonNull Uri relativeIconUri,
+                     @NonNull AuthorizedAccount[] accounts,
                      @NonNull String cluster,
                      @Nullable Uri walletUriBase,
                      @Nullable byte[] scope);

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsDao.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsDao.java
@@ -39,33 +39,33 @@ import java.util.List;
     private AuthRecord cursorToEntity(@NonNull Cursor cursor, @NonNull IdentityRecord identityRecord) {
         final int id = cursor.getInt(0);
         final long issued = cursor.getLong(1);
-        final int accountId = cursor.getInt(2);
-        final int walletUriBaseId = cursor.getInt(3);
-        final byte[] scope = cursor.getBlob(4);
-        final String cluster = cursor.getString(5);
-        final byte[] publicKey = cursor.getBlob(6);
-        final String accountLabel = cursor.isNull(7) ? null : cursor.getString(7);
-        final String accountIconStr = cursor.isNull(8) ? null : cursor.getString(8);
-        final String chainsStr = cursor.isNull(9) ? null : cursor.getString(9);
-        final String featuresStr = cursor.isNull(10) ? null : cursor.getString(10);
-        final Uri walletUriBase = cursor.isNull(11) ? null : Uri.parse(cursor.getString(11));
-        final AccountRecord account = AccountRecordsDao.buildAccountRecordFromRaw(accountId,
-                publicKey, accountLabel, accountIconStr, chainsStr, featuresStr);
-        return new AuthRecord(id, identityRecord, account, cluster, scope, walletUriBase, accountId,
+        final int walletUriBaseId = cursor.getInt(2);
+        final byte[] scope = cursor.getBlob(3);
+        final String cluster = cursor.getString(4);
+        final Uri walletUriBase = cursor.isNull(5) ? null : Uri.parse(cursor.getString(5));
+        // look up accounts for this auth record
+        final AccountRecord[] accounts = getAccounts(id).toArray(new AccountRecord[0]);
+        return new AuthRecord(id, identityRecord, accounts, cluster, scope, walletUriBase,
                 walletUriBaseId, issued, issued + authIssuerConfig.authorizationValidityMs);
     }
 
     @IntRange(from = -1)
     @Override
-    public long insert(@IntRange(from = 1) int id, long timeStamp, @IntRange(from = 1) int accountId, @NonNull String cluster, @IntRange(from = 1) int walletUriBaseId, @Nullable byte[] scope) {
-        final ContentValues contentValues = new ContentValues(6);
+    public long insert(@IntRange(from = 1) int id, long timeStamp, @NonNull String cluster, @IntRange(from = 1) int walletUriBaseId, @Nullable byte[] scope) {
+        final ContentValues contentValues = new ContentValues(5);
         contentValues.put(COLUMN_AUTHORIZATIONS_IDENTITY_ID, id);
         contentValues.put(COLUMN_AUTHORIZATIONS_ISSUED, timeStamp);
-        contentValues.put(COLUMN_AUTHORIZATIONS_ACCOUNT_ID, accountId);
         contentValues.put(COLUMN_AUTHORIZATIONS_CHAIN, cluster);
         contentValues.put(COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID, walletUriBaseId);
         contentValues.put(COLUMN_AUTHORIZATIONS_SCOPE, scope);
         return super.insert(TABLE_AUTHORIZATIONS, contentValues);
+    }
+
+    @Deprecated
+    @IntRange(from = -1)
+    @Override
+    public long insert(@IntRange(from = 1) int id, long timeStamp, @IntRange(from = 1) int accountId, @NonNull String cluster, @IntRange(from = 1) int walletUriBaseId, @Nullable byte[] scope) {
+        return insert(id, timeStamp, cluster, walletUriBaseId, scope);
     }
 
     @IntRange(from = 0)
@@ -88,25 +88,31 @@ import java.util.List;
     }
 
     @NonNull
+    private List<AccountRecord> getAccounts(int parentId) {
+        final List<AccountRecord> accounts = new ArrayList<>();
+        try (final Cursor c = super.query(TABLE_ACCOUNTS,
+                ACCOUNTS_COLUMNS,
+                COLUMN_ACCOUNTS_PARENT_ID + "=" + parentId,
+                null,
+                COLUMN_ACCOUNTS_ID)) {
+            while (c.moveToNext()) {
+                accounts.add(AccountRecordsDao.buildAccountRecordFromCursor(c));
+            }
+        }
+        return accounts;
+    }
+
+    @NonNull
     public synchronized List<AuthRecord> getAuthorizations(@NonNull IdentityRecord identityRecord) {
         final ArrayList<AuthRecord> authorizations = new ArrayList<>();
         try (final Cursor cursor = super.rawQuery("SELECT " +
                         TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ISSUED +
-                        ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_SCOPE +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_CHAIN +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_PUBLIC_KEY_RAW +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_LABEL +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_ICON +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_CHAINS +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_FEATURES +
                         ", " + TABLE_WALLET_URI_BASE + '.' + COLUMN_WALLET_URI_BASE_URI +
                         " FROM " + TABLE_AUTHORIZATIONS +
-                        " INNER JOIN " + TABLE_ACCOUNTS +
-                        " ON " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
-                        " = " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_ID +
                         " INNER JOIN " + TABLE_WALLET_URI_BASE +
                         " ON " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID +
                         " = " + TABLE_WALLET_URI_BASE + '.' + COLUMN_WALLET_URI_BASE_ID +
@@ -126,20 +132,11 @@ import java.util.List;
         try (final Cursor cursor = super.rawQuery("SELECT " +
                         TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ISSUED +
-                        ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_SCOPE +
                         ", " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_CHAIN +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_PUBLIC_KEY_RAW +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_LABEL +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_ICON +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_CHAINS +
-                        ", " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_FEATURES +
                         ", " + TABLE_WALLET_URI_BASE + '.' + COLUMN_WALLET_URI_BASE_URI +
                         " FROM " + TABLE_AUTHORIZATIONS +
-                        " INNER JOIN " + TABLE_ACCOUNTS +
-                        " ON " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_ACCOUNT_ID +
-                        " = " + TABLE_ACCOUNTS + '.' + COLUMN_ACCOUNTS_ID +
                         " INNER JOIN " + TABLE_WALLET_URI_BASE +
                         " ON " + TABLE_AUTHORIZATIONS + '.' + COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID +
                         " = " + TABLE_WALLET_URI_BASE + '.' + COLUMN_WALLET_URI_BASE_ID +

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsDaoInterface.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsDaoInterface.java
@@ -13,6 +13,10 @@ import java.util.List;
 /*package*/ interface AuthorizationsDaoInterface {
 
     @IntRange(from = -1)
+    long insert(@IntRange(from = 1) int id, long timeStamp, @NonNull String cluster, @IntRange(from = 1) int walletUriBaseId, @Nullable byte[] scope);
+
+    @Deprecated
+    @IntRange(from = -1)
     long insert(@IntRange(from = 1) int id, long timeStamp, @IntRange(from = 1) int accountId, @NonNull String cluster, @IntRange(from = 1) int walletUriBaseId, @Nullable byte[] scope);
 
     @IntRange(from = 0)

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsSchema.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/AuthorizationsSchema.java
@@ -9,7 +9,6 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
     String COLUMN_AUTHORIZATIONS_ID = "id"; // type: int
     String COLUMN_AUTHORIZATIONS_IDENTITY_ID = "identity_id"; // type: long
     String COLUMN_AUTHORIZATIONS_ISSUED = "issued"; // type: long
-    String COLUMN_AUTHORIZATIONS_ACCOUNT_ID = "account_id"; // type: long
     String COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID = "wallet_uri_base_id"; // type: long
     String COLUMN_AUTHORIZATIONS_SCOPE = "scope"; // type: byte[]
     String COLUMN_AUTHORIZATIONS_CHAIN = "chain"; // type: String
@@ -18,13 +17,14 @@ package com.solana.mobilewalletadapter.walletlib.authorization;
     String COLUMN_AUTHORIZATIONS_PUBLIC_KEY_ID = "public_key_id"; // type: long
     @Deprecated
     String COLUMN_AUTHORIZATIONS_CLUSTER = "cluster"; // type: String
+    @Deprecated
+    String COLUMN_AUTHORIZATIONS_ACCOUNT_ID = "account_id"; // type: long
 
     String CREATE_TABLE_AUTHORIZATIONS =
             "CREATE TABLE " + TABLE_AUTHORIZATIONS + " (" +
                     COLUMN_AUTHORIZATIONS_ID + " INTEGER NOT NULL PRIMARY KEY," +
                     COLUMN_AUTHORIZATIONS_IDENTITY_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_ISSUED + " INTEGER NOT NULL," +
-                    COLUMN_AUTHORIZATIONS_ACCOUNT_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_WALLET_URI_BASE_ID + " INTEGER NOT NULL," +
                     COLUMN_AUTHORIZATIONS_SCOPE + " BLOB NOT NULL," +
                     COLUMN_AUTHORIZATIONS_CHAIN + " TEXT NOT NULL)";

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/DbContentProvider.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/authorization/DbContentProvider.java
@@ -82,8 +82,7 @@ import androidx.annotation.Nullable;
     @IntRange(from = 0)
     protected int update(@NonNull String tableName, @Nullable ContentValues values,
                          @Nullable String selection, @Nullable String[] selectionArgs) {
-        return mDb.update(tableName, values, selection,
-                selectionArgs);
+        return mDb.update(tableName, values, selection, selectionArgs);
     }
 
     @NonNull

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/protocol/MobileWalletAdapterServer.java
@@ -237,21 +237,23 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
             final JSONObject o = new JSONObject();
             try {
                 o.put(ProtocolContract.RESULT_AUTH_TOKEN, result.authToken);
-                final AuthorizedAccount aa = result.account;
-                final String publicKeyBase64 = Base64.encodeToString(aa.publicKey, Base64.NO_WRAP);
-                final JSONObject account = new JSONObject();
-                account.put(ProtocolContract.RESULT_ACCOUNTS_ADDRESS, publicKeyBase64);
-                if (aa.displayAddress != null && aa.displayAddressFormat != null) {
-                    account.put(ProtocolContract.RESULT_ACCOUNTS_DISPLAY_ADDRESS, aa.displayAddress);
-                    account.put(ProtocolContract.RESULT_ACCOUNTS_DISPLAY_ADDRESS_FORMAT, aa.displayAddressFormat);
+                final JSONArray accounts = new JSONArray();
+                for (AuthorizedAccount aa : result.accounts) {
+                    final String publicKeyBase64 = Base64.encodeToString(aa.publicKey, Base64.NO_WRAP);
+                    final JSONObject account = new JSONObject();
+                    account.put(ProtocolContract.RESULT_ACCOUNTS_ADDRESS, publicKeyBase64);
+                    if (aa.displayAddress != null && aa.displayAddressFormat != null) {
+                        account.put(ProtocolContract.RESULT_ACCOUNTS_DISPLAY_ADDRESS, aa.displayAddress);
+                        account.put(ProtocolContract.RESULT_ACCOUNTS_DISPLAY_ADDRESS_FORMAT, aa.displayAddressFormat);
+                    }
+                    if (aa.accountLabel != null) {
+                        account.put(ProtocolContract.RESULT_ACCOUNTS_LABEL, aa.accountLabel);
+                    }
+                    if (aa.icon != null) {
+                        account.put(ProtocolContract.RESULT_ACCOUNTS_ICON, aa.icon);
+                    }
+                    accounts.put(account);
                 }
-                if (aa.accountLabel != null) {
-                    account.put(ProtocolContract.RESULT_ACCOUNTS_LABEL, aa.accountLabel);
-                }
-                if (aa.icon != null) {
-                    account.put(ProtocolContract.RESULT_ACCOUNTS_ICON, aa.icon);
-                }
-                final JSONArray accounts = new JSONArray().put(account); // TODO(#44): support multiple accounts
                 o.put(ProtocolContract.RESULT_ACCOUNTS, accounts);
                 o.put(ProtocolContract.RESULT_WALLET_URI_BASE, result.walletUriBase); // OK if null
                 if (result.signInResult != null) {
@@ -349,8 +351,12 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
         @Nullable
         public final Uri walletUriBase;
 
+        @Deprecated
         @NonNull
         public final AuthorizedAccount account;
+
+        @Size(min = 1)
+        public final AuthorizedAccount[] accounts;
 
         @Nullable
         public final SignInResult signInResult;
@@ -360,21 +366,26 @@ public class MobileWalletAdapterServer extends JsonRpc20Server {
                                    @NonNull byte[] publicKey,
                                    @Nullable String accountLabel,
                                    @Nullable Uri walletUriBase) {
-            this.authToken = authToken;
-            this.publicKey = publicKey;
-            this.accountLabel = accountLabel;
-            this.walletUriBase = walletUriBase;
-            this.signInResult = null;
-            this.account = new AuthorizedAccount(publicKey, accountLabel, null, null, null);
+            this(authToken, new AuthorizedAccount(publicKey, accountLabel, null, null,
+                    null), walletUriBase, null);
+        }
+
+        @Deprecated
+        public AuthorizationResult(@NonNull String authToken,
+                                   @NonNull AuthorizedAccount account,
+                                   @Nullable Uri walletUriBase,
+                                   @Nullable SignInResult signInResult) {
+            this(authToken, new AuthorizedAccount[] { account }, walletUriBase, signInResult);
         }
 
         public AuthorizationResult(@NonNull String authToken,
-                                   @NonNull @Size(min = 1) AuthorizedAccount account,
+                                   @NonNull @Size(min = 1) AuthorizedAccount[] accounts,
                                    @Nullable Uri walletUriBase,
                                    @Nullable SignInResult signInResult) {
             this.authToken = authToken;
             this.walletUriBase = walletUriBase;
-            this.account = account;
+            this.accounts = accounts;
+            this.account = accounts[0];
             this.signInResult = signInResult;
             this.publicKey = account.publicKey;
             this.accountLabel = account.accountLabel;

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizeRequest.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/AuthorizeRequest.java
@@ -117,11 +117,19 @@ public class AuthorizeRequest
         mRequest.complete(new Result(accounts, walletUriBase, scope, null));
     }
 
-    public void completeWithAuthorize(@NonNull AuthorizedAccount account, // TODO(#44): support multiple addresses
+    @Deprecated
+    public void completeWithAuthorize(@NonNull AuthorizedAccount account,
                                       @Nullable Uri walletUriBase,
                                       @Nullable byte[] scope,
                                       @Nullable SignInResult signInResult) {
         mRequest.complete(new Result(new AuthorizedAccount[] { account }, walletUriBase, scope, signInResult));
+    }
+
+    public void completeWithAuthorize(@NonNull AuthorizedAccount[] accounts,
+                                      @Nullable Uri walletUriBase,
+                                      @Nullable byte[] scope,
+                                      @Nullable SignInResult signInResult) {
+        mRequest.complete(new Result(accounts, walletUriBase, scope, signInResult));
     }
 
     public void completeWithDecline() {

--- a/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalScenario.java
+++ b/android/walletlib/src/main/java/com/solana/mobilewalletadapter/walletlib/scenario/LocalScenario.java
@@ -221,18 +221,16 @@ public abstract class LocalScenario implements Scenario {
                         final String name = request.identityName != null ? request.identityName : "";
                         final Uri uri = request.identityUri != null ? request.identityUri : Uri.EMPTY;
                         final Uri relativeIconUri = request.iconUri != null ? request.iconUri : Uri.EMPTY;
-                        final AuthRecord authRecord = mAuthRepository.issue(name, uri,
-                                relativeIconUri, authorize.accounts[0], // TODO(#44): support multiple addresses
-                                chain, authorize.walletUriBase, authorize.scope);
+                        final AuthRecord authRecord = mAuthRepository.issue(name, uri, relativeIconUri,
+                                authorize.accounts,chain, authorize.walletUriBase, authorize.scope);
                         Log.d(TAG, "Authorize request completed successfully; issued auth: " + authRecord);
                         synchronized (mLock) {
                             mActiveAuthorization = authRecord;
                         }
 
                         final String authToken = mAuthRepository.toAuthToken(authRecord);
-                        request.complete(new MobileWalletAdapterServer.AuthorizationResult(
-                                authToken, authorize.accounts[0], // TODO(#44): support multiple addresses
-                                authorize.walletUriBase, authorize.signInResult));
+                        request.complete(new MobileWalletAdapterServer.AuthorizationResult(authToken,
+                                authorize.accounts, authorize.walletUriBase, authorize.signInResult));
                     } else {
                         request.completeExceptionally(new MobileWalletAdapterServer.RequestDeclinedException(
                                 "authorize request declined"));


### PR DESCRIPTION
This PR addresses what should be the final refactor update to support multi-account through the entire MWA SDK stack. (#44 & #438)

The walletlib sdk authentication repository has been updated to support multiple authorized accounts (publickeys) per AuthRecord. The rest of the SDK stack was previously updated to support a list of accounts for each auth request. 

Note: sample apps still need to be updated to demonstrate the use of multiple accounts in a session 