### PR TITLE
fix: signature type

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/src/types.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/types.ts
@@ -187,7 +187,7 @@ export type SignInPayloadWithRequiredFields = Partial<SignInPayload> &
 export type SignInResult = Readonly<{
     address: Base64EncodedAddress;
     signed_message: Base64EncodedSignedMessage;
-    signature: Base64EncodedAddress;
+    signature: Base64EncodedSignature;
     signature_type?: string;
 }>;
 

--- a/js/packages/mobile-wallet-adapter-walletlib/src/resolve.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/src/resolve.ts
@@ -47,6 +47,7 @@ export type SignInPayload = Readonly<{
 }>;
 
 export type Base64EncodedAddress = string;
+export type Base64EncodedSignature = string;
 type Base64EncodedSignedMessage = string;
 
 /**
@@ -179,7 +180,7 @@ export type AuthorizedAccount = Readonly<{
 export type SignInResult = Readonly<{
     address: Base64EncodedAddress;
     signed_message: Base64EncodedSignedMessage;
-    signature: Base64EncodedAddress;
+    signature: Base64EncodedSignature;
     signature_type?: string;
 }>;
 export type AuthorizeDappCompleteResponse = Readonly<{


### PR DESCRIPTION
There are multiple instances of improper types for `signatures` being typed to `Base64EncodedAddress` vice the `Base64EncodedSignature`