### PR TITLE
Core Js Libs - Clarify Exports

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -8,28 +8,40 @@
         "url": "git+https://github.com/solana-mobile/mobile-wallet-adapter.git"
     },
     "license": "Apache-2.0",
-    "type": "module",
-    "sideEffects": false,
-    "main": "lib/cjs/index.js",
-    "react-native": "lib/cjs/index.native.js",
-    "module": "lib/esm/index.js",
-    "types": "lib/types/index.d.ts",
+    "exports": {
+        "edge-light": {
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "workerd": {
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "browser": {
+            "import": "./lib/cjs/index.browser.js",
+            "require": "./lib/esm/index.browser.js"
+        },
+        "node": {
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "react-native": "./lib/cjs/index.native.js",
+        "types": "./lib/types/index.d.ts"
+    },
     "browser": {
         "./lib/cjs/index.js": "./lib/cjs/index.browser.js",
         "./lib/esm/index.js": "./lib/esm/index.browser.js"
     },
-    "exports": {
-        "./package.json": "./package.json",
-        ".": {
-            "import": "./lib/esm/index.js",
-            "require": "./lib/cjs/index.js",
-            "types": "./lib/types/index.d.ts"
-        }
-    },
+    "main": "lib/cjs/index.js",
+    "module": "lib/esm/index.js",
+    "react-native": "lib/cjs/index.native.js",
+    "types": "lib/types/index.d.ts",
+    "type": "module",
     "files": [
         "lib",
         "LICENSE"
     ],
+    "sideEffects": false,
     "publishConfig": {
         "access": "public"
     },

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -8,24 +8,35 @@
         "url": "git+https://github.com/solana-mobile/mobile-wallet-adapter.git"
     },
     "license": "Apache-2.0",
-    "type": "module",
-    "sideEffects": false,
-    "main": "lib/cjs/index.js",
-    "react-native": "lib/cjs/index.native.js",
-    "module": "lib/esm/index.js",
-    "types": "lib/types/index.d.ts",
+    "exports": {
+        "edge-light": {
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "workerd": {
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "browser": {
+            "import": "./lib/cjs/index.browser.js",
+            "require": "./lib/esm/index.browser.js"
+        },
+        "node": {
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "react-native": "./lib/cjs/index.native.js",
+        "types": "./lib/types/index.d.ts"
+    },
     "browser": {
         "./lib/cjs/index.js": "./lib/cjs/index.browser.js",
         "./lib/esm/index.js": "./lib/esm/index.browser.js"
     },
-    "exports": {
-        "./package.json": "./package.json",
-        ".": {
-            "import": "./lib/esm/index.js",
-            "require": "./lib/cjs/index.js",
-            "types": "./lib/types/index.d.ts"
-        }
-    },
+    "main": "lib/cjs/index.js",
+    "module": "lib/esm/index.js",
+    "react-native": "lib/cjs/index.native.js",
+    "types": "lib/types/index.d.ts",
+    "type": "module",
     "files": [
         "android",
         "src/codegenSpec",
@@ -33,6 +44,7 @@
         "lib",
         "LICENSE"
     ],
+    "sideEffects": false,
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
cleans up package.josn files to clarify exports for each platform. this fixes incompatibility with recent React Native changes enabling package.json exports by default. Confirmed working with React Native 0.79