### PR TITLE
Walletlib RN 1.4.0-beta1

### DIFF
--- a/examples/example-react-native-wallet/screens/MobileWalletAdapterEntrypointBottomSheet.tsx
+++ b/examples/example-react-native-wallet/screens/MobileWalletAdapterEntrypointBottomSheet.tsx
@@ -111,11 +111,14 @@ export default function MobileWalletAdapterEntrypointBottomSheet() {
   //  2. Starting the MWA session
   useEffect(() => {
     async function initializeMWASession() {
-      const associationUri = await Linking.getInitialURL();
-      if (associationUri) {
-        initializeMobileWalletAdapterSession('wallet label', config);
-      } else {
-        console.error('Error retrieving associationUri');
+      try {
+        const sessionId = await initializeMobileWalletAdapterSession(
+          'wallet label',
+          config,
+        );
+        console.log('sessionId: ' + sessionId);
+      } catch (e) {
+        console.error(e);
       }
     }
     const listener = initializeMWAEventListener(

--- a/examples/example-react-native-wallet/screens/MobileWalletAdapterEntrypointBottomSheet.tsx
+++ b/examples/example-react-native-wallet/screens/MobileWalletAdapterEntrypointBottomSheet.tsx
@@ -14,7 +14,6 @@ import {
   SignMessagesRequest,
   SignTransactionsRequest,
   SignAndSendTransactionsRequest,
-  useMobileWalletAdapterSession,
   MWARequestType,
   MWARequest,
   MWASessionEvent,
@@ -114,11 +113,7 @@ export default function MobileWalletAdapterEntrypointBottomSheet() {
     async function initializeMWASession() {
       const associationUri = await Linking.getInitialURL();
       if (associationUri) {
-        initializeMobileWalletAdapterSession(
-          'wallet label',
-          config,
-          associationUri,
-        );
+        initializeMobileWalletAdapterSession('wallet label', config);
       } else {
         console.error('Error retrieving associationUri');
       }
@@ -129,7 +124,7 @@ export default function MobileWalletAdapterEntrypointBottomSheet() {
     );
     initializeMWASession();
     return () => listener.remove();
-  }, []);
+  }, [config, handleRequest, handleSessionEvent]);
 
   useEffect(() => {
     const initClientTrustUseCase = async () => {

--- a/examples/example-react-native-wallet/screens/MobileWalletAdapterEntrypointBottomSheet.tsx
+++ b/examples/example-react-native-wallet/screens/MobileWalletAdapterEntrypointBottomSheet.tsx
@@ -25,6 +25,8 @@ import {
   getCallingPackage,
   initializeMWAEventListener,
   initializeMobileWalletAdapterSession,
+  SolanaMWAWalletLibErrorCode,
+  SolanaMWAWalletLibError,
 } from '@solana-mobile/mobile-wallet-adapter-walletlib';
 
 import AuthenticationScreen from '../bottomsheets/AuthenticationScreen';
@@ -117,8 +119,12 @@ export default function MobileWalletAdapterEntrypointBottomSheet() {
           config,
         );
         console.log('sessionId: ' + sessionId);
-      } catch (e) {
-        console.error(e);
+      } catch (e: any) {
+        if (e instanceof SolanaMWAWalletLibError) {
+          console.error(e.name, e.code, e.message);
+        } else {
+          console.error(e);
+        }
       }
     }
     const listener = initializeMWAEventListener(

--- a/js/packages/mobile-wallet-adapter-walletlib/README.md
+++ b/js/packages/mobile-wallet-adapter-walletlib/README.md
@@ -63,15 +63,43 @@ Alternatively and for more flexibility, you can invoke individual methods to lis
 
 #### Example: 
 
-```
+```ts
 useEffect(() => {
+  const config: MobileWalletAdapterConfig = {
+      supportsSignAndSendTransactions: true,
+      maxTransactionsPerSigningRequest: 10,
+      maxMessagesPerSigningRequest: 10,
+      supportedTransactionVersions: [0, 'legacy'],
+      noConnectionWarningTimeoutMs: 3000,
+    };
+
+  // MWA Session Handlers
+  const handleRequest = (request: MWARequest) => {
+    /* ... */
+  };
+  const handleSessionEvent = (sessionEvent: MWASessionEvent) => {
+    /* ... */
+  };
+
+  async function initializeMWASession() {
+    try {
+      const sessionId = await initializeMobileWalletAdapterSession(
+        'wallet label',
+        config,
+      );
+      console.log('sessionId: ' + sessionId);
+    } catch (e) {
+      console.error(e);
+    }
+  }
   const listener = initializeMWAEventListener(
     handleRequest,
     handleSessionEvent,
   );
-      initializeMobileWalletAdapterSession('wallet label', config);
+  initializeMWASession();
+
   return () => listener.remove();
-}, [config, handleRequest, handleSessionEvent]);
+}, []);
 ```
 
 ### 2. Handling requests

--- a/js/packages/mobile-wallet-adapter-walletlib/README.md
+++ b/js/packages/mobile-wallet-adapter-walletlib/README.md
@@ -65,39 +65,33 @@ Alternatively and for more flexibility, you can invoke individual methods to lis
 
 ```ts
 useEffect(() => {
-  const config: MobileWalletAdapterConfig = {
+  async function initializeMWASession() {
+    const config: MobileWalletAdapterConfig = {
       supportsSignAndSendTransactions: true,
       maxTransactionsPerSigningRequest: 10,
       maxMessagesPerSigningRequest: 10,
       supportedTransactionVersions: [0, 'legacy'],
       noConnectionWarningTimeoutMs: 3000,
     };
-
-  // MWA Session Handlers
-  const handleRequest = (request: MWARequest) => {
-    /* ... */
-  };
-  const handleSessionEvent = (sessionEvent: MWASessionEvent) => {
-    /* ... */
-  };
-
-  async function initializeMWASession() {
     try {
       const sessionId = await initializeMobileWalletAdapterSession(
         'wallet label',
         config,
       );
       console.log('sessionId: ' + sessionId);
-    } catch (e) {
-      console.error(e);
+    } catch (e: any) {
+        if (e instanceof SolanaMWAWalletLibError) {
+          console.error(e.name, e.code, e.message);
+        } else {
+          console.error(e);
+        }   
     }
   }
   const listener = initializeMWAEventListener(
-    handleRequest,
-    handleSessionEvent,
+    (request: MWARequest) => { /* ... */ },
+    (sessionEvent: MWASessionEvent) => { /* ... */ },
   );
   initializeMWASession();
-
   return () => listener.remove();
 }, []);
 ```

--- a/js/packages/mobile-wallet-adapter-walletlib/README.md
+++ b/js/packages/mobile-wallet-adapter-walletlib/README.md
@@ -40,13 +40,38 @@ const handleSessionEvent = useCallback((sessionEvent: MWASessionEvent) => {
   /* ... */
 }, []);
 
-// Connect to the calling dApp and begin handling dApp requests
+// 1. Use a React hook API to begin listening for MWA events and initalize the session
 useMobileWalletAdapterSession(
   'Example Wallet Label',
   config,
   handleRequest,
   handleSessionEvent,
 );
+```
+
+Alternatively and for more flexibility, you can invoke individual methods to listen for MWA events (`initializeMWAEventListener`) and initialize the session (`initializeMWASession`).
+
+#### initializeMWAEventListener
+
+- Registers a listener for MWA Requests and MWA Session Events, using the provided handlers.
+- You should ensure the listener is cleaned up, when it is out of scope (e.g `listener.remove()` on dismount).
+
+#### initializeMWASession
+
+- Establishes a session with the dApp endpoint and begins transmission of MWA requests/events.
+- This should be called *after* `initializeMWAEventListener` is called, to ensure no events are missed.
+
+#### Example: 
+
+```
+useEffect(() => {
+  const listener = initializeMWAEventListener(
+    handleRequest,
+    handleSessionEvent,
+  );
+      initializeMobileWalletAdapterSession('wallet label', config);
+  return () => listener.remove();
+}, [config, handleRequest, handleSessionEvent]);
 ```
 
 ### 2. Handling requests
@@ -138,22 +163,3 @@ Fields:
 - `SignAndSendTransactionsRequest`
   - [Spec](https://solana-mobile.github.io/mobile-wallet-adapter/spec/spec.html#sign_and_send_transactions)
   - Interfaces: `IMWARequest`, `IVerifiableIdentityRequest`
-
-
-# Changelog
-
-## 1.0.3
-- Fixed a rerender bug within `useMobileWalletAdapterSession` where `initializeScenario` was needlessly called on rerender. 
-
-- Added `DeauthorizeDappRequest` type, so Javascript side now knows when a dApp requests for deauthorization.
-
-- Added `ReauthorizeDappRequest` type, so Javascript side now knows when a dApp requests for reauthorization.
-
-- Refactored `IMWARequest` to only include fields `requestId`, `sessionId`, and `__type`. 
-
-- Added `IVerifableIdentityRequest` to take on the fields `authorizationScope`, `cluster`, and `appIdentity`.
-
-- `AuthorizeDappRequest` now no longer includes `authorizationScope`. This was mistakenly included previously.
-
-- Updated documentation in the README. See "Properties of an MWA Request".
-

--- a/js/packages/mobile-wallet-adapter-walletlib/android/build.gradle
+++ b/js/packages/mobile-wallet-adapter-walletlib/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['SolanaMobileWalletAdapterWalletLibModule_kotlinVersion']
-  rootProject.ext.reactNativeAndroidRoot = new File("/Users/mikesulistio/sms/mobile-wallet-adapter/examples/example-react-native-wallet/node_modules/react-native/android")
 
   repositories {
       google()

--- a/js/packages/mobile-wallet-adapter-walletlib/android/build.gradle
+++ b/js/packages/mobile-wallet-adapter-walletlib/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['SolanaMobileWalletAdapterWalletLibModule_kotlinVersion']
+  rootProject.ext.reactNativeAndroidRoot = new File("/Users/mikesulistio/sms/mobile-wallet-adapter/examples/example-react-native-wallet/node_modules/react-native/android")
 
   repositories {
       google()

--- a/js/packages/mobile-wallet-adapter-walletlib/android/src/main/java/com/solanamobile/mobilewalletadapterwalletlib/reactnative/SolanaMobileWalletAdapterWalletLibModule.kt
+++ b/js/packages/mobile-wallet-adapter-walletlib/android/src/main/java/com/solanamobile/mobilewalletadapterwalletlib/reactnative/SolanaMobileWalletAdapterWalletLibModule.kt
@@ -1,36 +1,37 @@
 package com.solanamobile.mobilewalletadapterwalletlib.reactnative
 
+import android.content.Intent
 import android.net.Uri
 import android.util.Log
 import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule
-import com.solana.mobilewalletadapter.common.util.NotifyingCompletableFuture
+import com.solana.mobilewalletadapter.common.ProtocolContract
 import com.solana.mobilewalletadapter.walletlib.association.AssociationUri
 import com.solana.mobilewalletadapter.walletlib.association.LocalAssociationUri
 import com.solana.mobilewalletadapter.walletlib.authorization.AuthIssuerConfig
-import com.solana.mobilewalletadapter.walletlib.protocol.MobileWalletAdapterConfig
 import com.solana.mobilewalletadapter.walletlib.scenario.*
 import com.solana.mobilewalletadapter.walletlib.scenario.AuthorizedAccount
-import com.solana.mobilewalletadapter.common.ProtocolContract
-import com.solanamobile.mobilewalletadapterwalletlib.reactnative.BuildConfig
 import com.solanamobile.mobilewalletadapterwalletlib.reactnative.model.*
+import java.util.UUID
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
-import java.util.UUID
 
 class SolanaMobileWalletAdapterWalletLibModule(val reactContext: ReactApplicationContext) :
-    ReactContextBaseJavaModule(reactContext), CoroutineScope {
+        ReactContextBaseJavaModule(reactContext), CoroutineScope {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    // Sets the name of the module in React, accessible at ReactNative.NativeModules.SolanaMobileWalletAdapterWalletLib
+    // Sets the name of the module in React, accessible at
+    // ReactNative.NativeModules.SolanaMobileWalletAdapterWalletLib
     override fun getName() = "SolanaMobileWalletAdapterWalletLib"
-    
+
     override val coroutineContext =
-        Dispatchers.IO + CoroutineName("SolanaMobileWalletAdapterWalletLibModuleScope") + SupervisorJob()
+            Dispatchers.IO +
+                    CoroutineName("SolanaMobileWalletAdapterWalletLibModuleScope") +
+                    SupervisorJob()
 
     // Session events that notify about the lifecycle of the Scenario session. We are choosing
     // to go with the naming convention Session rather than Scenario for readability.
@@ -65,19 +66,27 @@ class SolanaMobileWalletAdapterWalletLibModule(val reactContext: ReactApplicatio
         }
     }
 
-    // Service requests that come from the dApp for Authorization, Signing, Sending, hence "RemoteRequest".
-    sealed class MobileWalletAdapterRemoteRequest(open val request: ScenarioRequest, 
-                                                  val id: String = UUID.randomUUID().toString()) {
-        data class AuthorizeDapp(override val request: AuthorizeRequest) : MobileWalletAdapterRemoteRequest(request)
-        data class ReauthorizeDapp(override val request: ReauthorizeRequest) : MobileWalletAdapterRemoteRequest(request)
-        data class DeauthorizeDapp(override val request: DeauthorizedEvent) : MobileWalletAdapterRemoteRequest(request)
+    // Service requests that come from the dApp for Authorization, Signing, Sending, hence
+    // "RemoteRequest".
+    sealed class MobileWalletAdapterRemoteRequest(
+            open val request: ScenarioRequest,
+            val id: String = UUID.randomUUID().toString()
+    ) {
+        data class AuthorizeDapp(override val request: AuthorizeRequest) :
+                MobileWalletAdapterRemoteRequest(request)
+        data class ReauthorizeDapp(override val request: ReauthorizeRequest) :
+                MobileWalletAdapterRemoteRequest(request)
+        data class DeauthorizeDapp(override val request: DeauthorizedEvent) :
+                MobileWalletAdapterRemoteRequest(request)
 
-        sealed class SignPayloads(override val request: SignPayloadsRequest) : MobileWalletAdapterRemoteRequest(request)
-        data class SignTransactions(override val request: SignTransactionsRequest) : SignPayloads(request)
+        sealed class SignPayloads(override val request: SignPayloadsRequest) :
+                MobileWalletAdapterRemoteRequest(request)
+        data class SignTransactions(override val request: SignTransactionsRequest) :
+                SignPayloads(request)
         data class SignMessages(override val request: SignMessagesRequest) : SignPayloads(request)
         data class SignAndSendTransactions(
-            override val request: SignAndSendTransactionsRequest,
-            val endpointUri: Uri,
+                override val request: SignAndSendTransactionsRequest,
+                val endpointUri: Uri,
         ) : MobileWalletAdapterRemoteRequest(request)
     }
 
@@ -86,36 +95,46 @@ class SolanaMobileWalletAdapterWalletLibModule(val reactContext: ReactApplicatio
     private var scenarioUri: Uri? = null
     private var scenario: Scenario? = null
         set(value) {
-            value?.let { scenarioId = UUID.randomUUID().toString() } ?: run {
-                scenarioId = null
-                scenario?.close()
-            }
+            value?.let { scenarioId = UUID.randomUUID().toString() }
+                    ?: run {
+                        scenarioId = null
+                        scenario?.close()
+                    }
             pendingRequests.clear()
             field = value
         }
 
-    // very basic/naive implememtion of request cache. 
-    // we could replace this with an abstraction that has expiration, persistance, etc. 
+    // very basic/naive implememtion of request cache.
+    // we could replace this with an abstraction that has expiration, persistance, etc.
     private val pendingRequests = mutableMapOf<String, MobileWalletAdapterRemoteRequest>()
 
     private fun clusterToRpcUri(cluster: String?): Uri {
         return when (cluster) {
             ProtocolContract.CLUSTER_MAINNET_BETA ->
-                Uri.parse("https://api.mainnet-beta.solana.com")
-            ProtocolContract.CLUSTER_DEVNET ->
-                Uri.parse("https://api.devnet.solana.com")
-            else ->
-                Uri.parse("https://api.testnet.solana.com")
+                    Uri.parse("https://api.mainnet-beta.solana.com")
+            ProtocolContract.CLUSTER_DEVNET -> Uri.parse("https://api.devnet.solana.com")
+            else -> Uri.parse("https://api.testnet.solana.com")
         }
     }
 
     @ReactMethod
     fun createScenario(
-        walletName: String,
-        uriStr: String,
-        config: String,
+            walletName: String,
+            config: String,
     ) = launch {
-        val uri = Uri.parse(uriStr)
+        // Get the intent that started this activity
+        val intent = reactContext.getCurrentActivity()?.getIntent()
+        if (intent == null) {
+            Log.e(TAG, "Unable to get intent in current context")
+            return@launch
+        }
+        // Get the data from the intent and parse into URI
+        val data = intent.getData();
+        if (data == null) {
+            Log.e(TAG, "Unable to get intent data in current context")
+            return@launch
+        }
+        val uri = Uri.parse(data.toString())
 
         // TODO: this is dirty, need some stateful object/data to know what state we are in.
         //  also, should we suport multiple simulatneous scenario?
@@ -140,12 +159,14 @@ class SolanaMobileWalletAdapterWalletLibModule(val reactContext: ReactApplicatio
         // created a scenario, told it to start (kicks off some threads in the background)
         // we've kept a reference to it in the global state of this module (scenario)
         // this won't be garbage collected and will just run, sit & wait for an incoming connection
-        scenario = associationUri.createScenario(
-            reactContext,
-            kotlinConfig,
-            AuthIssuerConfig(walletName),
-            MobileWalletAdapterScenarioCallbacks()
-        ).also { it.start() }
+        scenario =
+                associationUri.createScenario(
+                                reactContext,
+                                kotlinConfig,
+                                AuthIssuerConfig(walletName),
+                                MobileWalletAdapterScenarioCallbacks()
+                        )
+                        .also { it.start() }
 
         Log.d(TAG, "scenario created: $walletName")
     }
@@ -161,171 +182,270 @@ class SolanaMobileWalletAdapterWalletLibModule(val reactContext: ReactApplicatio
 
     @ReactMethod
     fun resolve(requestJson: String, responseJson: String) = launch {
-        val completedRequest = json.decodeFromString(MobileWalletAdapterRequestSerializer, requestJson)
+        val completedRequest =
+                json.decodeFromString(MobileWalletAdapterRequestSerializer, requestJson)
         val response = json.decodeFromString(MobileWalletAdapterResponseSerializer, responseJson)
         val pendingRequest = pendingRequests[completedRequest.requestId]
 
         if (completedRequest.sessionId != scenarioId) {
-            sendSessionEventToReact(MobileWalletAdapterSessionEvent.ScenarioError(
-                "Invalid session (${completedRequest.sessionId}). This session does not exist/is no longer active."
-            ))
+            sendSessionEventToReact(
+                    MobileWalletAdapterSessionEvent.ScenarioError(
+                            "Invalid session (${completedRequest.sessionId}). This session does not exist/is no longer active."
+                    )
+            )
             return@launch
         }
 
         fun completeWithInvalidResponse() {
-            pendingRequest?.request?.completeWithInternalError(Exception("Invalid Response For Request: response = $responseJson"))
+            pendingRequest?.request?.completeWithInternalError(
+                    Exception("Invalid Response For Request: response = $responseJson")
+            )
         }
 
         when (completedRequest) {
-            is AuthorizeDapp -> when (response) {
-                is MobileWalletAdapterFailureResponse -> {
+            is AuthorizeDapp ->
                     when (response) {
-                        is UserDeclinedResponse ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.AuthorizeDapp)?.request?.completeWithDecline()
+                        is MobileWalletAdapterFailureResponse -> {
+                            when (response) {
+                                is UserDeclinedResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.AuthorizeDapp)
+                                                ?.request?.completeWithDecline()
+                                else -> completeWithInvalidResponse()
+                            }
+                        }
+                        is AuthorizeDappResponse ->
+                                (pendingRequest as? MobileWalletAdapterRemoteRequest.AuthorizeDapp)
+                                        ?.request?.completeWithAuthorize(
+                                        response.accounts.first().let { account ->
+                                            AuthorizedAccount(
+                                                    account.publicKey,
+                                                    account.accountLabel,
+                                                    account.icon?.let { Uri.parse(it) },
+                                                    account.chains?.toTypedArray(),
+                                                    account.features?.toTypedArray()
+                                            )
+                                        },
+                                        response.walletUriBase?.let {
+                                            Uri.parse(response.walletUriBase)
+                                        },
+                                        response.authorizationScope,
+                                        response.signInResult
+                                )
                         else -> completeWithInvalidResponse()
                     }
-                }
-                is AuthorizeDappResponse ->
-                    (pendingRequest as? MobileWalletAdapterRemoteRequest.AuthorizeDapp)
-                        ?.request?.completeWithAuthorize(
-                            response.accounts.first().let { account ->
-                                AuthorizedAccount(account.publicKey, account.accountLabel, account.icon?.let{ Uri.parse(it) }, 
-                                    account.chains?.toTypedArray(), account.features?.toTypedArray())
-                            },
-                            response.walletUriBase?.let { Uri.parse(response.walletUriBase) },
-                            response.authorizationScope,
-                            response.signInResult
-                        )
-                else -> completeWithInvalidResponse()
-            }
-            is ReauthorizeDapp -> when (response) {
-                is MobileWalletAdapterFailureResponse -> {
+            is ReauthorizeDapp ->
                     when (response) {
-                        is AuthorizationNotValidResponse ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.ReauthorizeDapp)?.request?.completeWithDecline()
+                        is MobileWalletAdapterFailureResponse -> {
+                            when (response) {
+                                is AuthorizationNotValidResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.ReauthorizeDapp)
+                                                ?.request?.completeWithDecline()
+                                else -> completeWithInvalidResponse()
+                            }
+                        }
+                        is ReauthorizeDappResponse ->
+                                (pendingRequest as?
+                                                MobileWalletAdapterRemoteRequest.ReauthorizeDapp)
+                                        ?.request?.completeWithReauthorize()
                         else -> completeWithInvalidResponse()
                     }
-                }
-                is ReauthorizeDappResponse ->
-                    (pendingRequest as? MobileWalletAdapterRemoteRequest.ReauthorizeDapp)?.request?.completeWithReauthorize()
-                else -> completeWithInvalidResponse()
-            }
-            is DeauthorizeDapp -> when (response) {
-                is DeauthorizeDappResponse ->
-                    (pendingRequest as? MobileWalletAdapterRemoteRequest.DeauthorizeDapp)?.request?.complete()
-                else -> completeWithInvalidResponse()
-            }
-            is SignAndSendTransactions -> when (response) {
-                is MobileWalletAdapterFailureResponse -> {
+            is DeauthorizeDapp ->
                     when (response) {
-                        is UserDeclinedResponse  ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.SignAndSendTransactions)?.request?.completeWithDecline()
-                        is TooManyPayloadsResponse ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.SignAndSendTransactions)?.request?.completeWithTooManyPayloads()
-                        is AuthorizationNotValidResponse ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.SignAndSendTransactions)?.request?.completeWithAuthorizationNotValid()
-                        is InvalidSignaturesResponse ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.SignAndSendTransactions)?.request?.completeWithInvalidSignatures(response.valid)
+                        is DeauthorizeDappResponse ->
+                                (pendingRequest as?
+                                                MobileWalletAdapterRemoteRequest.DeauthorizeDapp)
+                                        ?.request?.complete()
+                        else -> completeWithInvalidResponse()
                     }
-                }
-                is SignedAndSentTransactions ->
-                    (pendingRequest as? MobileWalletAdapterRemoteRequest.SignAndSendTransactions)?.request?.completeWithSignatures(response.signedTransactions.toTypedArray())
-                else -> completeWithInvalidResponse()
-            }
-            is SignPayloads -> when (response) {
-                is MobileWalletAdapterFailureResponse -> {
+            is SignAndSendTransactions ->
                     when (response) {
-                        is UserDeclinedResponse  ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.SignPayloads)?.request?.completeWithDecline()
-                        is TooManyPayloadsResponse ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.SignPayloads)?.request?.completeWithTooManyPayloads()
-                        is AuthorizationNotValidResponse ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.SignPayloads)?.request?.completeWithAuthorizationNotValid()
-                        is InvalidSignaturesResponse ->
-                            (pendingRequest as? MobileWalletAdapterRemoteRequest.SignPayloads)?.request?.completeWithInvalidPayloads(response.valid)
+                        is MobileWalletAdapterFailureResponse -> {
+                            when (response) {
+                                is UserDeclinedResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.SignAndSendTransactions)
+                                                ?.request?.completeWithDecline()
+                                is TooManyPayloadsResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.SignAndSendTransactions)
+                                                ?.request?.completeWithTooManyPayloads()
+                                is AuthorizationNotValidResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.SignAndSendTransactions)
+                                                ?.request?.completeWithAuthorizationNotValid()
+                                is InvalidSignaturesResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.SignAndSendTransactions)
+                                                ?.request?.completeWithInvalidSignatures(
+                                                response.valid
+                                        )
+                            }
+                        }
+                        is SignedAndSentTransactions ->
+                                (pendingRequest as?
+                                                MobileWalletAdapterRemoteRequest.SignAndSendTransactions)
+                                        ?.request?.completeWithSignatures(
+                                        response.signedTransactions.toTypedArray()
+                                )
+                        else -> completeWithInvalidResponse()
                     }
-                }
-                is SignedPayloads ->
-                    (pendingRequest as? MobileWalletAdapterRemoteRequest.SignPayloads)?.request?.completeWithSignedPayloads(response.signedPayloads.toTypedArray())
-                else -> completeWithInvalidResponse()
-            }
+            is SignPayloads ->
+                    when (response) {
+                        is MobileWalletAdapterFailureResponse -> {
+                            when (response) {
+                                is UserDeclinedResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.SignPayloads)
+                                                ?.request?.completeWithDecline()
+                                is TooManyPayloadsResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.SignPayloads)
+                                                ?.request?.completeWithTooManyPayloads()
+                                is AuthorizationNotValidResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.SignPayloads)
+                                                ?.request?.completeWithAuthorizationNotValid()
+                                is InvalidSignaturesResponse ->
+                                        (pendingRequest as?
+                                                        MobileWalletAdapterRemoteRequest.SignPayloads)
+                                                ?.request?.completeWithInvalidPayloads(
+                                                response.valid
+                                        )
+                            }
+                        }
+                        is SignedPayloads ->
+                                (pendingRequest as? MobileWalletAdapterRemoteRequest.SignPayloads)
+                                        ?.request?.completeWithSignedPayloads(
+                                        response.signedPayloads.toTypedArray()
+                                )
+                        else -> completeWithInvalidResponse()
+                    }
         }
     }
 
