### PR TITLE
Fix signTransaction feature typo

### DIFF
--- a/js/packages/wallet-standard-mobile/package.json
+++ b/js/packages/wallet-standard-mobile/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@solana-mobile/wallet-standard-mobile",
     "description": "A wallet-standard wallet for mobile wallet apps that conform to the Solana Mobile Wallet Adapter protocol",
-    "version": "0.4.4",
+    "version": "0.4.4-hotfix.0",
     "author": "Marco Martinez <marco.martinez@solana.com>",
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",

--- a/js/packages/wallet-standard-mobile/src/wallet.ts
+++ b/js/packages/wallet-standard-mobile/src/wallet.ts
@@ -301,7 +301,7 @@ export class LocalSolanaMobileWalletAdapterWallet implements SolanaMobileWalletA
         capabilities: Awaited<ReturnType<GetCapabilitiesAPI['getCapabilities']>>
     ) => {
         // TODO: investigate why using SolanaSignTransactions constant breaks treeshaking
-        const supportsSignTransaction = capabilities.features.includes('solana:signTransaction');//SolanaSignTransactions);
+        const supportsSignTransaction = capabilities.features.includes('solana:signTransaction') || capabilities.features.includes('solana:signTransactions');//SolanaSignTransactions);
         const supportsSignAndSendTransaction = capabilities.supports_sign_and_send_transactions;
         const didCapabilitiesChange = 
             SolanaSignAndSendTransaction in this.features !== supportsSignAndSendTransaction ||


### PR DESCRIPTION
I discovered a typo in the `handleWalletCapabilitiesResult` when checking for the Wallet Standard `signTransaction` feature.

The typo caused a bug where `handleWalletCapabilitiesResult` would always think the wallet did *not* support `signTransaction`, thus removing it from it's advertised `#features` object.

Fix:
`solana:signTransactions` -> `solana:signTransaction`

Impact:
This change will fix a long-running bug with Privy x MWA web apps (see [here](https://github.com/solana-mobile/mobile-wallet-adapter/issues/1364)) where trying to sign a transaction throws an error

```
Error: WalletSignTransactionError: Connected wallet does not support signing transactions
```

This is because the Privy wallet library checks for the presence of the `signTransaction` feature