### PR TITLE
fix: package type export

### DIFF
--- a/js/packages/wallet-adapter-mobile/package.json
+++ b/js/packages/wallet-adapter-mobile/package.json
@@ -19,7 +19,8 @@
         "./package.json": "./package.json",
         ".": {
             "import": "./lib/esm/index.js",
-            "require": "./lib/cjs/index.js"
+            "require": "./lib/cjs/index.js",
+            "types": "./lib/types/index.d.ts"
         }
     },
     "files": [


### PR DESCRIPTION
Types need to be exported to be compatible with TypeScript's `"moduleResolution": "bundler"` compiler option.

https://publint.dev/@solana-mobile/wallet-adapter-mobile@2.1.3

If you use the adapter in a project with module resolution bundler, the types will not be resolved.