### PR TITLE
refactor: make authorizationCache, chainSelector and onWalletNotFound in registerMwa optional

### DIFF
--- a/js/.changeset/wallet-standard-mobile-optional-register-mwa-config.md
+++ b/js/.changeset/wallet-standard-mobile-optional-register-mwa-config.md
@@ -1,0 +1,5 @@
+---
+'@solana-mobile/wallet-standard-mobile': minor
+---
+
+Make `authorizationCache`, `chainSelector` and `onWalletNotFound` optional in `registerMwa` and the wallet constructors, defaulting to `createDefaultAuthorizationCache()`, `createDefaultChainSelector()` and `createDefaultWalletNotFoundHandler()` respectively. The config shapes are now exported as `SolanaMobileWalletAdapterWalletConfig`, with `LocalSolanaMobileWalletAdapterWalletConfig`, `RemoteSolanaMobileWalletAdapterWalletConfig` and `NostrSolanaMobileWalletAdapterWalletConfig` extending it. Existing callers that pass all properties are unaffected.

--- a/js/packages/wallet-standard-mobile/src/initialize.ts
+++ b/js/packages/wallet-standard-mobile/src/initialize.ts
@@ -10,14 +10,7 @@ import { AppIdentity } from "@solana-mobile/mobile-wallet-adapter-protocol";
 import { IdentifierArray } from "@wallet-standard/base";
 import { getIsLocalAssociationSupported, getIsRemoteAssociationSupported } from "./getIsSupported";
 
