### PR TITLE
feat: add warnings to `registerMwa` function

### DIFF
--- a/js/packages/wallet-standard-mobile/src/initialize.ts
+++ b/js/packages/wallet-standard-mobile/src/initialize.ts
@@ -18,6 +18,14 @@ export function registerMwa(config: {
     remoteHostAuthority?: string;
     onWalletNotFound: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
 }) {
+    if (typeof window === 'undefined') {
+        console.warn(`MWA not registered: no window object`)
+        return
+    }
+    if (!window.isSecureContext) {
+        console.warn(`MWA not registered: secure context required (https)`)
+        return
+    }
     if (getIsLocalAssociationSupported()) {
         registerWallet(new LocalSolanaMobileWalletAdapterWallet(config))
     } else if (getIsRemoteAssociationSupported() && config.remoteHostAuthority !== undefined) {


### PR DESCRIPTION
This commit adds a warning to the `registerMwa` function to inform the developer about why MWA might not be loaded (either it's not running in a browser, or not in a secure context).

This should help debugging them if they wonder why mobile wallets don't show up.

@Michaelsulistio I decided to use `console.warn` over `console.error`, otherwise Next starts acting up:

<img width="1408" height="1123" alt="image" src="https://github.com/user-attachments/assets/ba1ddfd6-e9ec-4b21-a03d-69c514603ab4" />