-    private fun checkSessionId(sessionId: String, doIfValid: (() -> Unit)) = 
-        if (sessionId == scenarioId) doIfValid() 
-        else sendSessionEventToReact(MobileWalletAdapterSessionEvent.ScenarioError(
-            "Invalid session ($sessionId). This session does not exist/is no longer active."
-        ))
+    private fun checkSessionId(sessionId: String, doIfValid: (() -> Unit)) =
+            if (sessionId == scenarioId) doIfValid()
+            else
+                    sendSessionEventToReact(
+                            MobileWalletAdapterSessionEvent.ScenarioError(
+                                    "Invalid session ($sessionId). This session does not exist/is no longer active."
+                            )
+                    )
 
     private fun sendSessionEventToReact(sessionEvent: MobileWalletAdapterSessionEvent) {
-        val eventInfo = when(sessionEvent) {
-            is MobileWalletAdapterSessionEvent.None -> null
-            is MobileWalletAdapterSessionEvent.ScenarioError -> Arguments.createMap().apply {
-                putString("__type", sessionEvent.type)
-                putString("error", sessionEvent.message)
-            }
-            else -> Arguments.createMap().apply {
-                putString("__type", sessionEvent.type)
-            }
-        }
+        val eventInfo =
+                when (sessionEvent) {
+                    is MobileWalletAdapterSessionEvent.None -> null
+                    is MobileWalletAdapterSessionEvent.ScenarioError ->
+                            Arguments.createMap().apply {
+                                putString("__type", sessionEvent.type)
+                                putString("error", sessionEvent.message)
+                            }
+                    else -> Arguments.createMap().apply { putString("__type", sessionEvent.type) }
+                }
 
         eventInfo?.putString("sessionId", scenarioId)
 
-        eventInfo?.let { sendEvent(reactContext,
-            Companion.MOBILE_WALLET_ADAPTER_SERVICE_REQUEST_BRIDGE_NAME, it) }
+        eventInfo?.let {
+            sendEvent(reactContext, Companion.MOBILE_WALLET_ADAPTER_SERVICE_REQUEST_BRIDGE_NAME, it)
+        }
     }
 
     private fun sendWalletServiceRequestToReact(request: MobileWalletAdapterRemoteRequest) {
-        val surrogate = when(request) {
-            is MobileWalletAdapterRemoteRequest.AuthorizeDapp -> AuthorizeDapp(
-                scenarioId!!, request.request.chain, request.request.identityName,
-                request.request.identityUri.toString(), request.request.iconRelativeUri.toString(),
-                request.request.features?.asList(), request.request.addresses?.asList(), 
-                request.request.signInPayload
-            )
-            is MobileWalletAdapterRemoteRequest.ReauthorizeDapp -> ReauthorizeDapp(
-                scenarioId!!, request.request.chain, request.request.identityName,
-                request.request.identityUri.toString(), request.request.iconRelativeUri.toString(),
-                request.request.authorizationScope
-            )
-            is MobileWalletAdapterRemoteRequest.DeauthorizeDapp -> DeauthorizeDapp(
-                scenarioId!!, request.request.chain, request.request.identityName,
-                request.request.identityUri.toString(), request.request.iconRelativeUri.toString(),
-                request.request.authorizationScope
-            )
-            is MobileWalletAdapterRemoteRequest.SignMessages -> SignMessages(
-                scenarioId!!, request.request.chain, request.request.identityName,
-                request.request.identityUri.toString(), request.request.iconRelativeUri.toString(),
-                request.request.authorizationScope, request.request.payloads.toList()
-            )
-            is MobileWalletAdapterRemoteRequest.SignTransactions -> SignTransactions(
-                scenarioId!!, request.request.chain, request.request.identityName,
-                request.request.identityUri.toString(), request.request.iconRelativeUri.toString(),
-                request.request.authorizationScope, request.request.payloads.toList()
-            )
-            is MobileWalletAdapterRemoteRequest.SignAndSendTransactions -> SignAndSendTransactions(
-                scenarioId!!, request.request.chain, request.request.identityName,
-                request.request.identityUri.toString(), request.request.iconRelativeUri.toString(),
-                request.request.authorizationScope, request.request.payloads.toList()
-            )
-        }
+        val surrogate =
+                when (request) {
+                    is MobileWalletAdapterRemoteRequest.AuthorizeDapp ->
+                            AuthorizeDapp(
+                                    scenarioId!!,
+                                    request.request.chain,
+                                    request.request.identityName,
+                                    request.request.identityUri.toString(),
+                                    request.request.iconRelativeUri.toString(),
+                                    request.request.features?.asList(),
+                                    request.request.addresses?.asList(),
+                                    request.request.signInPayload
+                            )
+                    is MobileWalletAdapterRemoteRequest.ReauthorizeDapp ->
+                            ReauthorizeDapp(
+                                    scenarioId!!,
+                                    request.request.chain,
+                                    request.request.identityName,
+                                    request.request.identityUri.toString(),
+                                    request.request.iconRelativeUri.toString(),
+                                    request.request.authorizationScope
+                            )
+                    is MobileWalletAdapterRemoteRequest.DeauthorizeDapp ->
+                            DeauthorizeDapp(
+                                    scenarioId!!,
+                                    request.request.chain,
+                                    request.request.identityName,
+                                    request.request.identityUri.toString(),
+                                    request.request.iconRelativeUri.toString(),
+                                    request.request.authorizationScope
+                            )
+                    is MobileWalletAdapterRemoteRequest.SignMessages ->
+                            SignMessages(
+                                    scenarioId!!,
+                                    request.request.chain,
+                                    request.request.identityName,
+                                    request.request.identityUri.toString(),
+                                    request.request.iconRelativeUri.toString(),
+                                    request.request.authorizationScope,
+                                    request.request.payloads.toList()
+                            )
+                    is MobileWalletAdapterRemoteRequest.SignTransactions ->
+                            SignTransactions(
+                                    scenarioId!!,
+                                    request.request.chain,
+                                    request.request.identityName,
+                                    request.request.identityUri.toString(),
+                                    request.request.iconRelativeUri.toString(),
+                                    request.request.authorizationScope,
+                                    request.request.payloads.toList()
+                            )
+                    is MobileWalletAdapterRemoteRequest.SignAndSendTransactions ->
+                            SignAndSendTransactions(
+                                    scenarioId!!,
+                                    request.request.chain,
+                                    request.request.identityName,
+                                    request.request.identityUri.toString(),
+                                    request.request.iconRelativeUri.toString(),
+                                    request.request.authorizationScope,
+                                    request.request.payloads.toList()
+                            )
+                }
 
         // this is dirty, the requestId needs to line up so have to manually overwrite here
         // should we change javascript side to accept json?
-        val eventInfo = 
-            JsonObject(json.encodeToJsonElement(MobileWalletAdapterRequestSerializer, surrogate)
-                .jsonObject.toMutableMap().apply { 
-                    put("requestId", JsonPrimitive(request.id))
-                }).toReadableMap()
+        val eventInfo =
+                JsonObject(
+                                json.encodeToJsonElement(
+                                                MobileWalletAdapterRequestSerializer,
+                                                surrogate
+                                        )
+                                        .jsonObject
+                                        .toMutableMap()
+                                        .apply { put("requestId", JsonPrimitive(request.id)) }
+                        )
+                        .toReadableMap()
 
-        sendEvent(reactContext, Companion.MOBILE_WALLET_ADAPTER_SERVICE_REQUEST_BRIDGE_NAME, eventInfo)
+        sendEvent(
+                reactContext,
+                Companion.MOBILE_WALLET_ADAPTER_SERVICE_REQUEST_BRIDGE_NAME,
+                eventInfo
+        )
     }
 
