### PR TITLE
Update remote wallet name

### DIFF
--- a/examples/example-web-app/patches/@solana+wallet-adapter-react-ui+0.9.34.patch
+++ b/examples/example-web-app/patches/@solana+wallet-adapter-react-ui+0.9.34.patch
@@ -1,84 +1,63 @@
 diff --git a/node_modules/@solana/wallet-adapter-react-ui/lib/cjs/WalletListItem.js b/node_modules/@solana/wallet-adapter-react-ui/lib/cjs/WalletListItem.js
-index 0aa2c3a..ef966f1 100644
+index 0aa2c3a..edba2e3 100644
 --- a/node_modules/@solana/wallet-adapter-react-ui/lib/cjs/WalletListItem.js
 +++ b/node_modules/@solana/wallet-adapter-react-ui/lib/cjs/WalletListItem.js
-@@ -8,10 +8,19 @@ const wallet_adapter_base_1 = require("@solana/wallet-adapter-base");
+@@ -8,10 +8,12 @@ const wallet_adapter_base_1 = require("@solana/wallet-adapter-base");
  const react_1 = __importDefault(require("react"));
  const Button_js_1 = require("./Button.js");
  const WalletIcon_js_1 = require("./WalletIcon.js");
-+const { SolanaMobileWalletAdapterWalletName } = require('@solana-mobile/wallet-adapter-mobile');
-+function getIsMwaMobileWeb() {
-+    return (
-+        typeof window !== 'undefined' &&
-+        window.isSecureContext &&
-+        typeof document !== 'undefined' &&
-+        /android/i.test(navigator.userAgent)
-+    );
-+}
++const { SolanaMobileWalletAdapterWalletName, SolanaMobileWalletAdapterRemoteWalletName } = require('@solana-mobile/wallet-adapter-mobile');
  const WalletListItem = ({ handleClick, tabIndex, wallet }) => {
      return (react_1.default.createElement("li", null,
          react_1.default.createElement(Button_js_1.Button, { onClick: handleClick, startIcon: react_1.default.createElement(WalletIcon_js_1.WalletIcon, { wallet: wallet }), tabIndex: tabIndex },
 -            wallet.adapter.name,
-+            wallet.adapter.name === SolanaMobileWalletAdapterWalletName ? (getIsMwaMobileWeb() ? "Use Installed Wallet" : "Use Mobile Phone") : wallet.adapter.name,
++            wallet.adapter.name === SolanaMobileWalletAdapterWalletName ? "Use Installed Wallet" : 
++                (wallet.adapter.name === SolanaMobileWalletAdapterRemoteWalletName ? "Use Mobile Phone" : wallet.adapter.name),
              wallet.readyState === wallet_adapter_base_1.WalletReadyState.Installed && react_1.default.createElement("span", null, "Detected"))));
  };
  exports.WalletListItem = WalletListItem;
 diff --git a/node_modules/@solana/wallet-adapter-react-ui/lib/esm/WalletListItem.js b/node_modules/@solana/wallet-adapter-react-ui/lib/esm/WalletListItem.js
-index a0b24c2..1a7f31f 100644
+index a0b24c2..09baf1b 100644
 --- a/node_modules/@solana/wallet-adapter-react-ui/lib/esm/WalletListItem.js
 +++ b/node_modules/@solana/wallet-adapter-react-ui/lib/esm/WalletListItem.js
-@@ -2,10 +2,19 @@ import { WalletReadyState } from '@solana/wallet-adapter-base';
+@@ -2,10 +2,12 @@ import { WalletReadyState } from '@solana/wallet-adapter-base';
  import React from 'react';
  import { Button } from './Button.js';
  import { WalletIcon } from './WalletIcon.js';
-+import { SolanaMobileWalletAdapterWalletName } from '@solana-mobile/wallet-adapter-mobile';
-+function getIsMwaMobileWeb() {
-+    return (
-+        typeof window !== 'undefined' &&
-+        window.isSecureContext &&
-+        typeof document !== 'undefined' &&
-+        /android/i.test(navigator.userAgent)
-+    );
-+}
++import { SolanaMobileWalletAdapterWalletName, SolanaMobileWalletAdapterRemoteWalletName, } from '@solana-mobile/wallet-adapter-mobile';
  export const WalletListItem = ({ handleClick, tabIndex, wallet }) => {
      return (React.createElement("li", null,
          React.createElement(Button, { onClick: handleClick, startIcon: React.createElement(WalletIcon, { wallet: wallet }), tabIndex: tabIndex },
 -            wallet.adapter.name,
-+            wallet.adapter.name === SolanaMobileWalletAdapterWalletName ? (getIsMwaMobileWeb() ? "Use Installed Wallet" : "Use Mobile Phone") : wallet.adapter.name,
++            wallet.adapter.name === SolanaMobileWalletAdapterWalletName ? "Use Installed Wallet" : 
++                (wallet.adapter.name === SolanaMobileWalletAdapterRemoteWalletName ? "Use Mobile Phone" : wallet.adapter.name),
              wallet.readyState === WalletReadyState.Installed && React.createElement("span", null, "Detected"))));
  };
  //# sourceMappingURL=WalletListItem.js.map
 \ No newline at end of file
 diff --git a/node_modules/@solana/wallet-adapter-react-ui/src/WalletListItem.tsx b/node_modules/@solana/wallet-adapter-react-ui/src/WalletListItem.tsx
