### PR TITLE
Add wallet-standard-mobile helper tests

### DIFF
--- a/js/packages/wallet-standard-mobile/test/createDefaultWalletNotFoundHandler.test.ts
+++ b/js/packages/wallet-standard-mobile/test/createDefaultWalletNotFoundHandler.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { ErrorModalMock, errorModalInstances, resetErrorModalMocks } = vi.hoisted(() => {
+    type ErrorModalInstance = {
+        initWithError: ReturnType<typeof vi.fn>;
+        open: ReturnType<typeof vi.fn>;
+    };
+
+    const errorModalInstances: ErrorModalInstance[] = [];
+
+    class ErrorModalMock {
+        initWithError = vi.fn();
+        open = vi.fn();
+
+        constructor() {
+            errorModalInstances.push(this);
+        }
+    }
+
+    const resetErrorModalMocks = () => {
+        errorModalInstances.length = 0;
+    };
+
+    return {
+        ErrorModalMock,
+        errorModalInstances,
+        resetErrorModalMocks,
+    };
+});
+
+vi.mock('../src/embedded-modal/errorModal.js', () => ({
+    default: ErrorModalMock,
+}));
+
+vi.mock('../src/wallet.js', () => ({
+    SolanaMobileWalletAdapterWallet: class SolanaMobileWalletAdapterWallet {},
+}));
+
+import createDefaultWalletNotFoundHandler, {
+    defaultErrorModalWalletNotFoundHandler,
+} from '../src/createDefaultWalletNotFoundHandler.js';
+
+const ANDROID_WEBVIEW_USER_AGENT =
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/123.0.0.0 Mobile Safari/537.36';
+const DESKTOP_BROWSER_USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36';
+
+afterEach(() => {
+    resetErrorModalMocks();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('createDefaultWalletNotFoundHandler', () => {
+    it('does nothing when the window object is unavailable', async () => {
+        vi.stubGlobal('window', undefined);
+
+        await expect(defaultErrorModalWalletNotFoundHandler()).resolves.toBeUndefined();
+
+        expect(errorModalInstances).toHaveLength(0);
+    });
+
+    it('shows the browser-not-supported error in Android WebViews', async () => {
+        installBrowserGlobals(ANDROID_WEBVIEW_USER_AGENT);
+
+        await expect(defaultErrorModalWalletNotFoundHandler()).resolves.toBeUndefined();
+
+        expect(errorModalInstances).toHaveLength(1);
+        expect(errorModalInstances[0].initWithError).toHaveBeenCalledWith({
+            code: 'ERROR_BROWSER_NOT_SUPPORTED',
+            message: '',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+        expect(errorModalInstances[0].open).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the wallet-not-found error in regular browsers', async () => {
+        installBrowserGlobals(DESKTOP_BROWSER_USER_AGENT);
+
+        await expect(defaultErrorModalWalletNotFoundHandler()).resolves.toBeUndefined();
+
+        expect(errorModalInstances).toHaveLength(1);
+        expect(errorModalInstances[0].initWithError).toHaveBeenCalledWith({
+            code: 'ERROR_WALLET_NOT_FOUND',
+            message: '',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+        expect(errorModalInstances[0].open).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a handler that delegates to the default modal flow', async () => {
+        installBrowserGlobals(DESKTOP_BROWSER_USER_AGENT);
+
+        const handler = createDefaultWalletNotFoundHandler();
+
+        await expect(handler({} as Parameters<typeof handler>[0])).resolves.toBeUndefined();
+
+        expect(errorModalInstances).toHaveLength(1);
+        expect(errorModalInstances[0].initWithError).toHaveBeenCalledWith({
+            code: 'ERROR_WALLET_NOT_FOUND',
+            message: '',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+        expect(errorModalInstances[0].open).toHaveBeenCalledTimes(1);
+    });
+});
+
+function installBrowserGlobals(userAgent: string) {
+    Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value: userAgent,
+    });
+}

--- a/js/packages/wallet-standard-mobile/test/getIsSupported.test.ts
+++ b/js/packages/wallet-standard-mobile/test/getIsSupported.test.ts
@@ -1,10 +1,113 @@
 // @vitest-environment jsdom
+import {
+    SolanaMobileWalletAdapterError,
+    SolanaMobileWalletAdapterErrorCode,
+} from '@solana-mobile/mobile-wallet-adapter-protocol';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const {
+    LocalConnectionModalMock,
+    LoopbackPermissionBlockedModalMock,
+    LoopbackPermissionModalMock,
+    blockedModalInstances,
+    localConnectionModalInstances,
+    permissionModalInstances,
+    resetModalMocks,
+} = vi.hoisted(() => {
+    type ModalEventListener = (event?: Event) => void;
+    type MockModalInstance = {
+        addEventListener: ReturnType<typeof vi.fn>;
+        closeListener: ModalEventListener | undefined;
+        init: ReturnType<typeof vi.fn>;
+        open: ReturnType<typeof vi.fn>;
+    };
+    type MockLocalConnectionModalInstance = MockModalInstance & {
+        callback: (() => Promise<void>) | undefined;
+        initWithCallback: ReturnType<typeof vi.fn>;
+    };
+
+    const blockedModalInstances: MockModalInstance[] = [];
+    const localConnectionModalInstances: MockLocalConnectionModalInstance[] = [];
+    const permissionModalInstances: MockModalInstance[] = [];
+
+    class LoopbackPermissionBlockedModalMock {
+        addEventListener = vi.fn((_: string, listener: ModalEventListener) => {
+            this.closeListener = listener;
+        });
+        closeListener: ModalEventListener | undefined;
+        init = vi.fn();
+        open = vi.fn();
+
+        constructor() {
+            blockedModalInstances.push(this);
+        }
+    }
+
+    class LocalConnectionModalMock {
+        addEventListener = vi.fn((_: string, listener: ModalEventListener) => {
+            this.closeListener = listener;
+        });
+        callback: (() => Promise<void>) | undefined;
+        closeListener: ModalEventListener | undefined;
+        init = vi.fn();
+        initWithCallback = vi.fn((callback: () => Promise<void>) => {
+            this.callback = callback;
+        });
+        open = vi.fn();
+
+        constructor() {
+            localConnectionModalInstances.push(this);
+        }
+    }
+
+    class LoopbackPermissionModalMock {
+        addEventListener = vi.fn((_: string, listener: ModalEventListener) => {
+            this.closeListener = listener;
+        });
+        closeListener: ModalEventListener | undefined;
+        init = vi.fn();
+        open = vi.fn();
+
+        constructor() {
+            permissionModalInstances.push(this);
+        }
+    }
+
+    const resetModalMocks = () => {
+        blockedModalInstances.length = 0;
+        localConnectionModalInstances.length = 0;
+        permissionModalInstances.length = 0;
+    };
+
+    return {
+        blockedModalInstances,
+        LocalConnectionModalMock,
+        localConnectionModalInstances,
+        LoopbackPermissionBlockedModalMock,
+        LoopbackPermissionModalMock,
+        permissionModalInstances,
+        resetModalMocks,
+    };
+});
+
+vi.mock('../src/embedded-modal/localConnectionModal.js', () => ({
+    default: LocalConnectionModalMock,
+}));
+
+vi.mock('../src/embedded-modal/loopbackBlockedModal.js', () => ({
+    default: LoopbackPermissionBlockedModalMock,
+}));
+
+vi.mock('../src/embedded-modal/loopbackPermissionModal.js', () => ({
+    default: LoopbackPermissionModalMock,
+}));
+
 import {
+    checkLocalNetworkAccessPermission,
     getIsLocalAssociationSupported,
     getIsPwaLaunchedAsApp,
     getIsRemoteAssociationSupported,
+    isSolanaMobileWebShell,
     isWebView,
 } from '../src/getIsSupported.js';
 
@@ -20,10 +123,158 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    resetModalMocks();
     vi.restoreAllMocks();
 });
 
+type MockPermissionStatus = {
+    onchange: ((event: Event) => void) | null;
+    state: PermissionState;
+};
+
 describe('getIsSupported helpers', () => {
+    it('bypasses local network access permission checks in the Solana Mobile Web Shell', async () => {
+        const permissionQuery = vi.fn();
+
+        installBrowserGlobals({
+            permissionQuery,
+            userAgent: `${ANDROID_WEBVIEW_USER_AGENT} Solana Mobile Web Shell`,
+        });
+
+        expect(isSolanaMobileWebShell(navigator.userAgent)).toBe(true);
+        await expect(checkLocalNetworkAccessPermission()).resolves.toBeUndefined();
+        expect(permissionQuery).not.toHaveBeenCalled();
+    });
+
+    it('covers the local network access API missing case', async () => {
+        installBrowserGlobals({
+            permissionQuery: vi
+                .fn()
+                .mockRejectedValue(new TypeError('loopback-network is not a valid permission name')),
+        });
+
+        await expect(checkLocalNetworkAccessPermission()).resolves.toBeUndefined();
+        expect(blockedModalInstances).toHaveLength(0);
+        expect(localConnectionModalInstances).toHaveLength(0);
+        expect(permissionModalInstances).toHaveLength(0);
+    });
+
+    it('covers the prompt flow cancelling before permission is granted', async () => {
+        const permission = createPermissionStatus('prompt');
+
+        installBrowserGlobals({
+            permissionQuery: vi.fn().mockResolvedValue(permission),
+        });
+
+        const permissionPromise = checkLocalNetworkAccessPermission();
+
+        await vi.waitFor(() => {
+            expect(permissionModalInstances).toHaveLength(1);
+        });
+
+        const closeEvent = new Event('close');
+        permissionModalInstances[0].closeListener?.(closeEvent);
+
+        await expect(permissionPromise).rejects.toMatchObject({
+            code: SolanaMobileWalletAdapterErrorCode.ERROR_ASSOCIATION_CANCELLED,
+            data: { event: closeEvent },
+            message: 'Wallet connection cancelled by user',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+        expect(localConnectionModalInstances).toHaveLength(0);
+    });
+
+    it('covers the prompt flow completing after permission is granted', async () => {
+        const permission = createPermissionStatus('prompt');
+
+        installBrowserGlobals({
+            permissionQuery: vi.fn().mockResolvedValue(permission),
+        });
+
+        const permissionPromise = checkLocalNetworkAccessPermission();
+
+        await vi.waitFor(() => {
+            expect(permissionModalInstances).toHaveLength(1);
+        });
+
+        permission.state = 'granted';
+        permission.onchange?.(new Event('change'));
+
+        await vi.waitFor(() => {
+            expect(localConnectionModalInstances).toHaveLength(1);
+        });
+
+        expect(permission.onchange).toBeNull();
+        expect(permissionModalInstances[0].init).toHaveBeenCalledTimes(1);
+        expect(permissionModalInstances[0].open).toHaveBeenCalledTimes(1);
+        expect(localConnectionModalInstances[0].initWithCallback).toHaveBeenCalledTimes(1);
+        expect(localConnectionModalInstances[0].open).toHaveBeenCalledTimes(1);
+        expect(localConnectionModalInstances[0].callback).toBeDefined();
+
+        await localConnectionModalInstances[0].callback?.();
+
+        await expect(permissionPromise).resolves.toBeUndefined();
+    });
+
+    it('covers the prompt flow failing after the local connection step is cancelled', async () => {
+        const permission = createPermissionStatus('prompt');
+
+        installBrowserGlobals({
+            permissionQuery: vi.fn().mockResolvedValue(permission),
+        });
+
+        const permissionPromise = checkLocalNetworkAccessPermission();
+
+        await vi.waitFor(() => {
+            expect(permissionModalInstances).toHaveLength(1);
+        });
+
+        permission.state = 'granted';
+        permission.onchange?.(new Event('change'));
+
+        await vi.waitFor(() => {
+            expect(localConnectionModalInstances).toHaveLength(1);
+        });
+
+        const closeEvent = new Event('close');
+        localConnectionModalInstances[0].closeListener?.(closeEvent);
+
+        await expect(permissionPromise).rejects.toMatchObject({
+            code: SolanaMobileWalletAdapterErrorCode.ERROR_ASSOCIATION_CANCELLED,
+            data: { event: closeEvent },
+            message: 'Wallet connection cancelled by user',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+    });
+
+    it('covers the prompt flow retrying and then failing once permission is denied', async () => {
+        const deniedPermission = createPermissionStatus('denied');
+        const permissionQuery = vi.fn();
+        const promptPermission = createPermissionStatus('prompt');
+        permissionQuery.mockResolvedValueOnce(promptPermission).mockResolvedValueOnce(deniedPermission);
+
+        installBrowserGlobals({
+            permissionQuery,
+        });
+
+        const permissionPromise = checkLocalNetworkAccessPermission();
+
+        await vi.waitFor(() => {
+            expect(permissionModalInstances).toHaveLength(1);
+        });
+
+        promptPermission.state = 'denied';
+        promptPermission.onchange?.(new Event('change'));
+
+        await expect(permissionPromise).rejects.toMatchObject({
+            code: SolanaMobileWalletAdapterErrorCode.ERROR_LOOPBACK_ACCESS_BLOCKED,
+            message: 'Local Network Access permission denied',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+        expect(permissionQuery).toHaveBeenCalledTimes(2);
+        expect(blockedModalInstances).toHaveLength(1);
+    });
+
     it('detects Android local association support only in a secure context', () => {
         installBrowserGlobals({ isSecureContext: true, userAgent: ANDROID_BROWSER_USER_AGENT });
         expect(getIsLocalAssociationSupported()).toBe(true);
@@ -43,6 +294,11 @@ describe('getIsSupported helpers', () => {
     it('recognizes WebView user agents', () => {
         expect(isWebView(ANDROID_WEBVIEW_USER_AGENT)).toBe(true);
         expect(isWebView(ANDROID_BROWSER_USER_AGENT)).toBe(false);
+    });
+
+    it('recognizes Solana Mobile Web Shell user agents', () => {
+        expect(isSolanaMobileWebShell(`${ANDROID_WEBVIEW_USER_AGENT} Solana Mobile Web Shell`)).toBe(true);
+        expect(isSolanaMobileWebShell(ANDROID_BROWSER_USER_AGENT)).toBe(false);
     });
 
     it('returns false for local association support on non-Android browsers', () => {
@@ -83,7 +339,79 @@ describe('getIsSupported helpers', () => {
 
         expect(getIsPwaLaunchedAsApp()).toBe(true);
     });
+
+    it('returns immediately when local network access is already granted', async () => {
+        const permission = createPermissionStatus('granted');
+        const permissionQuery = vi.fn().mockResolvedValue(permission);
+
+        installBrowserGlobals({
+            permissionQuery,
+        });
+
+        await expect(checkLocalNetworkAccessPermission()).resolves.toBeUndefined();
+        expect(permissionQuery).toHaveBeenCalledWith({ name: 'loopback-network' });
+        expect(blockedModalInstances).toHaveLength(0);
+        expect(localConnectionModalInstances).toHaveLength(0);
+        expect(permissionModalInstances).toHaveLength(0);
+    });
+
+    it('shows the blocked modal and throws when local network access is denied', async () => {
+        const permission = createPermissionStatus('denied');
+
+        installBrowserGlobals({
+            permissionQuery: vi.fn().mockResolvedValue(permission),
+        });
+
+        let thrownError: unknown;
+
+        try {
+            await checkLocalNetworkAccessPermission();
+        } catch (error) {
+            thrownError = error;
+        }
+
+        expect(thrownError).toBeInstanceOf(SolanaMobileWalletAdapterError);
+        expect(thrownError).toMatchObject({
+            code: SolanaMobileWalletAdapterErrorCode.ERROR_LOOPBACK_ACCESS_BLOCKED,
+            message: 'Local Network Access permission denied',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+        expect(blockedModalInstances).toHaveLength(1);
+        expect(blockedModalInstances[0].init).toHaveBeenCalledTimes(1);
+        expect(blockedModalInstances[0].open).toHaveBeenCalledTimes(1);
+    });
+
+    it('wraps unknown permission errors', async () => {
+        installBrowserGlobals({
+            permissionQuery: vi.fn().mockRejectedValue(new Error('permission service unavailable')),
+        });
+
+        await expect(checkLocalNetworkAccessPermission()).rejects.toMatchObject({
+            code: SolanaMobileWalletAdapterErrorCode.ERROR_LOOPBACK_ACCESS_BLOCKED,
+            message: 'permission service unavailable',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+    });
+
+    it('wraps unknown permission states with the expected adapter error', async () => {
+        installBrowserGlobals({
+            permissionQuery: vi.fn().mockResolvedValue(createPermissionStatus('unknown' as PermissionState)),
+        });
+
+        await expect(checkLocalNetworkAccessPermission()).rejects.toMatchObject({
+            code: SolanaMobileWalletAdapterErrorCode.ERROR_LOOPBACK_ACCESS_BLOCKED,
+            message: 'Local Network Access permission unknown',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+    });
 });
+
+function createPermissionStatus(state: PermissionState): MockPermissionStatus {
+    return {
+        onchange: null,
+        state,
+    };
+}
 
 function createMatchMedia({
     fullscreen = false,
@@ -112,6 +440,7 @@ function installBrowserGlobals({
     displayMode,
     documentReferrer = '',
     isSecureContext = true,
+    permissionQuery,
     userAgent = DESKTOP_BROWSER_USER_AGENT,
 }: {
     displayMode?: {
@@ -121,6 +450,7 @@ function installBrowserGlobals({
     };
     documentReferrer?: string;
     isSecureContext?: boolean;
+    permissionQuery?: ReturnType<typeof vi.fn>;
     userAgent?: string;
 } = {}) {
     Object.defineProperty(document, 'referrer', {
@@ -130,6 +460,12 @@ function installBrowserGlobals({
     Object.defineProperty(navigator, 'userAgent', {
         configurable: true,
         value: userAgent,
+    });
+    Object.defineProperty(navigator, 'permissions', {
+        configurable: true,
+        value: {
+            query: permissionQuery ?? vi.fn(),
+        },
     });
     Object.defineProperty(window, 'isSecureContext', {
         configurable: true,

--- a/js/packages/wallet-standard-mobile/test/initialize.test.ts
+++ b/js/packages/wallet-standard-mobile/test/initialize.test.ts
@@ -1,0 +1,211 @@
+import { SOLANA_MAINNET_CHAIN } from '@solana/wallet-standard-chains';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const {
+    LocalWalletMock,
+    RemoteWalletMock,
+    mockGetIsLocalAssociationSupported,
+    mockGetIsRemoteAssociationSupported,
+    mockIsSolanaMobileWebShell,
+    mockIsWebView,
+    mockLocalWalletConstructor,
+    mockRegisterWallet,
+    mockRemoteWalletConstructor,
+} = vi.hoisted(() => {
+    const mockGetIsLocalAssociationSupported = vi.fn();
+    const mockGetIsRemoteAssociationSupported = vi.fn();
+    const mockIsSolanaMobileWebShell = vi.fn();
+    const mockIsWebView = vi.fn();
+    const mockLocalWalletConstructor = vi.fn();
+    const mockRegisterWallet = vi.fn();
+    const mockRemoteWalletConstructor = vi.fn();
+
+    class LocalWalletMock {
+        constructor(config: unknown) {
+            mockLocalWalletConstructor(config);
+        }
+    }
+
+    class RemoteWalletMock {
+        constructor(config: unknown) {
+            mockRemoteWalletConstructor(config);
+        }
+    }
+
+    return {
+        LocalWalletMock,
+        RemoteWalletMock,
+        mockGetIsLocalAssociationSupported,
+        mockGetIsRemoteAssociationSupported,
+        mockIsSolanaMobileWebShell,
+        mockIsWebView,
+        mockLocalWalletConstructor,
+        mockRegisterWallet,
+        mockRemoteWalletConstructor,
+    };
+});
+
+vi.mock('@wallet-standard/wallet', () => ({
+    registerWallet: mockRegisterWallet,
+}));
+
+vi.mock('../src/getIsSupported.js', () => ({
+    getIsLocalAssociationSupported: mockGetIsLocalAssociationSupported,
+    getIsRemoteAssociationSupported: mockGetIsRemoteAssociationSupported,
+    isSolanaMobileWebShell: mockIsSolanaMobileWebShell,
+    isWebView: mockIsWebView,
+}));
+
+vi.mock('../src/wallet.js', () => ({
+    LocalSolanaMobileWalletAdapterWallet: LocalWalletMock,
+    RemoteSolanaMobileWalletAdapterWallet: RemoteWalletMock,
+    SolanaMobileWalletAdapterWallet: class SolanaMobileWalletAdapterWallet {},
+}));
+
+import { registerMwa } from '../src/initialize.js';
+
+afterEach(() => {
+    mockGetIsLocalAssociationSupported.mockReset();
+    mockGetIsRemoteAssociationSupported.mockReset();
+    mockIsSolanaMobileWebShell.mockReset();
+    mockIsWebView.mockReset();
+    mockLocalWalletConstructor.mockReset();
+    mockRegisterWallet.mockReset();
+    mockRemoteWalletConstructor.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('registerMwa', () => {
+    it('registers a local wallet outside WebViews', () => {
+        const config = createConfig();
+        const userAgent = 'Mozilla/5.0 (Linux; Android 14; Pixel 8)';
+
+        installBrowserGlobals({ isSecureContext: true, userAgent });
+        mockGetIsLocalAssociationSupported.mockReturnValue(true);
+        mockIsWebView.mockReturnValue(false);
+
+        registerMwa(config);
+
+        expect(mockGetIsLocalAssociationSupported).toHaveBeenCalledTimes(1);
+        expect(mockGetIsRemoteAssociationSupported).not.toHaveBeenCalled();
+        expect(mockIsSolanaMobileWebShell).not.toHaveBeenCalled();
+        expect(mockIsWebView).toHaveBeenCalledWith(userAgent);
+        expect(mockLocalWalletConstructor).toHaveBeenCalledWith(config);
+        expect(mockRemoteWalletConstructor).not.toHaveBeenCalled();
+        expect(mockRegisterWallet).toHaveBeenCalledWith(expect.any(LocalWalletMock));
+    });
+
+    it('registers a local wallet inside the Solana Mobile Web Shell', () => {
+        const config = createConfig();
+        const userAgent = 'Mozilla/5.0 (Linux; Android 14; Pixel 8; wv) Solana Mobile Web Shell';
+
+        installBrowserGlobals({ isSecureContext: true, userAgent });
+        mockGetIsLocalAssociationSupported.mockReturnValue(true);
+        mockIsSolanaMobileWebShell.mockReturnValue(true);
+        mockIsWebView.mockReturnValue(true);
+
+        registerMwa(config);
+
+        expect(mockGetIsLocalAssociationSupported).toHaveBeenCalledTimes(1);
+        expect(mockGetIsRemoteAssociationSupported).not.toHaveBeenCalled();
+        expect(mockIsSolanaMobileWebShell).toHaveBeenCalledWith(userAgent);
+        expect(mockIsWebView).toHaveBeenCalledWith(userAgent);
+        expect(mockLocalWalletConstructor).toHaveBeenCalledWith(config);
+        expect(mockRemoteWalletConstructor).not.toHaveBeenCalled();
+        expect(mockRegisterWallet).toHaveBeenCalledWith(expect.any(LocalWalletMock));
+    });
+
+    it('registers a remote wallet when local association is unavailable in a WebView', () => {
+        const config = createConfig({ remoteHostAuthority: 'remote.example.com' });
+        const userAgent = 'Mozilla/5.0 (Linux; Android 14; Pixel 8; wv)';
+
+        installBrowserGlobals({ isSecureContext: true, userAgent });
+        mockGetIsLocalAssociationSupported.mockReturnValue(true);
+        mockGetIsRemoteAssociationSupported.mockReturnValue(true);
+        mockIsSolanaMobileWebShell.mockReturnValue(false);
+        mockIsWebView.mockReturnValue(true);
+
+        registerMwa(config);
+
+        expect(mockGetIsLocalAssociationSupported).toHaveBeenCalledTimes(1);
+        expect(mockGetIsRemoteAssociationSupported).toHaveBeenCalledTimes(1);
+        expect(mockIsSolanaMobileWebShell).toHaveBeenCalledWith(userAgent);
+        expect(mockIsWebView).toHaveBeenCalledWith(userAgent);
+        expect(mockLocalWalletConstructor).not.toHaveBeenCalled();
+        expect(mockRemoteWalletConstructor).toHaveBeenCalledWith(config);
+        expect(mockRegisterWallet).toHaveBeenCalledWith(expect.any(RemoteWalletMock));
+    });
+
+    it('skips registration when remote association lacks a host authority', () => {
+        const config = createConfig();
+        const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)';
+
+        installBrowserGlobals({ isSecureContext: true, userAgent });
+        mockGetIsLocalAssociationSupported.mockReturnValue(false);
+        mockGetIsRemoteAssociationSupported.mockReturnValue(true);
+
+        registerMwa(config);
+
+        expect(mockGetIsLocalAssociationSupported).toHaveBeenCalledTimes(1);
+        expect(mockGetIsRemoteAssociationSupported).toHaveBeenCalledTimes(1);
+        expect(mockIsSolanaMobileWebShell).not.toHaveBeenCalled();
+        expect(mockIsWebView).not.toHaveBeenCalled();
+        expect(mockLocalWalletConstructor).not.toHaveBeenCalled();
+        expect(mockRemoteWalletConstructor).not.toHaveBeenCalled();
+        expect(mockRegisterWallet).not.toHaveBeenCalled();
+    });
+
+    it('warns and returns when there is no window object', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        registerMwa(createConfig());
+
+        expect(mockGetIsLocalAssociationSupported).not.toHaveBeenCalled();
+        expect(mockRegisterWallet).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith('MWA not registered: no window object');
+    });
+
+    it('warns and returns when the context is insecure', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        installBrowserGlobals({
+            isSecureContext: false,
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)',
+        });
+
+        registerMwa(createConfig());
+
+        expect(mockGetIsLocalAssociationSupported).not.toHaveBeenCalled();
+        expect(mockRegisterWallet).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith('MWA not registered: secure context required (https)');
+    });
+});
+
+function createConfig({ remoteHostAuthority }: { remoteHostAuthority?: string } = {}): Parameters<
+    typeof registerMwa
+>[0] {
+    return {
+        appIdentity: {
+            icon: 'favicon.ico',
+            name: 'Example App',
+            uri: 'https://example.test',
+        },
+        authorizationCache: {
+            clear: vi.fn().mockResolvedValue(undefined),
+            get: vi.fn().mockResolvedValue(undefined),
+            set: vi.fn().mockResolvedValue(undefined),
+        },
+        chainSelector: {
+            select: vi.fn().mockResolvedValue(SOLANA_MAINNET_CHAIN),
+        },
+        chains: [SOLANA_MAINNET_CHAIN],
+        onWalletNotFound: vi.fn().mockResolvedValue(undefined),
+        ...(remoteHostAuthority ? { remoteHostAuthority } : {}),
+    };
+}
+
+function installBrowserGlobals({ isSecureContext, userAgent }: { isSecureContext: boolean; userAgent: string }) {
+    vi.stubGlobal('navigator', { userAgent });
+    vi.stubGlobal('window', { isSecureContext });
+}

--- a/js/packages/wallet-standard-mobile/test/solana.test.ts
+++ b/js/packages/wallet-standard-mobile/test/solana.test.ts
@@ -1,0 +1,15 @@
+import { SOLANA_DEVNET_CHAIN, SOLANA_MAINNET_CHAIN, SOLANA_TESTNET_CHAIN } from '@solana/wallet-standard-chains';
+import { describe, expect, it } from 'vitest';
+
+import { isVersionedTransaction, MWA_SOLANA_CHAINS } from '../src/solana.js';
+
+describe('solana helpers', () => {
+    it('exports the supported Solana chains in the expected order', () => {
+        expect(MWA_SOLANA_CHAINS).toEqual([SOLANA_MAINNET_CHAIN, SOLANA_DEVNET_CHAIN, SOLANA_TESTNET_CHAIN]);
+    });
+
+    it('detects versioned transactions by the presence of a version field', () => {
+        expect(isVersionedTransaction({ signatures: [] })).toBe(false);
+        expect(isVersionedTransaction({ signatures: [], version: 0 })).toBe(true);
+    });
+});


### PR DESCRIPTION
Cover the wallet-standard-mobile package helpers for default wallet-not-found handling, browser support and local network permission flows, wallet registration, and Solana chain exports and transaction detection.