### PR TITLE
fix: added native export to esm

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -21,8 +21,14 @@
     "exports": {
         "./package.json": "./package.json",
         ".": {
-            "import": "./lib/esm/index.js",
-            "require": "./lib/cjs/index.js",
+            "import": {
+                "react-native": "./lib/esm/index.native.js",
+                "default": "./lib/esm/index.js"
+            },
+            "require": {
+                "react-native": "./lib/cjs/index.native.js",
+                "default": "./lib/cjs/index.js"
+            },
             "types": "./lib/types/index.d.ts"
         }
     },

--- a/js/rollup.config.ts
+++ b/js/rollup.config.ts
@@ -93,6 +93,11 @@ const config: RollupOptions[] = [
         format: 'cjs',
         runtime: 'react-native',
     }),
+    createConfig({
+        bundleName: 'index.native.js',
+        format: 'esm',
+        runtime: 'react-native',
+    }),
 ];
 
 export default config;


### PR DESCRIPTION
This pull request introduces changes to enhance React Native support in the `mobile-wallet-adapter-protocol` package by adding platform-specific entry points for both CommonJS and ES modules. Additionally, the build configuration is updated to generate React Native-specific bundles.

### Enhancements for React Native support:

* [`js/packages/mobile-wallet-adapter-protocol/package.json`](diffhunk://#diff-4b1c599dcf3090b65273e77eb56a79f1290833ed9c343d27cbb9503342a5c634L24-R31): Updated the `exports` field to include platform-specific entry points for React Native. Separate paths are now defined for `react-native` and `default` under both `import` and `require` keys.

### Build configuration updates:

* [`js/rollup.config.ts`](diffhunk://#diff-551fa5f3d3126a29a0f843a57b6230cf7fad6c73187022ce819f1ac8c47c8805R96-R100): Added a new configuration to generate an ES module bundle (`index.native.js`) specifically for React Native, complementing the existing CommonJS bundle.

### Screenshots
After building the package, you can see that `lib/esm` now contains the `index.native.js` file

<img width="232" alt="Screenshot 2025-06-03 at 5 06 03 PM" src="https://github.com/user-attachments/assets/c1d1c0ee-4050-417a-aaaf-9dae1be1005b" />


### Related issue:
https://github.com/solana-mobile/mobile-wallet-adapter/issues/1179