-index fb0355e..4cd5f66 100644
+index fb0355e..96a1929 100644
 --- a/node_modules/@solana/wallet-adapter-react-ui/src/WalletListItem.tsx
 +++ b/node_modules/@solana/wallet-adapter-react-ui/src/WalletListItem.tsx
-@@ -5,6 +5,19 @@ import React from 'react';
+@@ -5,6 +5,11 @@ import React from 'react';
  import { Button } from './Button.js';
  import { WalletIcon } from './WalletIcon.js';
  
 +import {
 +    SolanaMobileWalletAdapterWalletName,
++    SolanaMobileWalletAdapterRemoteWalletName,
 +} from '@solana-mobile/wallet-adapter-mobile';
-+
-+function getIsMwaMobileWeb() {
-+    return (
-+        typeof window !== 'undefined' &&
-+        window.isSecureContext &&
-+        typeof document !== 'undefined' &&
-+        /android/i.test(navigator.userAgent)
-+    );
-+}
 +
  export interface WalletListItemProps {
      handleClick: MouseEventHandler<HTMLButtonElement>;
      tabIndex?: number;
-@@ -15,7 +28,7 @@ export const WalletListItem: FC<WalletListItemProps> = ({ handleClick, tabIndex,
+@@ -15,7 +20,8 @@ export const WalletListItem: FC<WalletListItemProps> = ({ handleClick, tabIndex,
      return (
          <li>
              <Button onClick={handleClick} startIcon={<WalletIcon wallet={wallet} />} tabIndex={tabIndex}>
 -                {wallet.adapter.name}
-+                {wallet.adapter.name === SolanaMobileWalletAdapterWalletName ? (getIsMwaMobileWeb() ? "Use Installed Wallet" : "Use Mobile Phone") : wallet.adapter.name}
++                {wallet.adapter.name === SolanaMobileWalletAdapterWalletName ? "Use Installed Wallet" : 
++                    (wallet.adapter.name === SolanaMobileWalletAdapterRemoteWalletName ? "Use Mobile Phone" : wallet.adapter.name)}
                  {wallet.readyState === WalletReadyState.Installed && <span>Detected</span>}
              </Button>
          </li>

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -52,6 +52,8 @@ import {
     createDefaultChainSelector,
     LocalSolanaMobileWalletAdapterWallet,
     RemoteSolanaMobileWalletAdapterWallet,
+    SolanaMobileWalletAdapterWalletName as WalletStandardWalletName,
+    SolanaMobileWalletAdapterRemoteWalletName as WalletStandardRemoteWalletName,
 } from '@solana-mobile/wallet-standard-mobile';
 import { fromUint8Array } from './base64Utils.js';
 import getIsSupported from './getIsSupported.js';
@@ -66,7 +68,8 @@ export interface AddressSelector {
     select(addresses: Base64EncodedAddress[]): Promise<Base64EncodedAddress>;
 }
 
-export const SolanaMobileWalletAdapterWalletName = 'Mobile Wallet Adapter' as WalletName;
+export const SolanaMobileWalletAdapterWalletName = WalletStandardWalletName as WalletName;
+export const SolanaMobileWalletAdapterRemoteWalletName = WalletStandardRemoteWalletName as WalletName;
 
 const SIGNATURE_LENGTH_IN_BYTES = 64;
 

--- a/js/packages/wallet-standard-mobile/src/wallet.ts
+++ b/js/packages/wallet-standard-mobile/src/wallet.ts
@@ -66,6 +66,7 @@ export interface ChainSelector {
 }
 
 export const SolanaMobileWalletAdapterWalletName = 'Mobile Wallet Adapter';
+export const SolanaMobileWalletAdapterRemoteWalletName = 'Remote Mobile Wallet Adapter';
 
 const SIGNATURE_LENGTH_IN_BYTES = 64;
 const DEFAULT_FEATURES = [SolanaSignAndSendTransaction, SolanaSignTransaction, SolanaSignMessage, SolanaSignIn] as const;
@@ -538,7 +539,7 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
 export class RemoteSolanaMobileWalletAdapterWallet implements SolanaMobileWalletAdapterWallet, SolanaMobileWalletAdapterAuthorization {
     readonly #listeners: { [E in StandardEventsNames]?: StandardEventsListeners[E][] } = {};
     readonly #version = '1.0.0' as const; // wallet-standard version
-    readonly #name = SolanaMobileWalletAdapterWalletName;
+    readonly #name = SolanaMobileWalletAdapterRemoteWalletName;
     readonly #url = 'https://solanamobile.com/wallets';
     readonly #icon = icon;
 


### PR DESCRIPTION
Updates the remote wallet/adapter name from "Mobile Wallet Adapter" (same as the local wallet/adapter) to "Remote Mobile Wallet Adapter". This makes it easier to differentiate which version of MWA is in use. 