### PR TITLE
Walletlib-RN v1.4.0-beta2

### DIFF
--- a/js/packages/mobile-wallet-adapter-walletlib/README.md
+++ b/js/packages/mobile-wallet-adapter-walletlib/README.md
@@ -19,7 +19,7 @@ import {
   initializeMWAEventListener,
   MWARequest,
   MWASessionEvent,
-} from '@solana-mobile/mobile-wallet-adapter-protocol-walletlib';
+} from '@solana-mobile/mobile-wallet-adapter-walletlib';
 
 const listener: EmitterSubscription = initializeMWAEventListener(
   (request: MWARequest) => { /* ... */ },
@@ -113,7 +113,7 @@ An example of handling an `AuthorizationRequest`:
 ```typescript
 import {
   AuthorizeDappResponse
-} from '@solana-mobile/mobile-wallet-adapter-protocol-walletlib';
+} from '@solana-mobile/mobile-wallet-adapter-walletlib';
 
 const response = {
   publicKey: Keypair.generate().publicKey.toBytes(),
@@ -127,7 +127,7 @@ There are a a selection of "fail" responses that you can return to the dApp. The
 ```typescript
 import {
   UserDeclinedResponse
-} from '@solana-mobile/mobile-wallet-adapter-protocol-walletlib';
+} from '@solana-mobile/mobile-wallet-adapter-walletlib';
 
 const response = {
   failReason: MWARequestFailReason.UserDeclined,

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-walletlib",
     "description": "A React Native wrapper of the Solana Mobile, Mobile Wallet Adapter Wallet Library. Wallet apps can use this to handle dapp requests for signing and sending.",
-    "version": "1.4.0-beta1",
+    "version": "1.4.0-beta2",
     "author": "Michael Sulistio <mike.sulistio@solanamobile.com>",
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",

--- a/js/packages/mobile-wallet-adapter-walletlib/src/resolve.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/resolve.ts
@@ -170,7 +170,7 @@ export type InvalidSignaturesResponse = Readonly<{
 
 /* Authorize Dapp */
 export type AuthorizedAccount = Readonly<{
-    publicKey: Base64EncodedAddress;
+    publicKey: Uint8Array;
     accountLabel?: string;
     icon?: string;
     chains?: IdentifierArray;


### PR DESCRIPTION
# v1.4.0-beta2 Changes
- Previously, the `AuthorizedAccount` object's `publicKey` parameter was incorrectly type labeled as `Base64EncodedAddress`, when the kotlin side is really expecting a `ByteArray`. 
   - Fixed by changing type from `Base64EncodedAddress` -> `Uint8Array`
   - Sample app doesn't need to be updated, because it is already passing in a `Uint8Array`
   
- Import typo in readme is fixed