### PR TITLE
feat(android): add getInstalledWallets and packageName targeting to local association

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/android/src/main/java/com/solanamobile/mobilewalletadapter/reactnative/SolanaMobileWalletAdapterModule.kt
+++ b/js/packages/mobile-wallet-adapter-protocol/android/src/main/java/com/solanamobile/mobilewalletadapter/reactnative/SolanaMobileWalletAdapterModule.kt
@@ -3,6 +3,7 @@ package com.solanamobile.mobilewalletadapter.reactnative
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.util.Log
 import com.facebook.react.bridge.*
@@ -97,6 +98,7 @@ class SolanaMobileWalletAdapterModule(reactContext: ReactApplicationContext) :
             }
             try {
                 val uriPrefix = config?.getString("baseUri")?.let { Uri.parse(it) }
+                val packageName = config?.getString("packageName")
                 val localAssociation =
                     LocalAssociationScenario(
                         CLIENT_TIMEOUT_MS,
@@ -107,6 +109,7 @@ class SolanaMobileWalletAdapterModule(reactContext: ReactApplicationContext) :
                         localAssociation.port,
                         localAssociation.session
                     )
+                packageName?.let { intent.setPackage(it) }
                 withContext(Dispatchers.Main) {
                     sessionTaskId = headlessJsTaskContext.startTask(sessionBackgroundTaskConfig)
                 }
@@ -221,6 +224,25 @@ class SolanaMobileWalletAdapterModule(reactContext: ReactApplicationContext) :
                 }
             }
         } ?: throw NullPointerException("Tried to end a session without an active session")
+    }
+
+    @ReactMethod
+    override fun getInstalledWallets(promise: Promise) {
+        try {
+            val queryIntent = Intent(Intent.ACTION_VIEW, Uri.parse("solana-wallet://"))
+            val pm = reactApplicationContext.packageManager
+            val resolveInfos = pm.queryIntentActivities(queryIntent, PackageManager.MATCH_ALL)
+            val result: WritableArray = WritableNativeArray()
+            for (info in resolveInfos) {
+                val map: WritableMap = WritableNativeMap()
+                map.putString("packageName", info.activityInfo.packageName)
+                map.putString("appName", info.loadLabel(pm).toString())
+                result.pushMap(map)
+            }
+            promise.resolve(result)
+        } catch (e: Throwable) {
+            promise.reject("ERROR_QUERY_WALLETS", e)
+        }
     }
 
     private fun cleanup() {

--- a/js/packages/mobile-wallet-adapter-protocol/android/src/oldarch/SolanaMobileWalletAdapter.kt
+++ b/js/packages/mobile-wallet-adapter-protocol/android/src/oldarch/SolanaMobileWalletAdapter.kt
@@ -13,4 +13,6 @@ internal constructor(context: ReactApplicationContext) : ReactContextBaseJavaMod
     abstract fun invoke(method: String, params: ReadableMap?, promise: Promise)
 
     abstract fun endSession(promise: Promise)
+
+    abstract fun getInstalledWallets(promise: Promise)
 }

--- a/js/packages/mobile-wallet-adapter-protocol/src/codegenSpec/NativeSolanaMobileWalletAdapter.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/codegenSpec/NativeSolanaMobileWalletAdapter.ts
@@ -1,13 +1,15 @@
 import { TurboModule, TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
-    startSession(config?: { baseUri?: string }): Promise<{
+    startSession(config?: { baseUri?: string; packageName?: string }): Promise<{
         protocol_version: 'legacy' | 'v1';
     }>;
 
     invoke(method: string, params: Object | undefined): Promise<Object>;
 
     endSession(): Promise<boolean>;
+
+    getInstalledWallets(): Promise<Array<{ packageName: string; appName: string }>>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SolanaMobileWalletAdapter') as Spec;


### PR DESCRIPTION
## Summary

  Users who tap "Always open with" on the Android wallet chooser get permanently routed to one
  wallet with no escape from within the dApp. This PR adds two APIs to address that:

  - **`getInstalledWallets()`** — queries `PackageManager` for all apps handling
  `solana-wallet://`, returning `packageName` + `appName` per wallet
  - **`packageName` in `startSession` config** — calls `intent.setPackage()` before
  `startActivityForResult`, bypassing Android intent resolution and any stored "always open with"
  default
  
  This PR implements #1436 