### PR TITLE
JS Packages 2.1.5 Version Bump

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -1,9 +1,12 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-protocol-web3js",
     "description": "A convenience wrapper that enables you to call Solana Mobile Stack protocol methods using objects from @solana/web3.js",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "author": "Steven Luscher <steven.luscher@solanamobile.com>",
-    "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/solana-mobile/mobile-wallet-adapter.git"
+    },
     "license": "Apache-2.0",
     "type": "module",
     "sideEffects": false,
@@ -41,7 +44,7 @@
         "@solana/web3.js": "^1.58.0"
     },
     "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.1.4",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.1.5",
         "bs58": "^5.0.0",
         "js-base64": "^3.7.5"
     },

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -1,9 +1,12 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-protocol",
     "description": "An implementation of the Solana Mobile Mobile Wallet Adapter protocol. Use this to open a session with a mobile wallet app, and to issue API calls to it.",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "author": "Steven Luscher <steven.luscher@solanamobile.com>",
-    "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/solana-mobile/mobile-wallet-adapter.git"
+    },
     "license": "Apache-2.0",
     "type": "module",
     "sideEffects": false,

--- a/js/packages/wallet-adapter-mobile/package.json
+++ b/js/packages/wallet-adapter-mobile/package.json
@@ -1,9 +1,12 @@
 {
     "name": "@solana-mobile/wallet-adapter-mobile",
     "description": "An adapter for mobile wallet apps that conform to the Solana Mobile Wallet Adapter protocol",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "author": "Steven Luscher <steven.luscher@solanamobile.com>",
-    "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/solana-mobile/mobile-wallet-adapter.git"
+    },
     "license": "Apache-2.0",
     "type": "module",
     "sideEffects": false,
@@ -41,7 +44,7 @@
         "@solana/web3.js": "^1.58.0"
     },
     "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.1.4",
+        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.1.5",
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-standard-features": "^1.2.0",
         "js-base64": "^3.7.5",


### PR DESCRIPTION
published `mobile-wallet-adapter-protocol`, `mobile-wallet-adapter-protocol-web3js` and `wallet-adapter-mobile`  version 2.1.5. 

walletlib and the new wallet-standard lib not included here - they are still exp and need to be cleaned up and synced versions