### PR TITLE
Remove web3js usage from wallet-standard-mobile

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -57,7 +57,6 @@
         "shx": "^0.3.4"
     },
     "peerDependencies": {
-        "@solana/web3.js": "^1.58.0",
         "react-native": ">0.69"
     },
     "codegenConfig": {

--- a/js/packages/wallet-standard-mobile/package.json
+++ b/js/packages/wallet-standard-mobile/package.json
@@ -37,11 +37,8 @@
         "postbuild": "cross-env echo {\\\"type\\\":\\\"commonjs\\\"} | npx json > lib/cjs/package.json && echo {\\\"type\\\":\\\"module\\\"} | npx json > lib/esm/package.json",
         "prepublishOnly": "agadoo"
     },
-    "peerDependencies": {
-        "@solana/web3.js": "^1.58.0"
-    },
     "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.0",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.0",
         "@solana/wallet-standard-chains": "^1.1.0",
         "@solana/wallet-standard-features": "^1.2.0",
         "@wallet-standard/base": "^1.0.1",
@@ -51,7 +48,6 @@
         "qrcode": "^1.5.4"
     },
     "devDependencies": {
-        "@solana/web3.js": "^1.95.3",
         "@types/qrcode": "^1.5.5",
         "agadoo": "^3.0.0",
         "cross-env": "^7.0.3",

--- a/js/packages/wallet-standard-mobile/src/__forks__/react-native/createDefaultAuthorizationCache.ts
+++ b/js/packages/wallet-standard-mobile/src/__forks__/react-native/createDefaultAuthorizationCache.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { Authorization, AuthorizationCache } from '../../wallet.js';
-import { PublicKey } from '@solana/web3.js';
+import base58 from 'bs58';
 
 const CACHE_KEY = 'SolanaMobileWalletAdapterWalletStandardDefaultAuthorizationCache';
 
@@ -22,7 +22,7 @@ export default function createDefaultAuthorizationCache(): AuthorizationCache {
                             ...account,
                             publicKey: 'publicKey' in account
                                 ? new Uint8Array(Object.values(account.publicKey)) // Rebuild publicKey for WalletAccount
-                                : new PublicKey(account.address).toBytes(), // Fallback, get publicKey from address
+                                : base58.decode(account.address), // Fallback, get publicKey from address
                         }
                     })
                     return { ...parsed, accounts: parsedAccounts }

--- a/js/packages/wallet-standard-mobile/src/createDefaultAuthorizationCache.ts
+++ b/js/packages/wallet-standard-mobile/src/createDefaultAuthorizationCache.ts
@@ -1,6 +1,6 @@
 import { AuthorizationResult } from '@solana-mobile/mobile-wallet-adapter-protocol';
 import { Authorization, AuthorizationCache } from './wallet';
-import { PublicKey } from '@solana/web3.js';
+import base58 from 'bs58';
 
 const CACHE_KEY = 'SolanaMobileWalletAdapterDefaultAuthorizationCache';
 
@@ -32,7 +32,7 @@ export default function createDefaultAuthorizationCache(): AuthorizationCache {
                             ...account,
                             publicKey: 'publicKey' in account
                                 ? new Uint8Array(Object.values(account.publicKey)) // Rebuild publicKey for WalletAccount
-                                : new PublicKey(account.address).toBytes(), // Fallback, get publicKey from address
+                                : base58.decode(account.address), // Fallback, get publicKey from address
                         }
                     })
                     return { ...parsed, accounts: parsedAccounts }

--- a/js/packages/wallet-standard-mobile/src/solana.ts
+++ b/js/packages/wallet-standard-mobile/src/solana.ts
@@ -3,7 +3,6 @@ import {
     SOLANA_MAINNET_CHAIN, 
     SOLANA_TESTNET_CHAIN 
 } from "@solana/wallet-standard-chains";
