### PR TITLE
Wallet Standard Mobile 0.4.1

### DIFF
--- a/examples/example-web-app/components/SignInButton.tsx
+++ b/examples/example-web-app/components/SignInButton.tsx
@@ -9,7 +9,7 @@ type Props = Readonly<ComponentProps<typeof Button>>;
 
 export default function SignInButton(props: Props) {
     const { connected, signIn } = useWallet();
-    const handleDisconnectClick = useGuardedCallback(async () => {
+    const handleSignInClick = useGuardedCallback(async () => {
         if (signIn) {
             const input: SolanaSignInInput = {
                 domain: window.location.host,
@@ -24,6 +24,6 @@ export default function SignInButton(props: Props) {
             throw new Error('Sign In not available, wallet does not support sign in');
         }
     }, [signIn]);
-    return <Button {...props} disabled={connected} onClick={handleDisconnectClick} />;
+    return <Button {...props} disabled={connected} onClick={handleSignInClick} />;
 }
 

--- a/examples/example-web-app/next-env.d.ts
+++ b/examples/example-web-app/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/example-web-app/pages/_app.tsx
+++ b/examples/example-web-app/pages/_app.tsx
@@ -44,6 +44,15 @@ const ENDPOINT = /*#__PURE__*/ clusterApiUrl(CLUSTER);
 
 const theme = /*#__PURE__*/ createTheme();
 
+function isAndroidMobile() {
+    return (
+        typeof window !== 'undefined' &&
+        window.isSecureContext &&
+        typeof document !== 'undefined' &&
+        /android/i.test(navigator.userAgent)
+    );
+}
+
 function App({ children }: { children: ReactNode }) {
     const { enqueueSnackbar } = useSnackbar();
     const handleWalletError = useCallback(
@@ -67,7 +76,7 @@ function App({ children }: { children: ReactNode }) {
     return (
         <ThemeProvider theme={theme}>
             <ConnectionProvider config={CONNECTION_CONFIG} endpoint={ENDPOINT}>
-                <WalletProvider autoConnect={true} onError={handleWalletError} wallets={adapters}>
+                <WalletProvider autoConnect={isAndroidMobile()} onError={handleWalletError} wallets={adapters}>
                     <WalletModalProvider>{children}</WalletModalProvider>
                 </WalletProvider>
             </ConnectionProvider>

--- a/js/packages/wallet-standard-mobile/package.json
+++ b/js/packages/wallet-standard-mobile/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/wallet-standard-mobile",
     "description": "A wallet-standard wallet for mobile wallet apps that conform to the Solana Mobile Wallet Adapter protocol",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "author": "Marco Martinez <marco.martinez@solana.com>",
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",

--- a/js/packages/wallet-standard-mobile/src/wallet.ts
+++ b/js/packages/wallet-standard-mobile/src/wallet.ts
@@ -515,16 +515,15 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
             }
             const signedInAddress = authorizationResult.sign_in_result.address;
             const signedInAccount = authorizationResult.accounts.find(acc => acc.address == signedInAddress);
-            const wsWalletAccount: WalletAccount = {
-                ...signedInAccount ?? {
-                    address: base58.encode(toUint8Array(signedInAddress))
-                },
-                publicKey: toUint8Array(signedInAddress),
-                chains: signedInAccount?.chains ?? this.#chains,
-                features: signedInAccount?.features ?? authorizationResult.capabilities.features
-            } as WalletAccount;
             return {
-                account: wsWalletAccount,
+                account: {
+                    ...signedInAccount ?? {
+                        address: base58.encode(toUint8Array(signedInAddress))
+                    },
+                    publicKey: toUint8Array(signedInAddress),
+                    chains: signedInAccount?.chains ?? this.#chains,
+                    features: signedInAccount?.features ?? authorizationResult.capabilities.features
+                },
                 signedMessage: toUint8Array(authorizationResult.sign_in_result.signed_message),
                 signature: toUint8Array(authorizationResult.sign_in_result.signature)
             };
@@ -980,14 +979,16 @@ export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWallet
                 throw new Error("Sign in failed, no sign in result returned by wallet");
             }
             const signedInAddress = authorizationResult.sign_in_result.address;
-            const signedInAccount: WalletAccount = {
-                ...authorizationResult.accounts.find(acc => acc.address == signedInAddress) ?? {
-                    address: signedInAddress
-                }, 
-                publicKey: toUint8Array(signedInAddress)
-            } as WalletAccount;
+            const signedInAccount = authorizationResult.accounts.find(acc => acc.address == signedInAddress);
             return {
-                account: signedInAccount,
+                account: {
+                    ...signedInAccount ?? {
+                        address: base58.encode(toUint8Array(signedInAddress))
+                    },
+                    publicKey: toUint8Array(signedInAddress),
+                    chains: signedInAccount?.chains ?? this.#chains,
+                    features: signedInAccount?.features ?? authorizationResult.capabilities.features
+                },
                 signedMessage: toUint8Array(authorizationResult.sign_in_result.signed_message),
                 signature: toUint8Array(authorizationResult.sign_in_result.signature)
             };


### PR DESCRIPTION
- copies the wallet standard sign in fix from #1250 
- disabled auto connect on desktop in the example web app so that Sign In With Solana can be used
- bumps `wallet-standard-mobile@0.4.1`