### PR TITLE
Add codegenSpec to npm files

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-protocol-web3js",
     "description": "A convenience wrapper that enables you to call Solana Mobile Stack protocol methods using objects from @solana/web3.js",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "author": "Steven Luscher <steven.luscher@solanamobile.com>",
     "repository": {
         "type": "git",
@@ -44,7 +44,7 @@
         "@solana/web3.js": "^1.58.0"
     },
     "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.1.6",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.1.7",
         "bs58": "^5.0.0",
         "js-base64": "^3.7.5"
     },

--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-protocol-web3js",
     "description": "A convenience wrapper that enables you to call Solana Mobile Stack protocol methods using objects from @solana/web3.js",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "author": "Steven Luscher <steven.luscher@solanamobile.com>",
     "repository": {
         "type": "git",
@@ -44,7 +44,7 @@
         "@solana/web3.js": "^1.58.0"
     },
     "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.1.5",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.1.6",
         "bs58": "^5.0.0",
         "js-base64": "^3.7.5"
     },

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-protocol",
     "description": "An implementation of the Solana Mobile Mobile Wallet Adapter protocol. Use this to open a session with a mobile wallet app, and to issue API calls to it.",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "author": "Steven Luscher <steven.luscher@solanamobile.com>",
     "repository": {
         "type": "git",

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -28,6 +28,7 @@
     },
     "files": [
         "android",
+        "src/codegenSpec",
         "!android/build",
         "lib",
         "LICENSE"

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/mobile-wallet-adapter-protocol",
     "description": "An implementation of the Solana Mobile Mobile Wallet Adapter protocol. Use this to open a session with a mobile wallet app, and to issue API calls to it.",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "author": "Steven Luscher <steven.luscher@solanamobile.com>",
     "repository": {
         "type": "git",


### PR DESCRIPTION
# Context

The codegenSpec required for React Native New Architecture is defined in `src/codegenSpec/NativeSolanaMobileWalletAdapter.ts`. 

This is used in the build process, no matter whether `newArchitecture` is enabled or not.

# Problem

`src/codegenSpec` is not a tracked directory in our npm package. This means when the user downloads the package from npm  their local copy of `@solana-mobile/mobile-wallet-adapter`(inside their `node_modules`) is missing the codegenSpec.

When they try building (with newArchitecture both `true` or `false`) it causes the error:
```
Error: ENOENT: no such file or directory, lstat '/private/var/folders/27/8kp6nvsx7zz5zn8ft_zysc600000gn/T/eas-build-local-nodejs/3e99db7c-5d88-42a6-a01a-f56c0b0781ea/build/node_modules/@solana-mobile/mobile-wallet-adapter-protocol/src/codegenSpec'
```

# Fix

I've added `src/codegenSpec/` to the `files` property in the `package.json`. This willl tell npm to include `src/codegenSpec/NativeSolanaMobileWalletAdapter.ts` in the hosted package.

# Test Plan

- I've tested that manually adding the codegenSpec to the node_modules fixes the build issue.