-import { Transaction, VersionedTransaction } from "@solana/web3.js";
 
 /** Array of all supported Solana clusters */
 export const MWA_SOLANA_CHAINS = [
@@ -12,8 +11,15 @@ export const MWA_SOLANA_CHAINS = [
     SOLANA_TESTNET_CHAIN,
 ] as const;
 
+// Placeholder types to remove dependency on web3.js
+type LegacyTransaction = { [key: string]: any }; // Placeholder type
+type LegacyVersionedTransaction = LegacyTransaction & { version: number };
+
+/**
+ * @deprecated unused method, will be removed before 1.0 release. Do not use!
+ */
 export function isVersionedTransaction(
-    transaction: Transaction | VersionedTransaction
-): transaction is VersionedTransaction {
+    transaction: LegacyTransaction | LegacyVersionedTransaction
+): transaction is LegacyVersionedTransaction {
     return 'version' in transaction;
 }

--- a/js/packages/wallet-standard-mobile/src/wallet.ts
+++ b/js/packages/wallet-standard-mobile/src/wallet.ts
@@ -16,10 +16,6 @@ import {
     type SolanaSignTransactionFeature,
     type SolanaSignTransactionMethod,
 } from '@solana/wallet-standard-features';
-import { 
-    Transaction as LegacyTransaction,
-    VersionedTransaction
-} from '@solana/web3.js';
 import RemoteConnectionModal from './embedded-modal/remoteConnectionModal.js';
 import {
     type Account,
@@ -27,10 +23,12 @@ import {
     type AuthorizationResult,
     AuthToken,
     GetCapabilitiesAPI,
+    MobileWallet,
     SignInPayload,
     type SolanaMobileWalletAdapterError,
     type SolanaMobileWalletAdapterErrorCode,
-    SolanaSignTransactions,
+    startRemoteScenario,
+    transact,
 } from '@solana-mobile/mobile-wallet-adapter-protocol';
 import type { IdentifierArray, IdentifierString, Wallet, WalletAccount } from '@wallet-standard/base';
 import {
@@ -47,8 +45,6 @@ import {
     type StandardEventsOnMethod,
 } from '@wallet-standard/features';
 import { icon } from './icon';
-import { isVersionedTransaction } from './solana';
-import { transact, startRemoteScenario, Web3MobileWallet } from '@solana-mobile/mobile-wallet-adapter-protocol-web3js';
 import { fromUint8Array, toUint8Array } from './base64Utils';
 import base58 from 'bs58';
 
@@ -319,7 +315,7 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
         }
     }
 
-    #performReauthorization = async (wallet: Web3MobileWallet, authToken: AuthToken, chain: IdentifierString) => {
+    #performReauthorization = async (wallet: MobileWallet, authToken: AuthToken, chain: IdentifierString) => {
         try {
             const mwaAuthorizationResult = await wallet.authorize({
                 auth_token: authToken,
@@ -350,7 +346,7 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
         this.#emit('change', { accounts: this.accounts });
     };
 
-    #transact = async <TReturn>(callback: (wallet: Web3MobileWallet) => TReturn) => {
+    #transact = async <TReturn>(callback: (wallet: MobileWallet) => TReturn) => {
         const walletUriBase = this.#authorization?.wallet_uri_base;
         const config = walletUriBase ? { baseUri: walletUriBase } : undefined;
         const currentConnectionGeneration = this.#connectionGeneration;
@@ -395,16 +391,17 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
         });
     }
 
-    #performSignTransactions = async <T extends LegacyTransaction | VersionedTransaction>(
-        transactions: T[]
+    #performSignTransactions = async(
+        transactions: Uint8Array[]
     ) => {
         const { authToken, chain } = this.#assertIsAuthorized();
         try {
+            const base64Transactions = transactions.map((tx) => { return fromUint8Array(tx) });
             return await this.#transact(async (wallet) => {
                 await this.#performReauthorization(wallet, authToken, chain);
-                const signedTransactions = await wallet.signTransactions({
-                    transactions,
-                });
+                const signedTransactions = (await wallet.signTransactions({
+                    payloads: base64Transactions,
+                })).signed_payloads.map(toUint8Array);
                 return signedTransactions;
             });
         } catch (e) {
@@ -413,7 +410,7 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
     }
 
     #performSignAndSendTransaction = async (
