### PR TITLE
Add mobile-wallet-adapter-protocol helper tests

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/test/associationPort.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/associationPort.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { assertAssociationPort, getRandomAssociationPort } from '../src/associationPort.js';
+import { SolanaMobileWalletAdapterErrorCode } from '../src/errors.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('associationPort', () => {
+    it('accepts association ports at the supported boundaries', () => {
+        expect(assertAssociationPort(49152)).toBe(49152);
+        expect(assertAssociationPort(65535)).toBe(65535);
+    });
+
+    it('rejects association ports below the supported range', () => {
+        expect(() => assertAssociationPort(49151)).toThrowError(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_ASSOCIATION_PORT_OUT_OF_RANGE,
+                data: { port: 49151 },
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+    });
+
+    it('rejects association ports above the supported range', () => {
+        expect(() => assertAssociationPort(65536)).toThrowError(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_ASSOCIATION_PORT_OUT_OF_RANGE,
+                data: { port: 65536 },
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+    });
+
+    it('derives the lowest valid association port from Math.random', () => {
+        vi.spyOn(Math, 'random').mockReturnValue(0);
+
+        expect(getRandomAssociationPort()).toBe(49152);
+    });
+
+    it('derives the highest valid association port from Math.random', () => {
+        vi.spyOn(Math, 'random').mockReturnValue(0.99999);
+
+        expect(getRandomAssociationPort()).toBe(65535);
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/createHelloReq.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/createHelloReq.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import createHelloReq from '../src/createHelloReq.js';
+
+const ASSOCIATION_PRIVATE_KEY = {} as CryptoKey;
+const ECDH_PUBLIC_KEY = {} as CryptoKey;
+const EXPORTED_PUBLIC_KEY = Uint8Array.of(1, 2, 3);
+const SIGNATURE = Uint8Array.of(4, 5, 6, 7);
+
+const { mockExportKey, mockSign } = vi.hoisted(() => ({
+    mockExportKey: vi.fn(),
+    mockSign: vi.fn(),
+}));
+
+beforeEach(() => {
+    mockExportKey.mockResolvedValue(EXPORTED_PUBLIC_KEY.buffer);
+    mockSign.mockResolvedValue(SIGNATURE.buffer);
+    vi.stubGlobal('crypto', {
+        subtle: {
+            exportKey: mockExportKey,
+            sign: mockSign,
+        },
+    });
+});
+
+afterEach(() => {
+    mockExportKey.mockReset();
+    mockSign.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('createHelloReq', () => {
+    it('concatenates the exported public key and signature', async () => {
+        const helloReq = await createHelloReq(ECDH_PUBLIC_KEY, ASSOCIATION_PRIVATE_KEY);
+
+        expect(mockExportKey).toHaveBeenCalledWith('raw', ECDH_PUBLIC_KEY);
+        expect(mockSign).toHaveBeenCalledWith(
+            { hash: 'SHA-256', name: 'ECDSA' },
+            ASSOCIATION_PRIVATE_KEY,
+            EXPORTED_PUBLIC_KEY.buffer,
+        );
+        expect(helloReq).toEqual(Uint8Array.of(1, 2, 3, 4, 5, 6, 7));
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/createSIWSMessage.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/createSIWSMessage.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSIWSMessage, createSIWSMessageBase64Url } from '../src/createSIWSMessage.js';
+
+const PAYLOAD = {
+    address: 'Address123',
+    chainId: 'solana:mainnet',
+    domain: 'example.com',
+    expirationTime: '2024-01-03T03:04:05.000Z',
+    issuedAt: '2024-01-02T03:04:05.000Z',
+    nonce: 'nonce-123',
+    notBefore: '2024-01-02T03:00:00.000Z',
+    requestId: 'request-123',
+    resources: ['https://example.com', 'ipfs://example'],
+    statement: 'Sign in to continue.',
+    uri: 'https://example.com/login',
+    version: '1',
+} as const;
+
+const EXPECTED_MESSAGE = `example.com wants you to sign in with your Solana account:
+Address123
+
+Sign in to continue.
+
+URI: https://example.com/login
+Version: 1
+Chain ID: solana:mainnet
+Nonce: nonce-123
+Issued At: 2024-01-02T03:04:05.000Z
+Expiration Time: 2024-01-03T03:04:05.000Z
+Not Before: 2024-01-02T03:00:00.000Z
+Request ID: request-123
+Resources:
+- https://example.com
+- ipfs://example`;
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('createSIWSMessage', () => {
+    it('creates a sign-in message with the expected field order', () => {
+        expect(createSIWSMessage(PAYLOAD)).toBe(EXPECTED_MESSAGE);
+    });
+
+    it('encodes the sign-in message as base64url', () => {
+        const btoaSpy = vi.spyOn(window, 'btoa').mockReturnValue('abc+/==');
+
+        expect(createSIWSMessageBase64Url(PAYLOAD)).toBe('abc-_');
+        expect(btoaSpy).toHaveBeenCalledWith(EXPECTED_MESSAGE);
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/generateAssociationKeypair.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/generateAssociationKeypair.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import generateAssociationKeypair from '../src/generateAssociationKeypair.js';
+
+const KEYPAIR = {
+    privateKey: {} as CryptoKey,
+    publicKey: {} as CryptoKey,
+} as const satisfies CryptoKeyPair;
+
+const { mockGenerateKey } = vi.hoisted(() => ({
+    mockGenerateKey: vi.fn(),
+}));
+
+beforeEach(() => {
+    mockGenerateKey.mockResolvedValue(KEYPAIR);
+    vi.stubGlobal('crypto', {
+        subtle: {
+            generateKey: mockGenerateKey,
+        },
+    });
+});
+
+afterEach(() => {
+    mockGenerateKey.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('generateAssociationKeypair', () => {
+    it('generates a non-extractable ECDSA P-256 keypair for signing', async () => {
+        await expect(generateAssociationKeypair()).resolves.toBe(KEYPAIR);
+        expect(mockGenerateKey).toHaveBeenCalledWith(
+            {
+                name: 'ECDSA',
+                namedCurve: 'P-256',
+            },
+            false,
+            ['sign'],
+        );
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/generateECDHKeypair.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/generateECDHKeypair.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import generateECDHKeypair from '../src/generateECDHKeypair.js';
+
+const KEYPAIR = {
+    privateKey: {} as CryptoKey,
+    publicKey: {} as CryptoKey,
+} as const satisfies CryptoKeyPair;
+
+const { mockGenerateKey } = vi.hoisted(() => ({
+    mockGenerateKey: vi.fn(),
+}));
+
+beforeEach(() => {
+    mockGenerateKey.mockResolvedValue(KEYPAIR);
+    vi.stubGlobal('crypto', {
+        subtle: {
+            generateKey: mockGenerateKey,
+        },
+    });
+});
+
+afterEach(() => {
+    mockGenerateKey.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('generateECDHKeypair', () => {
+    it('generates a non-extractable ECDH P-256 keypair for derivation', async () => {
+        await expect(generateECDHKeypair()).resolves.toBe(KEYPAIR);
+        expect(mockGenerateKey).toHaveBeenCalledWith(
+            {
+                name: 'ECDH',
+                namedCurve: 'P-256',
+            },
+            false,
+            ['deriveKey', 'deriveBits'],
+        );
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/getAssociateAndroidIntentURL.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/getAssociateAndroidIntentURL.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SolanaMobileWalletAdapterErrorCode } from '../src/errors.js';
+import getAssociateAndroidIntentURL, {
+    getRemoteAssociateAndroidIntentURL,
+} from '../src/getAssociateAndroidIntentURL.js';
+
+const ASSOCIATION_PUBLIC_KEY = {} as CryptoKey;
+const EXPORTED_KEY_BYTES = Uint8Array.of(251, 255);
+const REFLECTOR_ID = Uint8Array.of(251, 255);
+
+const { mockExportKey } = vi.hoisted(() => ({
+    mockExportKey: vi.fn(),
+}));
+
+beforeEach(() => {
+    mockExportKey.mockResolvedValue(EXPORTED_KEY_BYTES.buffer);
+    vi.stubGlobal('crypto', {
+        subtle: {
+            exportKey: mockExportKey,
+        },
+    });
+});
+
+afterEach(() => {
+    mockExportKey.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getAssociateAndroidIntentURL', () => {
+    it('creates a local association URL with the default wallet scheme', async () => {
+        const url = await getAssociateAndroidIntentURL(ASSOCIATION_PUBLIC_KEY, 49152);
+
+        expect(mockExportKey).toHaveBeenCalledWith('raw', ASSOCIATION_PUBLIC_KEY);
+        expect(url.pathname).toBe('/v1/associate/local');
+        expect(url.protocol).toBe('solana-wallet:');
+        expect(url.searchParams.get('association')).toBe('-_8.');
+        expect(url.searchParams.get('port')).toBe('49152');
+        expect(url.searchParams.get('v')).toBe('v1');
+    });
+
+    it('creates a remote association URL with reflector metadata', async () => {
+        const url = await getRemoteAssociateAndroidIntentURL(
+            ASSOCIATION_PUBLIC_KEY,
+            'reflector.example',
+            REFLECTOR_ID,
+            'https://wallet.example',
+        );
+
+        expect(mockExportKey).toHaveBeenCalledWith('raw', ASSOCIATION_PUBLIC_KEY);
+        expect(url.host).toBe('wallet.example');
+        expect(url.pathname).toBe('/v1/associate/remote');
+        expect(url.searchParams.get('association')).toBe('-_8.');
+        expect(url.searchParams.get('id')).toBe('-_8');
+        expect(url.searchParams.get('reflector')).toBe('reflector.example');
+        expect(url.searchParams.get('v')).toBe('v1');
+    });
+
+    it('creates a local association URL with an https wallet base URL', async () => {
+        const url = await getAssociateAndroidIntentURL(ASSOCIATION_PUBLIC_KEY, 61234, 'https://wallet.example');
+
+        expect(url.host).toBe('wallet.example');
+        expect(url.pathname).toBe('/v1/associate/local');
+        expect(url.protocol).toBe('https:');
+        expect(url.searchParams.get('port')).toBe('61234');
+    });
+
+    it('rejects wallet base URLs that are not https', async () => {
+        await expect(
+            getAssociateAndroidIntentURL(ASSOCIATION_PUBLIC_KEY, 49152, 'http://wallet.example'),
+        ).rejects.toEqual(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_FORBIDDEN_WALLET_BASE_URL,
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/getJWS.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/getJWS.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import getJWS from '../src/getJWS.js';
+
+const PAYLOAD = 'payload';
+const PRIVATE_KEY = {} as CryptoKey;
+const SIGNATURE_BYTES = Uint8Array.of(1, 2, 3);
+
+const { mockSign } = vi.hoisted(() => ({
+    mockSign: vi.fn(),
+}));
+
+beforeEach(() => {
+    mockSign.mockResolvedValue(SIGNATURE_BYTES.buffer);
+    vi.stubGlobal('crypto', {
+        subtle: {
+            sign: mockSign,
+        },
+    });
+});
+
+afterEach(() => {
+    mockSign.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('getJWS', () => {
+    it('creates an ES256 JWS from the encoded header, payload, and signature', async () => {
+        const headerEncoded = window.btoa(JSON.stringify({ alg: 'ES256' }));
+        const payloadEncoded = window.btoa(PAYLOAD);
+        const message = `${headerEncoded}.${payloadEncoded}`;
+
+        await expect(getJWS(PAYLOAD, PRIVATE_KEY)).resolves.toBe(`${message}.AQID`);
+        expect(mockSign).toHaveBeenCalledWith(
+            {
+                hash: 'SHA-256',
+                name: 'ECDSA',
+            },
+            PRIVATE_KEY,
+            new TextEncoder().encode(message),
+        );
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/jsonRpcMessage.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/jsonRpcMessage.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDecryptMessage, mockEncryptMessage } = vi.hoisted(() => ({
+    mockDecryptMessage: vi.fn(),
+    mockEncryptMessage: vi.fn(),
+}));
+
+vi.mock('../src/encryptedMessage.js', () => ({
+    decryptMessage: mockDecryptMessage,
+    encryptMessage: mockEncryptMessage,
+}));
+
+import { SolanaMobileWalletAdapterProtocolError } from '../src/errors.js';
+import { decryptJsonRpcMessage, encryptJsonRpcMessage } from '../src/jsonRpcMessage.js';
+
+const MESSAGE = Uint8Array.of(1, 2, 3).buffer;
+const SHARED_SECRET = {} as CryptoKey;
+
+afterEach(() => {
+    mockDecryptMessage.mockReset();
+    mockEncryptMessage.mockReset();
+    vi.restoreAllMocks();
+});
+
+describe('jsonRpcMessage', () => {
+    it('encrypts a JSON-RPC request using the message id as the sequence number', async () => {
+        const jsonRpcMessage = {
+            id: 7,
+            jsonrpc: '2.0' as const,
+            method: 'authorize',
+            params: { chain: 'solana:mainnet' },
+        };
+        const encrypted = Uint8Array.of(4, 5, 6);
+
+        mockEncryptMessage.mockResolvedValue(encrypted);
+
+        await expect(encryptJsonRpcMessage(jsonRpcMessage, SHARED_SECRET)).resolves.toBe(encrypted);
+        expect(mockEncryptMessage).toHaveBeenCalledWith(JSON.stringify(jsonRpcMessage), 7, SHARED_SECRET);
+    });
+
+    it('decrypts a JSON-RPC result message', async () => {
+        mockDecryptMessage.mockResolvedValue(
+            JSON.stringify({
+                id: 8,
+                jsonrpc: '2.0',
+                result: { auth_token: 'token' },
+            }),
+        );
+
+        await expect(decryptJsonRpcMessage(MESSAGE, SHARED_SECRET)).resolves.toEqual({
+            id: 8,
+            jsonrpc: '2.0',
+            result: { auth_token: 'token' },
+        });
+        expect(mockDecryptMessage).toHaveBeenCalledWith(MESSAGE, SHARED_SECRET);
+    });
+
+    it('throws a protocol error for JSON-RPC error responses', async () => {
+        mockDecryptMessage.mockResolvedValue(
+            JSON.stringify({
+                error: {
+                    code: -3,
+                    message: 'not signed',
+                },
+                id: 9,
+                jsonrpc: '2.0',
+            }),
+        );
+
+        await expect(decryptJsonRpcMessage(MESSAGE, SHARED_SECRET)).rejects.toBeInstanceOf(
+            SolanaMobileWalletAdapterProtocolError,
+        );
+        await expect(decryptJsonRpcMessage(MESSAGE, SHARED_SECRET)).rejects.toEqual(
+            expect.objectContaining({
+                code: -3,
+                jsonRpcMessageId: 9,
+                message: 'not signed',
+                name: 'SolanaMobileWalletAdapterProtocolError',
+            }),
+        );
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/parseSessionProps.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/parseSessionProps.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDecryptMessage } = vi.hoisted(() => ({
+    mockDecryptMessage: vi.fn(),
+}));
+
+vi.mock('../src/encryptedMessage.js', () => ({
+    decryptMessage: mockDecryptMessage,
+}));
+
+import { SolanaMobileWalletAdapterErrorCode } from '../src/errors.js';
+import parseSessionProps from '../src/parseSessionProps.js';
+
+const MESSAGE = Uint8Array.of(1, 2, 3).buffer;
+const SHARED_SECRET = {} as CryptoKey;
+
+afterEach(() => {
+    mockDecryptMessage.mockReset();
+    vi.restoreAllMocks();
+});
+
+describe('parseSessionProps', () => {
+    it('defaults to the legacy protocol version when the version field is absent', async () => {
+        mockDecryptMessage.mockResolvedValue(JSON.stringify({}));
+
+        await expect(parseSessionProps(MESSAGE, SHARED_SECRET)).resolves.toEqual({
+            protocol_version: 'legacy',
+        });
+        expect(mockDecryptMessage).toHaveBeenCalledWith(MESSAGE, SHARED_SECRET);
+    });
+
+    it('parses the legacy protocol version string', async () => {
+        mockDecryptMessage.mockResolvedValue(JSON.stringify({ v: 'legacy' }));
+
+        await expect(parseSessionProps(MESSAGE, SHARED_SECRET)).resolves.toEqual({
+            protocol_version: 'legacy',
+        });
+    });
+
+    it('parses the numeric v1 protocol version', async () => {
+        mockDecryptMessage.mockResolvedValue(JSON.stringify({ v: 1 }));
+
+        await expect(parseSessionProps(MESSAGE, SHARED_SECRET)).resolves.toEqual({
+            protocol_version: 'v1',
+        });
+    });
+
+    it('parses the string v1 protocol version', async () => {
+        mockDecryptMessage.mockResolvedValue(JSON.stringify({ v: '1' }));
+
+        await expect(parseSessionProps(MESSAGE, SHARED_SECRET)).resolves.toEqual({
+            protocol_version: 'v1',
+        });
+    });
+
+    it('parses the v1 protocol version literal', async () => {
+        mockDecryptMessage.mockResolvedValue(JSON.stringify({ v: 'v1' }));
+
+        await expect(parseSessionProps(MESSAGE, SHARED_SECRET)).resolves.toEqual({
+            protocol_version: 'v1',
+        });
+    });
+
+    it('rejects unsupported protocol versions', async () => {
+        mockDecryptMessage.mockResolvedValue(JSON.stringify({ v: 'v2' }));
+
+        await expect(parseSessionProps(MESSAGE, SHARED_SECRET)).rejects.toEqual(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_INVALID_PROTOCOL_VERSION,
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/reflectorId.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/reflectorId.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SolanaMobileWalletAdapterErrorCode } from '../src/errors.js';
+import { assertReflectorId, getRandomReflectorId } from '../src/reflectorId.js';
+
+const MAX_REFLECTOR_ID = 9007199254740991;
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('reflectorId', () => {
+    it('accepts reflector ids at the supported boundaries', () => {
+        expect(assertReflectorId(0)).toBe(0);
+        expect(assertReflectorId(MAX_REFLECTOR_ID)).toBe(MAX_REFLECTOR_ID);
+    });
+
+    it('rejects reflector ids below the supported range', () => {
+        expect(() => assertReflectorId(-1)).toThrowError(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_REFLECTOR_ID_OUT_OF_RANGE,
+                data: { id: -1 },
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+    });
+
+    it('rejects reflector ids above the supported range', () => {
+        expect(() => assertReflectorId(MAX_REFLECTOR_ID + 1)).toThrowError(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_REFLECTOR_ID_OUT_OF_RANGE,
+                data: { id: MAX_REFLECTOR_ID + 1 },
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+    });
+
+    it('derives a reflector id from window.crypto', () => {
+        const getRandomValuesSpy = vi.spyOn(window.crypto, 'getRandomValues').mockImplementation((buffer) => {
+            const randomBuffer = buffer as Uint32Array;
+
+            randomBuffer[0] = 0;
+            return randomBuffer;
+        });
+
+        expect(getRandomReflectorId()).toBe(0);
+        expect(getRandomValuesSpy).toHaveBeenCalledWith(expect.any(Uint32Array));
+    });
+});


### PR DESCRIPTION
Cover package-local helpers for association ports, hello requests, SIWS messages, association URL construction, JWS generation, JSON-RPC message handling, session property parsing, reflector ids, and keypair generation.