### PR TITLE
Add JS coverage command

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -1,3 +1,4 @@
-node_modules/
 .turbo/
+coverage/
+node_modules/
 packages/*/lib/

--- a/js/package.json
+++ b/js/package.json
@@ -11,7 +11,8 @@
         "lint:check": "eslint . --ext .cjs,.cts,.js,.mjs,.mts,.ts,.tsx",
         "lint:fix": "eslint . --ext .cjs,.cts,.js,.mjs,.mts,.ts,.tsx --fix",
         "publish-packages": "pnpm build && pnpm changeset publish --access public --no-git-checks",
-        "test": "vitest"
+        "test": "vitest",
+        "test:coverage": "vitest run --coverage.enabled"
     },
     "devDependencies": {
         "@changesets/cli": "^2.29.8",
@@ -20,6 +21,7 @@
         "@types/node-fetch": "^2.6.1",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
+        "@vitest/coverage-v8": "^4.1.0",
         "eslint": "^10.2.0",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "jsdom": "^29.0.1",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
             '@typescript-eslint/parser':
                 specifier: ^8.56.1
                 version: 8.56.1(eslint@10.2.0)(typescript@5.6.3)
+            '@vitest/coverage-v8':
+                specifier: ^4.1.0
+                version: 4.1.0(vitest@4.1.0(@types/node@20.19.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@20.19.0)(terser@5.46.0)(yaml@2.8.2)))
             eslint:
                 specifier: ^10.2.0
                 version: 10.2.0
@@ -592,6 +595,13 @@ packages:
                 integrity: sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==,
             }
         engines: { node: ^20.19.0 || >=22.12.0 }
+
+    '@bcoe/v8-coverage@1.0.2':
+        resolution:
+            {
+                integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==,
+            }
+        engines: { node: '>=18' }
 
     '@bramus/specificity@2.4.2':
         resolution:
@@ -2626,6 +2636,18 @@ packages:
             }
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
+    '@vitest/coverage-v8@4.1.0':
+        resolution:
+            {
+                integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==,
+            }
+        peerDependencies:
+            '@vitest/browser': 4.1.0
+            vitest: 4.1.0
+        peerDependenciesMeta:
+            '@vitest/browser':
+                optional: true
+
     '@vitest/expect@4.1.0':
         resolution:
             {
@@ -2891,6 +2913,12 @@ packages:
                 integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==,
             }
         engines: { node: '>=20.19.0' }
+
+    ast-v8-to-istanbul@1.0.0:
+        resolution:
+            {
+                integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==,
+            }
 
     async-function@1.0.0:
         resolution:
@@ -4176,6 +4204,12 @@ packages:
             }
         engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
 
+    html-escaper@2.0.2:
+        resolution:
+            {
+                integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
+            }
+
     http-errors@2.0.1:
         resolution:
             {
@@ -4557,6 +4591,20 @@ packages:
             }
         engines: { node: '>=8' }
 
+    istanbul-lib-report@3.0.1:
+        resolution:
+            {
+                integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==,
+            }
+        engines: { node: '>=10' }
+
+    istanbul-reports@3.2.0:
+        resolution:
+            {
+                integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
+            }
+        engines: { node: '>=8' }
+
     iterate-iterator@1.0.2:
         resolution:
             {
@@ -4644,6 +4692,12 @@ packages:
         resolution:
             {
                 integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==,
+            }
+
+    js-tokens@10.0.0:
+        resolution:
+            {
+                integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==,
             }
 
     js-tokens@4.0.0:
@@ -4813,6 +4867,19 @@ packages:
             {
                 integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
             }
+
+    magicast@0.5.2:
+        resolution:
+            {
+                integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==,
+            }
+
+    make-dir@4.0.0:
+        resolution:
+            {
+                integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==,
+            }
+        engines: { node: '>=10' }
 
     makeerror@1.0.12:
         resolution:
@@ -7038,6 +7105,8 @@ snapshots:
             '@babel/helper-string-parser': 8.0.0-rc.2
             '@babel/helper-validator-identifier': 8.0.0-rc.2
 
+    '@bcoe/v8-coverage@1.0.2': {}
+
     '@bramus/specificity@2.4.2':
         dependencies:
             css-tree: 3.2.1
@@ -8437,6 +8506,20 @@ snapshots:
             '@typescript-eslint/types': 8.56.1
             eslint-visitor-keys: 5.0.1
 
+    '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@20.19.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@20.19.0)(terser@5.46.0)(yaml@2.8.2)))':
+        dependencies:
+            '@bcoe/v8-coverage': 1.0.2
+            '@vitest/utils': 4.1.0
+            ast-v8-to-istanbul: 1.0.0
+            istanbul-lib-coverage: 3.2.2
+            istanbul-lib-report: 3.0.1
+            istanbul-reports: 3.2.0
+            magicast: 0.5.2
+            obug: 2.1.1
+            std-env: 4.0.0
+            tinyrainbow: 3.1.0
+            vitest: 4.1.0(@types/node@20.19.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@20.19.0)(terser@5.46.0)(yaml@2.8.2))
+
     '@vitest/expect@4.1.0':
         dependencies:
             '@standard-schema/spec': 1.1.0
@@ -8602,6 +8685,12 @@ snapshots:
             '@babel/parser': 8.0.0-rc.2
             estree-walker: 3.0.3
             pathe: 2.0.3
+
+    ast-v8-to-istanbul@1.0.0:
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.31
+            estree-walker: 3.0.3
+            js-tokens: 10.0.0
 
     async-function@1.0.0: {}
 
@@ -9457,6 +9546,8 @@ snapshots:
         transitivePeerDependencies:
             - '@noble/hashes'
 
+    html-escaper@2.0.2: {}
+
     http-errors@2.0.1:
         dependencies:
             depd: 2.0.0
@@ -9669,6 +9760,17 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
+    istanbul-lib-report@3.0.1:
+        dependencies:
+            istanbul-lib-coverage: 3.2.2
+            make-dir: 4.0.0
+            supports-color: 7.2.0
+
+    istanbul-reports@3.2.0:
+        dependencies:
+            html-escaper: 2.0.2
+            istanbul-lib-report: 3.0.1
+
     iterate-iterator@1.0.2: {}
 
     iterate-value@1.0.2:
@@ -9767,6 +9869,8 @@ snapshots:
             supports-color: 8.1.1
 
     js-base64@3.7.8: {}
+
+    js-tokens@10.0.0: {}
 
     js-tokens@4.0.0: {}
 
@@ -9870,6 +9974,16 @@ snapshots:
     magic-string@0.30.21:
         dependencies:
             '@jridgewell/sourcemap-codec': 1.5.5
+
+    magicast@0.5.2:
+        dependencies:
+            '@babel/parser': 7.29.0
+            '@babel/types': 7.29.0
+            source-map-js: 1.2.1
+
+    make-dir@4.0.0:
+        dependencies:
+            semver: 7.7.4
 
     makeerror@1.0.12:
         dependencies:

--- a/js/vitest.config.ts
+++ b/js/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
+        coverage: {
+            include: ['packages/*/src/**/*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}'],
+            reportOnFailure: true,
+            reporter: ['html', 'text'],
+            skipFull: true,
+        },
         environmentOptions: {
             jsdom: {
                 url: 'https://example.test',


### PR DESCRIPTION
Add a Vitest coverage script in the JS workspace and enable HTML and text coverage reports for package source files.

Ignore the generated coverage directory and add the V8 coverage provider so the report can be opened locally from `js/coverage/index.html`.

This is useful to get visual overview of what code needs more testing.

To use this, run the following command from the root of the repo:

```shell
pnpm run -C js test:coverage
```

Then you can view it:

```shell
# open it over the filesystem
open js/coverage/index.html
# host it over http
pnpx serve js/coverage/
```