-        transaction: VersionedTransaction,
+        transaction: Uint8Array,
         options?: SolanaSignAndSendTransactionOptions | undefined,
     ) => {
         const { authToken, chain } = this.#assertIsAuthorized();
@@ -424,10 +421,11 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
                     this.#performReauthorization(wallet, authToken, chain)
                 ]);
                 if (capabilities.supports_sign_and_send_transactions) {
-                    const signatures = await wallet.signAndSendTransactions({
+                    const base64Transaction = fromUint8Array(transaction);
+                    const signatures = (await wallet.signAndSendTransactions({
                         ...options,
-                        transactions: [transaction],
-                    });
+                        payloads: [base64Transaction],
+                    })).signatures.map(toUint8Array);
                     return signatures[0];
                 } else {
                     throw new Error('connected wallet does not support signAndSendTransaction')
@@ -443,42 +441,31 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
         const outputs: SolanaSignAndSendTransactionOutput[] = [];
 
         for (const input of inputs) {
-            const transaction = VersionedTransaction.deserialize(input.transaction);
-            const signature = (await this.#performSignAndSendTransaction(transaction, input.options))
-            outputs.push({ signature: base58.decode(signature) })
+            const signature = await this.#performSignAndSendTransaction(input.transaction, input.options)
+            outputs.push({ signature })
         }
 
         return outputs;
     };
 
     #signTransaction: SolanaSignTransactionMethod = async (...inputs) => {
-        const transactions = inputs.map(({ transaction }) => VersionedTransaction.deserialize(transaction));
-        const signedTransactions = await this.#performSignTransactions(transactions);
-        return signedTransactions.map((signedTransaction) => {
-            const serializedTransaction = isVersionedTransaction(signedTransaction)
-                ? signedTransaction.serialize()
-                : new Uint8Array(
-                        (signedTransaction as LegacyTransaction).serialize({
-                            requireAllSignatures: false,
-                            verifySignatures: false,
-                        })
-                    );
-
-            return { signedTransaction: serializedTransaction };
-        });
+        return (await this.#performSignTransactions(inputs.map(({ transaction }) => transaction)))
+            .map((signedTransaction) => {
+                return { signedTransaction }
+            });
     };
 
     #signMessage: SolanaSignMessageMethod = async (...inputs) => {
         const { authToken, chain } = this.#assertIsAuthorized();
         const addresses = inputs.map(({ account }) => fromUint8Array(account.publicKey))
-        const messages = inputs.map(({ message }) => message);
+        const messages = inputs.map(({ message }) => fromUint8Array(message));
         try {
             return await this.#transact(async (wallet) => {
                 await this.#performReauthorization(wallet, authToken, chain);
-                const signedMessages = await wallet.signMessages({
+                const signedMessages = (await wallet.signMessages({
                     addresses: addresses,
                     payloads: messages,
-                });
+                })).signed_payloads.map(toUint8Array);
                 return signedMessages.map((signedMessage) => { 
                     return { signedMessage: signedMessage, signature: signedMessage.slice(-SIGNATURE_LENGTH_IN_BYTES) }
                 });
@@ -554,7 +541,7 @@ export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWallet
     #optionalFeatures: SolanaSignAndSendTransactionFeature | SolanaSignTransactionFeature;
     #onWalletNotFound: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
     #hostAuthority: string;
-    #session: { close: () => void, wallet: Web3MobileWallet } | undefined;
+    #session: { close: () => void, wallet: MobileWallet } | undefined;
 
     get version() {
         return this.#version;
@@ -767,7 +754,7 @@ export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWallet
         }
     }
 
-    #performReauthorization = async (wallet: Web3MobileWallet, authToken: AuthToken, chain: IdentifierString) => {
+    #performReauthorization = async (wallet: MobileWallet, authToken: AuthToken, chain: IdentifierString) => {
         try {
             const mwaAuthorizationResult = await wallet.authorize({
                 auth_token: authToken,
@@ -799,7 +786,7 @@ export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWallet
         this.#emit('change', { accounts: this.accounts });
     };
 
-    #transact = async <TReturn>(callback: (wallet: Web3MobileWallet) => TReturn) => {
+    #transact = async <TReturn>(callback: (wallet: MobileWallet) => TReturn) => {
         const walletUriBase = this.#authorization?.wallet_uri_base;
         const baseConfig = walletUriBase ? { baseUri: walletUriBase } : undefined;
         const remoteConfig = { ...baseConfig, remoteHostAuthority: this.#hostAuthority };
@@ -861,16 +848,16 @@ export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWallet
         });
     }
 
-    #performSignTransactions = async <T extends LegacyTransaction | VersionedTransaction>(
-        transactions: T[]
+    #performSignTransactions = async(
+        transactions: Uint8Array[]
     ) => {
         const { authToken, chain } = this.#assertIsAuthorized();
         try {
             return await this.#transact(async (wallet) => {
                 await this.#performReauthorization(wallet, authToken, chain);
-                const signedTransactions = await wallet.signTransactions({
-                    transactions,
-                });
+                const signedTransactions = (await wallet.signTransactions({
+                    payloads: transactions.map(fromUint8Array),
+                })).signed_payloads.map(toUint8Array);
                 return signedTransactions;
             });
         } catch (e) {
@@ -879,7 +866,7 @@ export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWallet
     }
 
     #performSignAndSendTransaction = async (
