### PR TITLE
Declare types in package.json exports

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -19,7 +19,8 @@
         "./package.json": "./package.json",
         ".": {
             "import": "./lib/esm/index.js",
-            "require": "./lib/cjs/index.js"
+            "require": "./lib/cjs/index.js",
+            "types": "./lib/types/index.d.ts"
         }
     },
     "files": [

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -20,7 +20,7 @@
         ".": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js",
-            "types": "./lib/types/indes.d.ts"
+            "types": "./lib/types/index.d.ts"
         }
     },
     "files": [

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -19,7 +19,8 @@
         "./package.json": "./package.json",
         ".": {
             "import": "./lib/esm/index.js",
-            "require": "./lib/cjs/index.js"
+            "require": "./lib/cjs/index.js",
+            "types": "./lib/types/indes.d.ts"
         }
     },
     "files": [

--- a/js/packages/wallet-adapter-mobile/package.json
+++ b/js/packages/wallet-adapter-mobile/package.json
@@ -19,7 +19,8 @@
         "./package.json": "./package.json",
         ".": {
             "import": "./lib/esm/index.js",
-            "require": "./lib/cjs/index.js"
+            "require": "./lib/cjs/index.js",
+            "types": "./lib/types/index.d.ts"
         }
     },
     "files": [


### PR DESCRIPTION
When installing `@solana-mobile/wallet-adapter-mobile` as dependency for a solidjs project, I got this error:

> Could not find a declaration file for module '@solana-mobile/wallet-adapter-mobile'. '/home/nedrise/Work/Personal/solid-solana-wallet-adapter/node_modules/@solana-mobile/wallet-adapter-mobile/lib/esm/index.js' implicitly has an 'any' type.
  There are types at '/home/nedrise/Work/Personal/solid-solana-wallet-adapter/node_modules/@solana-mobile/wallet-adapter-mobile/lib/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@solana-mobile/wallet-adapter-mobile' library may need to update its package.json or typings.ts(7016)

When using locally linked version with the suggested changes, this error went away.