-export function registerMwa(config: {
-    appIdentity: AppIdentity;
-    authorizationCache: AuthorizationCache;
-    chains: IdentifierArray;
-    chainSelector: ChainSelector;
-    remoteHostAuthority?: string;
-    onWalletNotFound: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
-}) {
+export function registerMwa(config: RemoteSolanaMobileWalletAdapterWalletOptions) {
     if (getIsLocalAssociationSupported()) {
         registerWallet(new LocalSolanaMobileWalletAdapterWallet(config))
     } else if (getIsRemoteAssociationSupported() && config.remoteHostAuthority !== undefined) {

--- a/js/packages/wallet-standard-mobile/src/initialize.ts
+++ b/js/packages/wallet-standard-mobile/src/initialize.ts
@@ -1,5 +1,3 @@
-import { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
-import { IdentifierArray } from '@wallet-standard/base';
 import { registerWallet } from '@wallet-standard/wallet';
 
 import {
@@ -9,21 +7,13 @@ import {
     isWebView,
 } from './getIsSupported.js';
 import {
-    AuthorizationCache,
-    ChainSelector,
     LocalSolanaMobileWalletAdapterWallet,
     RemoteSolanaMobileWalletAdapterWallet,
-    SolanaMobileWalletAdapterWallet,
+    SolanaMobileWalletAdapterWalletConfig,
 } from './wallet.js';
 
 export function registerMwa(
-    config: {
-        appIdentity: AppIdentity;
-        authorizationCache: AuthorizationCache;
-        chains: IdentifierArray;
-        chainSelector: ChainSelector;
-        onWalletNotFound: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
-    } & ({ remoteHostAuthority?: string } | { nostrRelay: string }),
+    config: SolanaMobileWalletAdapterWalletConfig & ({ remoteHostAuthority?: string } | { nostrRelay: string }),
 ) {
     if (typeof window === 'undefined') {
         console.warn(`MWA not registered: no window object`);

--- a/js/packages/wallet-standard-mobile/src/wallet.ts
+++ b/js/packages/wallet-standard-mobile/src/wallet.ts
@@ -51,6 +51,9 @@ import {
     type StandardEventsOnMethod,
 } from '@wallet-standard/features';
 
+import { createDefaultAuthorizationCache } from './createDefaultAuthorizationCache.js';
+import { createDefaultChainSelector } from './createDefaultChainSelector.js';
+import { createDefaultWalletNotFoundHandler } from './createDefaultWalletNotFoundHandler.js';
 import EmbeddedLoadingSpinner from './embedded-modal/loadingSpinner.js';
 import RemoteConnectionModal from './embedded-modal/remoteConnectionModal.js';
 import { checkLocalNetworkAccessPermission, isLocalWebSocketAvailable } from './getIsSupported.js';
@@ -98,6 +101,26 @@ interface SolanaMobileWalletAdapterAuthorization {
     get isAuthorized(): boolean;
     get currentAuthorization(): Authorization | undefined;
     get cachedAuthorizationResult(): Promise<Authorization | undefined>;
+}
+
+export interface SolanaMobileWalletAdapterWalletConfig {
+    appIdentity: AppIdentity;
+    authorizationCache?: AuthorizationCache;
+    chains: IdentifierArray;
+    chainSelector?: ChainSelector;
+    onWalletNotFound?: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
+}
+
+export interface LocalSolanaMobileWalletAdapterWalletConfig extends SolanaMobileWalletAdapterWalletConfig {
+    nostrRelay?: string;
+}
+
+export interface NostrSolanaMobileWalletAdapterWalletConfig extends SolanaMobileWalletAdapterWalletConfig {
+    nostrRelay: string;
+}
+
+export interface RemoteSolanaMobileWalletAdapterWalletConfig extends SolanaMobileWalletAdapterWalletConfig {
+    remoteHostAuthority: string;
 }
 
 export class LocalSolanaMobileWalletAdapterWallet
@@ -180,20 +203,20 @@ export class LocalSolanaMobileWalletAdapterWallet
         return (this.#authorization?.accounts as WalletAccount[]) ?? [];
     }
 
-    constructor(config: {
-        appIdentity: AppIdentity;
-        authorizationCache: AuthorizationCache;
-        chains: IdentifierArray;
-        chainSelector: ChainSelector;
-        onWalletNotFound: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
-        nostrRelay?: string;
-    }) {
-        this.#authorizationCache = config.authorizationCache;
-        this.#appIdentity = config.appIdentity;
-        this.#chains = config.chains;
-        this.#chainSelector = config.chainSelector;
-        this.#onWalletNotFound = config.onWalletNotFound;
-        this.#nostrRelay = config.nostrRelay;
+    constructor({
+        appIdentity,
+        authorizationCache = createDefaultAuthorizationCache(),
+        chains,
+        chainSelector = createDefaultChainSelector(),
+        onWalletNotFound = createDefaultWalletNotFoundHandler(),
+        nostrRelay,
+    }: LocalSolanaMobileWalletAdapterWalletConfig) {
+        this.#authorizationCache = authorizationCache;
+        this.#appIdentity = appIdentity;
+        this.#chains = chains;
+        this.#chainSelector = chainSelector;
+        this.#onWalletNotFound = onWalletNotFound;
+        this.#nostrRelay = nostrRelay;
         this.#optionalFeatures = {
             // In MWA 1.0, signAndSend is optional and signTransaction is mandatory. Whereas in MWA 2.0+,
             // signAndSend is mandatory and signTransaction is optional (and soft deprecated). As of mid
@@ -699,40 +722,25 @@ export class RemoteSolanaMobileWalletAdapterWallet
         return (this.#authorization?.accounts as WalletAccount[]) ?? [];
     }
 
-    constructor(config: {
-        appIdentity: AppIdentity;
-        authorizationCache: AuthorizationCache;
-        chains: IdentifierArray;
-        chainSelector: ChainSelector;
-        remoteHostAuthority: string;
-        onWalletNotFound: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
-    });
-    constructor(config: {
-        appIdentity: AppIdentity;
-        authorizationCache: AuthorizationCache;
-        chains: IdentifierArray;
-        chainSelector: ChainSelector;
-        nostrRelay: string;
-        onWalletNotFound: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
-    });
-    constructor(
-        config: {
-            appIdentity: AppIdentity;
-            authorizationCache: AuthorizationCache;
-            chains: IdentifierArray;
-            chainSelector: ChainSelector;
-            onWalletNotFound: (mobileWalletAdapter: SolanaMobileWalletAdapterWallet) => Promise<void>;
-        } & ({ remoteHostAuthority: string } | { nostrRelay: string }),
-    ) {
-        this.#authorizationCache = config.authorizationCache;
-        this.#appIdentity = config.appIdentity;
-        this.#chains = config.chains;
-        this.#chainSelector = config.chainSelector;
+    constructor(config: RemoteSolanaMobileWalletAdapterWalletConfig);
+    constructor(config: NostrSolanaMobileWalletAdapterWalletConfig);
+    constructor(config: RemoteSolanaMobileWalletAdapterWalletConfig | NostrSolanaMobileWalletAdapterWalletConfig) {
+        const {
+            appIdentity,
+            authorizationCache = createDefaultAuthorizationCache(),
+            chains,
+            chainSelector = createDefaultChainSelector(),
+            onWalletNotFound = createDefaultWalletNotFoundHandler(),
+        } = config;
+        this.#authorizationCache = authorizationCache;
+        this.#appIdentity = appIdentity;
+        this.#chains = chains;
+        this.#chainSelector = chainSelector;
         this.#relay =
             'remoteHostAuthority' in config
                 ? { kind: 'reflector', domain: config.remoteHostAuthority }
                 : { kind: 'nostr', domain: config.nostrRelay };
-        this.#onWalletNotFound = config.onWalletNotFound;
+        this.#onWalletNotFound = onWalletNotFound;
         this.#optionalFeatures = {
             // In MWA 1.0, signAndSend is optional and signTransaction is mandatory. Whereas in MWA 2.0+,
             // signAndSend is mandatory and signTransaction is optional (and soft deprecated). As of mid

--- a/js/packages/wallet-standard-mobile/test/wallet.test.ts
+++ b/js/packages/wallet-standard-mobile/test/wallet.test.ts
@@ -1112,7 +1112,9 @@ function createRemoteWallet({
     return { authorizationCache, chainSelector, onWalletNotFound, wallet };
 }
 
-type WalletNotFoundHandler = ConstructorParameters<typeof LocalSolanaMobileWalletAdapterWallet>[0]['onWalletNotFound'];
+type WalletNotFoundHandler = NonNullable<
+    ConstructorParameters<typeof LocalSolanaMobileWalletAdapterWallet>[0]['onWalletNotFound']
+>;
 
 function createAuthorizationCache(cachedAuthorization?: Authorization) {
     return {


### PR DESCRIPTION
This commit makes the `authorizationCache`, `chainSelector` and `onWalletNotFound` properties of `registerMwa` optional.

It does so by extracting the `LocalSolanaMobileWalletAdapterWalletOptions` into an object, marking the properties as optional and have `RemoteSolanaMobileWalletAdapterWalletOptions` extend it.

After that, we provide a default value in the constructor so that this function remains working the same, it just needs a few less parameters to set up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified wallet setup by making authorization caching, chain selection, and wallet-not-found handling optional.
  - Added reusable configuration types for local, remote, and Nostr-based wallet connections.
  - Improved connection configuration so relay selection is preserved across supported connection methods.
- **Documentation**
  - Added release notes describing the new optional configuration options and exported configuration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->