-        transaction: VersionedTransaction,
+        transaction: Uint8Array,
         options?: SolanaSignAndSendTransactionOptions | undefined,
     ) => {
         const { authToken, chain } = this.#assertIsAuthorized();
@@ -890,10 +877,10 @@ export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWallet
                     this.#performReauthorization(wallet, authToken, chain)
                 ]);
                 if (capabilities.supports_sign_and_send_transactions) {
-                    const signatures = await wallet.signAndSendTransactions({
+                    const signatures = (await wallet.signAndSendTransactions({
                         ...options,
-                        transactions: [transaction],
-                    });
+                        payloads: [fromUint8Array(transaction)],
+                    })).signatures.map(toUint8Array);
                     return signatures[0];
                 } else {
                     throw new Error('connected wallet does not support signAndSendTransaction')
@@ -907,42 +894,31 @@ export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWallet
     #signAndSendTransaction: SolanaSignAndSendTransactionMethod = async (...inputs) => {
         const outputs: SolanaSignAndSendTransactionOutput[] = [];
         for (const input of inputs) {
-            const transaction = VersionedTransaction.deserialize(input.transaction);
-            const signature = (await this.#performSignAndSendTransaction(transaction, input.options))
-            outputs.push({ signature: base58.decode(signature) })
+            const signature = (await this.#performSignAndSendTransaction(input.transaction, input.options))
+            outputs.push({ signature })
         }
 
         return outputs;
     };
 
     #signTransaction: SolanaSignTransactionMethod = async (...inputs) => {
-        const transactions = inputs.map(({ transaction }) => VersionedTransaction.deserialize(transaction));
-        const signedTransactions = await this.#performSignTransactions(transactions);
-        return signedTransactions.map((signedTransaction) => {
-            const serializedTransaction = isVersionedTransaction(signedTransaction)
-                ? signedTransaction.serialize()
-                : new Uint8Array(
-                        (signedTransaction as LegacyTransaction).serialize({
-                            requireAllSignatures: false,
-                            verifySignatures: false,
-                        })
-                    );
-
-            return { signedTransaction: serializedTransaction };
-        });
+        return (await this.#performSignTransactions(inputs.map(({ transaction }) => transaction)))
+            .map((signedTransaction) => {
+                return { signedTransaction }
+            });
     };
 
     #signMessage: SolanaSignMessageMethod = async (...inputs) => {
         const { authToken, chain } = this.#assertIsAuthorized();
         const addresses = inputs.map(({ account }) => fromUint8Array(account.publicKey))
-        const messages = inputs.map(({ message }) => message);
+        const messages = inputs.map(({ message }) => fromUint8Array(message));
         try {
             return await this.#transact(async (wallet) => {
                 await this.#performReauthorization(wallet, authToken, chain);
-                const signedMessages = await wallet.signMessages({
+                const signedMessages = (await wallet.signMessages({
                     addresses: addresses,
                     payloads: messages,
-                });
+                })).signed_payloads.map(toUint8Array);
                 return signedMessages.map((signedMessage) => { 
                     return { signedMessage: signedMessage, signature: signedMessage.slice(-SIGNATURE_LENGTH_IN_BYTES) }
                 });


### PR DESCRIPTION
wallet-standard-mobile should not depend on @solana/web3.js. This PR removes dependency on our `mobile-wallet-adapter-protocol-web3js` module as it was unnecessary and created a dependency on web3.js 1.x. `wallet-standard-mobile` now uses `mobile-wallet-adapter-protocol` directly (as it always should have)