-    private fun sendEvent(reactContext: ReactContext, eventName: String, params: ReadableMap? = null) {
+    private fun sendEvent(
+            reactContext: ReactContext,
+            eventName: String,
+            params: ReadableMap? = null
+    ) {
         reactContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-            .emit(eventName, params)
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                .emit(eventName, params)
     }
 
     private inner class MobileWalletAdapterScenarioCallbacks : LocalScenario.Callbacks {
@@ -389,7 +509,8 @@ class SolanaMobileWalletAdapterWalletLibModule(val reactContext: ReactApplicatio
 
         override fun onSignAndSendTransactionsRequest(request: SignAndSendTransactionsRequest) {
             val endpointUri = clusterToRpcUri(request.cluster)
-            val request = MobileWalletAdapterRemoteRequest.SignAndSendTransactions(request, endpointUri)
+            val request =
+                    MobileWalletAdapterRemoteRequest.SignAndSendTransactions(request, endpointUri)
             pendingRequests.put(request.id, request)
             sendWalletServiceRequestToReact(request)
         }
@@ -403,7 +524,9 @@ class SolanaMobileWalletAdapterWalletLibModule(val reactContext: ReactApplicatio
 
     companion object {
         private val TAG = SolanaMobileWalletAdapterWalletLibModule::class.simpleName
-        const val MOBILE_WALLET_ADAPTER_SERVICE_REQUEST_BRIDGE_NAME = "MobileWalletAdapterServiceRequestBridge"
-        const val MOBILE_WALLET_ADAPTER_SESSION_EVENT_BRIDGE_NAME = "MobileWalletAdapterSessionEventBridge"
+        const val MOBILE_WALLET_ADAPTER_SERVICE_REQUEST_BRIDGE_NAME =
+                "MobileWalletAdapterServiceRequestBridge"
+        const val MOBILE_WALLET_ADAPTER_SESSION_EVENT_BRIDGE_NAME =
+                "MobileWalletAdapterSessionEventBridge"
     }
 }

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-walletlib",
     "description": "A React Native wrapper of the Solana Mobile, Mobile Wallet Adapter Wallet Library. Wallet apps can use this to handle dapp requests for signing and sending.",
-    "version": "1.4.0",
+    "version": "1.4.0-beta1",
     "author": "Michael Sulistio <mike.sulistio@solanamobile.com>",
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-walletlib",
     "description": "A React Native wrapper of the Solana Mobile, Mobile Wallet Adapter Wallet Library. Wallet apps can use this to handle dapp requests for signing and sending.",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "author": "Michael Sulistio <mike.sulistio@solanamobile.com>",
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",

--- a/js/packages/mobile-wallet-adapter-walletlib/src/SolanaMobileWalletAdapterWalletLib.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/SolanaMobileWalletAdapterWalletLib.ts
@@ -1,0 +1,18 @@
+import { NativeModules, Platform } from 'react-native';
+import { LINKING_ERROR } from './initializeMWAEventListener.js';
+
+export const SolanaMobileWalletAdapterWalletLib =
+    Platform.OS === 'android' && NativeModules.SolanaMobileWalletAdapterWalletLib
+        ? NativeModules.SolanaMobileWalletAdapterWalletLib
+        : new Proxy(
+              {},
+              {
+                  get() {
+                      throw new Error(
+                          Platform.OS !== 'android'
+                              ? 'The package `solana-mobile-wallet-adapter-walletlib` is only compatible with React Native Android'
+                              : LINKING_ERROR,
+                      );
+                  },
+              },
+          );

--- a/js/packages/mobile-wallet-adapter-walletlib/src/errors.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/errors.ts
@@ -1,0 +1,15 @@
+export enum SolanaMWAWalletLibErrorCode {
+    ERROR_INTENT_DATA_NOT_FOUND = 'ERROR_INTENT_DATA_NOT_FOUND',
+    ERROR_SESSION_ALREADY_CREATED = 'ERROR_SESSION_ALREADY_CREATED',
+    ERROR_UNSUPPORTED_ASSOCIATION_URI = 'ERROR_UNSUPPORTED_ASSOCIATION_URI',
+    ERROR_UNSUPPORTED_ASSOCIATION_TYPE = 'ERROR_UNSUPPORTED_ASSOCIATION_TYPE',
+}
+
+export class SolanaMWAWalletLibError extends Error {
+    code: SolanaMWAWalletLibErrorCode;
+    constructor(code: SolanaMWAWalletLibErrorCode, message: string) {
+        super(message);
+        this.name = 'SolanaMWAWalletLibError';
+        this.code = code;
+    }
+}

--- a/js/packages/mobile-wallet-adapter-walletlib/src/index.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/index.ts
@@ -1,4 +1,7 @@
 export * from './mwaSessionEvents.js';
 export * from './resolve.js';
 export * from './useMobileWalletAdapterSession.js';
+export * from './initializeMobileWalletAdapterSession.js';
+export * from './initializeMWAEventListener.js';
 export * from './useDigitalAssetLinks.js';
+export * from './errors.js';

--- a/js/packages/mobile-wallet-adapter-walletlib/src/initializeMWAEventListener.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/initializeMWAEventListener.ts
@@ -1,0 +1,32 @@
+import { EmitterSubscription, NativeEventEmitter } from 'react-native';
+
+import { MWASessionEvent, MWASessionEventType } from './mwaSessionEvents.js';
+import { MWARequest, MWARequestType } from './resolve.js';
+
+const MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME = 'MobileWalletAdapterServiceRequestBridge';
+
+export function initializeMWAEventListener(
+    handleRequest: (request: MWARequest) => void,
+    handleSessionEvent: (sessionEvent: MWASessionEvent) => void,
+): EmitterSubscription {
+    const mwaEventEmitter = new NativeEventEmitter();
+    const listener = mwaEventEmitter.addListener(MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME, (nativeEvent) => {
+        if (isMWARequest(nativeEvent)) {
+            handleRequest(nativeEvent as MWARequest);
+        } else if (isMWASessionEvent(nativeEvent)) {
+            handleSessionEvent(nativeEvent as MWASessionEvent);
+        } else {
+            console.warn('Unexpected native event type');
+        }
+    });
+
+    return listener;
+}
+
+function isMWARequest(nativeEvent: any): boolean {
+    return Object.values(MWARequestType).includes(nativeEvent.__type);
+}
+
+function isMWASessionEvent(nativeEvent: any) {
+    return Object.values(MWASessionEventType).includes(nativeEvent.__type);
+}

--- a/js/packages/mobile-wallet-adapter-walletlib/src/initializeMobileWalletAdapterSession.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/initializeMobileWalletAdapterSession.ts
@@ -1,0 +1,67 @@
+import type { TransactionVersion } from '@solana/web3.js';
+import type { IdentifierArray } from '@wallet-standard/core';
+import { NativeModules, Platform } from 'react-native';
+
+import { SolanaMWAWalletLibError, SolanaMWAWalletLibErrorCode } from './errors.js';
+
+const LINKING_ERROR =
+    `The package 'solana-mobile-wallet-adapter-walletlib' doesn't seem to be linked. Make sure: \n\n` +
+    '- You rebuilt the app after installing the package\n' +
+    '- If you are using Lerna workspaces\n' +
+    '  - You have added `@solana-mobile/mobile-wallet-adapter-walletlib` as an explicit dependency, and\n' +
+    '  - You have added `@solana-mobile/mobile-wallet-adapter-walletlib` to the `nohoist` section of your package.json\n' +
+    '- You are not using Expo managed workflow\n';
+
+const SolanaMobileWalletAdapterWalletLib =
+    Platform.OS === 'android' && NativeModules.SolanaMobileWalletAdapterWalletLib
+        ? NativeModules.SolanaMobileWalletAdapterWalletLib
+        : new Proxy(
+              {},
+              {
+                  get() {
+                      throw new Error(
+                          Platform.OS !== 'android'
+                              ? 'The package `solana-mobile-wallet-adapter-walletlib` is only compatible with React Native Android'
+                              : LINKING_ERROR,
+                      );
+                  },
+              },
+          );
+
+type ReactNativeError = Error & { code?: string; userInfo?: Record<string, unknown> };
+
+function handleError(e: any): never {
+    if (e instanceof Error) {
+        const { code, message } = e as ReactNativeError;
+        if (code && code in SolanaMWAWalletLibErrorCode) {
+            throw new SolanaMWAWalletLibError(code as SolanaMWAWalletLibErrorCode, message);
+        }
+    }
+    throw e;
+}
+
+export type MWASessionId = string;
+
+export interface MobileWalletAdapterConfig {
+    maxTransactionsPerSigningRequest: number;
+    maxMessagesPerSigningRequest: number;
+    supportedTransactionVersions: Array<TransactionVersion>;
+    noConnectionWarningTimeoutMs: number;
+    optionalFeatures: IdentifierArray;
+}
+
+export async function initializeMobileWalletAdapterSession(
+    walletName: string,
+    config: MobileWalletAdapterConfig,
+): Promise<MWASessionId> {
+    try {
+        return await initializeScenario(walletName, config);
+    } catch (e) {
+        handleError(e);
+    }
+}
+
+// Create Scenario and establish session with dapp
+function initializeScenario(walletName: string, walletConfig: MobileWalletAdapterConfig): Promise<MWASessionId> {
+    return SolanaMobileWalletAdapterWalletLib.createScenario(walletName, JSON.stringify(walletConfig));
+}

--- a/js/packages/mobile-wallet-adapter-walletlib/src/resolve.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/resolve.ts
@@ -44,7 +44,7 @@ export type SignInPayload = Readonly<{
     notBefore?: string;
     requestId?: string;
     resources?: readonly string[];
-}>
+}>;
 
 export type Base64EncodedAddress = string;
 type Base64EncodedSignedMessage = string;
@@ -88,7 +88,7 @@ export type AuthorizeDappRequest = Readonly<{
     chain: string;
     appIdentity?: AppIdentity;
     features?: IdentifierArray;
-    addresses?: [String];
+    addresses?: [string];
     signInPayload?: SignInPayload;
 }> &
     IMWARequest;
@@ -183,7 +183,7 @@ export type SignInResult = Readonly<{
     signature_type?: string;
 }>;
 export type AuthorizeDappCompleteResponse = Readonly<{
-    accounts: Array<AuthorizedAccount>
+    accounts: Array<AuthorizedAccount>;
     walletUriBase?: string;
     authorizationScope?: Uint8Array;
     signInResult?: SignInResult;

--- a/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
@@ -43,7 +43,6 @@ export interface MobileWalletAdapterConfig {
 export function useMobileWalletAdapterSession(
     walletName: string,
     config: MobileWalletAdapterConfig,
-    associationUri: string,
     handleRequest: (request: MWARequest) => void,
     handleSessionEvent: (sessionEvent: MWASessionEvent) => void,
 ) {
@@ -59,7 +58,7 @@ export function useMobileWalletAdapterSession(
                 console.warn('Unexpected native event type');
             }
         });
-        initializeScenario(walletName, config, associationUri);
+        initializeScenario(walletName, config);
 
         return () => {
             listener.remove();
@@ -85,17 +84,13 @@ export function initializeMWAEventListener(
     return listener;
 }
 
-export function initializeMobileWalletAdapterSession(
-    walletName: string,
-    config: MobileWalletAdapterConfig,
-    associationUri: string,
-) {
-    initializeScenario(walletName, config, associationUri);
+export function initializeMobileWalletAdapterSession(walletName: string, config: MobileWalletAdapterConfig) {
+    initializeScenario(walletName, config);
 }
 
 // Create Scenario and establish session with dapp
-function initializeScenario(walletName: string, walletConfig: MobileWalletAdapterConfig, associationUri: string) {
-    SolanaMobileWalletAdapterWalletLib.createScenario(walletName, associationUri, JSON.stringify(walletConfig));
+function initializeScenario(walletName: string, walletConfig: MobileWalletAdapterConfig) {
+    SolanaMobileWalletAdapterWalletLib.createScenario(walletName, JSON.stringify(walletConfig));
 }
 
 function isMWARequest(nativeEvent: any): boolean {

--- a/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/useMobileWalletAdapterSession.ts
@@ -1,44 +1,12 @@
-import type { TransactionVersion } from '@solana/web3.js';
-import type { IdentifierArray } from '@wallet-standard/core';
 import { useEffect } from 'react';
-import { EmitterSubscription, NativeEventEmitter, NativeModules, Platform } from 'react-native';
 
-import { MWASessionEvent, MWASessionEventType } from './mwaSessionEvents.js';
-import { MWARequest, MWARequestType } from './resolve.js';
-
-const LINKING_ERROR =
-    `The package 'solana-mobile-wallet-adapter-walletlib' doesn't seem to be linked. Make sure: \n\n` +
-    '- You rebuilt the app after installing the package\n' +
-    '- If you are using Lerna workspaces\n' +
-    '  - You have added `@solana-mobile/mobile-wallet-adapter-walletlib` as an explicit dependency, and\n' +
-    '  - You have added `@solana-mobile/mobile-wallet-adapter-walletlib` to the `nohoist` section of your package.json\n' +
-    '- You are not using Expo managed workflow\n';
-
-const SolanaMobileWalletAdapterWalletLib =
-    Platform.OS === 'android' && NativeModules.SolanaMobileWalletAdapterWalletLib
-        ? NativeModules.SolanaMobileWalletAdapterWalletLib
-        : new Proxy(
-              {},
-              {
-                  get() {
-                      throw new Error(
-                          Platform.OS !== 'android'
-                              ? 'The package `solana-mobile-wallet-adapter-walletlib` is only compatible with React Native Android'
-                              : LINKING_ERROR,
-                      );
-                  },
-              },
-          );
-
-const MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME = 'MobileWalletAdapterServiceRequestBridge';
-
-export interface MobileWalletAdapterConfig {
-    maxTransactionsPerSigningRequest: number;
-    maxMessagesPerSigningRequest: number;
-    supportedTransactionVersions: Array<TransactionVersion>;
-    noConnectionWarningTimeoutMs: number;
-    optionalFeatures: IdentifierArray;
-}
+import {
+    initializeMobileWalletAdapterSession,
+    MobileWalletAdapterConfig,
+} from './initializeMobileWalletAdapterSession.js';
+import { initializeMWAEventListener } from './initializeMWAEventListener.js';
+import { MWASessionEvent } from './mwaSessionEvents.js';
+import { MWARequest } from './resolve.js';
 
 export function useMobileWalletAdapterSession(
     walletName: string,
@@ -46,57 +14,18 @@ export function useMobileWalletAdapterSession(
     handleRequest: (request: MWARequest) => void,
     handleSessionEvent: (sessionEvent: MWASessionEvent) => void,
 ) {
-    // Start native event listeners
     useEffect(() => {
-        const mwaEventEmitter = new NativeEventEmitter();
-        const listener = mwaEventEmitter.addListener(MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME, (nativeEvent) => {
-            if (isMWARequest(nativeEvent)) {
-                handleRequest(nativeEvent as MWARequest);
-            } else if (isMWASessionEvent(nativeEvent)) {
-                handleSessionEvent(nativeEvent as MWASessionEvent);
-            } else {
-                console.warn('Unexpected native event type');
+        async function startSession() {
+            try {
+                await initializeMobileWalletAdapterSession(walletName, config);
+            } catch (e) {
+                console.error(e);
             }
-        });
-        initializeScenario(walletName, config);
-
+        }
+        const listener = initializeMWAEventListener(handleRequest, handleSessionEvent);
+        startSession();
         return () => {
             listener.remove();
         };
     }, []);
-}
-
-export function initializeMWAEventListener(
-    handleRequest: (request: MWARequest) => void,
-    handleSessionEvent: (sessionEvent: MWASessionEvent) => void,
-): EmitterSubscription {
-    const mwaEventEmitter = new NativeEventEmitter();
-    const listener = mwaEventEmitter.addListener(MOBILE_WALLET_ADAPTER_EVENT_BRIDGE_NAME, (nativeEvent) => {
-        if (isMWARequest(nativeEvent)) {
-            handleRequest(nativeEvent as MWARequest);
-        } else if (isMWASessionEvent(nativeEvent)) {
-            handleSessionEvent(nativeEvent as MWASessionEvent);
-        } else {
-            console.warn('Unexpected native event type');
-        }
-    });
-
-    return listener;
-}
-
-export function initializeMobileWalletAdapterSession(walletName: string, config: MobileWalletAdapterConfig) {
-    initializeScenario(walletName, config);
-}
-
-// Create Scenario and establish session with dapp
-function initializeScenario(walletName: string, walletConfig: MobileWalletAdapterConfig) {
-    SolanaMobileWalletAdapterWalletLib.createScenario(walletName, JSON.stringify(walletConfig));
-}
-
-function isMWARequest(nativeEvent: any): boolean {
-    return Object.values(MWARequestType).includes(nativeEvent.__type);
-}
-
-function isMWASessionEvent(nativeEvent: any) {
-    return Object.values(MWASessionEventType).includes(nativeEvent.__type);
 }


### PR DESCRIPTION
# Changes

- Removed the `associationUri` parameter from `initializeMobileWalletAdapterSession` and `useMobileWalletAdapterSession` from `v1.4.0` **(breaking)**
- Instead, the `associationUri` is directly derived from `reactContext.getCurrentActivity().getIntent()` within the Kotlin native module