### PR TITLE
Prevent registering MWA in webviews

### DIFF
--- a/js/packages/wallet-standard-mobile/src/getIsSupported.ts
+++ b/js/packages/wallet-standard-mobile/src/getIsSupported.ts
@@ -16,6 +16,8 @@ export function getIsRemoteAssociationSupported() {
     );
 }
 
+// Source: https://github.com/anza-xyz/wallet-adapter/blob/master/packages/core/react/src/getEnvironment.ts#L14
+// This is the same implementation that gated MWA in the Anza wallet-adapter-react library.
 export function isWebView(userAgentString: string) {
     return /(WebView|Version\/.+(Chrome)\/(\d+)\.(\d+)\.(\d+)\.(\d+)|; wv\).+(Chrome)\/(\d+)\.(\d+)\.(\d+)\.(\d+))/i.test(
         userAgentString

--- a/js/packages/wallet-standard-mobile/src/initialize.ts
+++ b/js/packages/wallet-standard-mobile/src/initialize.ts
@@ -26,6 +26,9 @@ export function registerMwa(config: {
         console.warn(`MWA not registered: secure context required (https)`)
         return
     }
+
+    // Local association technically is possible in a webview, but we prevent registration
+    // by default because it usually fails in the most common cases (e.g wallet browsers).
     if (getIsLocalAssociationSupported() && !isWebView(navigator.userAgent)) {
         registerWallet(new LocalSolanaMobileWalletAdapterWallet(config))
     } else if (getIsRemoteAssociationSupported() && config.remoteHostAuthority !== undefined) {


### PR DESCRIPTION
This change prevents automatic registration of Local MWA in webview environments when calling `registerMwa`

## Reason
While local association is technically possible in a webview, in practice it usually fails in the most common cases (e.g wallet browsers). There are no wallet browsers that support MWA (nor should they) so we just prevent registration and users will stop seeing a non-functional MWA option.

This allow apps to adopt [UX Guidelines](https://docs.solanamobile.com/mobile-wallet-adapter/ux-guidelines#call-connect-directly) where we recommend only using MWA when detected.