### PR TITLE
Walletlib React Native v1.3.0

### DIFF
--- a/examples/example-react-native-wallet/package.json
+++ b/examples/example-react-native-wallet/package.json
@@ -49,5 +49,6 @@
   },
   "jest": {
     "preset": "react-native"
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -13,6 +13,7 @@
     "types": "lib/types/index.d.ts",
     "files": [
         "lib",
+        "android",
         "LICENSE"
     ],
     "publishConfig": {

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-walletlib",
     "description": "A React Native wrapper of the Solana Mobile, Mobile Wallet Adapter Wallet Library. Wallet apps can use this to handle dapp requests for signing and sending.",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "author": "Michael Sulistio <mike.sulistio@solanamobile.com>",
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-walletlib",
     "description": "A React Native wrapper of the Solana Mobile, Mobile Wallet Adapter Wallet Library. Wallet apps can use this to handle dapp requests for signing and sending.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "author": "Michael Sulistio <mike.sulistio@solanamobile.com>",
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",


### PR DESCRIPTION
# Walletlib RN Changes

## useMobileWalletAdapterSession 
The change here is motivated by the problematic default `Linking.getInitialUrl` for getting hte `associationUri`. `Linking.getInitialUrl` can be `null` in certain cases, like with Expo Router, and it's faulty to expect that it will always be populated correctly.

- Removed default `associcationUri` using `Linking.getInitialUrl` due to Expo Router incompatibility
- Added an `associationUri` parameter to `useMobileWalletAdapterSession` **(breaking)**

## New API methods
The goal is to expose the API outside of a React hook. This gives users the option to create their own hook to manage a session, decouple event listening and session initialization, and overall flexibility.

- Added an `initializeMWAEventListener` method that starts and returns a bridged listener for MWA events.
- Added an `initializeMobileWalletAdapterSession` method that starts an MWA scenario for the given `associationUri`.