### PR TITLE
Update Sonatype Publish URLs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,8 +26,8 @@ nexusPublishing {
         sonatype {
             // Username and password provided by ORG_GRADLE_PROJECT_sonatypeUsername and
             // ORG_GRADLE_PROJECT_sonatypeUsername, respectively
-            nexusUrl.set(uri('https://s01.oss.sonatype.org/service/local/'))
-            snapshotRepositoryUrl.set(uri('https://s01.oss.sonatype.org/content/repositories/snapshots/'))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
Update publishing URLs to point to the new central repository now that S01 has been shutdown 