### PR TITLE
Prepare JS configs for TypeScript 6

### DIFF
--- a/examples/example-web-app/css.d.ts
+++ b/examples/example-web-app/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/examples/example-web-app/package.json
+++ b/examples/example-web-app/package.json
@@ -38,6 +38,7 @@
         "swr": "^1.3.0"
     },
     "devDependencies": {
+        "@types/node": "20.19.0",
         "@types/react": "^18.0.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "ngrok": "^4.3.1",

--- a/examples/example-web-app/pnpm-lock.yaml
+++ b/examples/example-web-app/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(react@18.3.1)
     devDependencies:
+      '@types/node':
+        specifier: 20.19.0
+        version: 20.19.0
       '@types/react':
         specifier: ^18.0.0
         version: 18.3.28
@@ -1041,8 +1044,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.3.0':
-    resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
+  '@types/node@20.19.0':
+    resolution: {integrity: sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==}
 
   '@types/node@8.10.66':
     resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
@@ -2739,8 +2742,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -3327,14 +3330,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3368,7 +3371,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -3925,12 +3928,12 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 8.10.66
+      '@types/node': 20.19.0
       '@types/responselike': 1.0.3
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 20.19.0
 
   '@types/esrecurse@4.3.1': {}
 
@@ -3938,7 +3941,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -3956,13 +3959,13 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 8.10.66
+      '@types/node': 20.19.0
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.3.0':
+  '@types/node@20.19.0':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 6.21.0
 
   '@types/node@8.10.66': {}
 
@@ -3981,7 +3984,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 8.10.66
+      '@types/node': 20.19.0
 
   '@types/stack-utils@2.0.3': {}
 
@@ -3989,11 +3992,11 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 20.19.0
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -4003,7 +4006,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 8.10.66
+      '@types/node': 20.19.0
     optional: true
 
   '@wallet-standard/app@1.1.0':
@@ -4264,7 +4267,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -4273,7 +4276,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -4873,7 +4876,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -4883,7 +4886,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4910,7 +4913,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -4918,7 +4921,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -4935,7 +4938,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.3.0
+      '@types/node': 20.19.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -5856,7 +5859,7 @@ snapshots:
 
   typescript@5.6.3: {}
 
-  undici-types@7.18.2: {}
+  undici-types@6.21.0: {}
 
   universalify@2.0.1: {}
 

--- a/examples/example-web-app/tsconfig.json
+++ b/examples/example-web-app/tsconfig.json
@@ -1,20 +1,22 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext",
+    "types": ["node"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["**/*.d.ts", "**/*.ts", "**/*.tsx", "next-env.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/js/.changeset/five-cars-fail.md
+++ b/js/.changeset/five-cars-fail.md
@@ -1,0 +1,10 @@
+"@solana-mobile/mobile-wallet-adapter-protocol": patch
+"@solana-mobile/mobile-wallet-adapter-protocol-kit": patch
+"@solana-mobile/mobile-wallet-adapter-protocol-web3js": patch
+"@solana-mobile/mobile-wallet-adapter-walletlib": patch
+"@solana-mobile/wallet-adapter-mobile": patch
+"@solana-mobile/wallet-standard-mobile": patch
+
+---
+
+Prepare the JS packages for a future TypeScript 6 upgrade without changing the current TypeScript version.

--- a/js/packages/mobile-wallet-adapter-protocol-kit/tsconfig.cjs.json
+++ b/js/packages/mobile-wallet-adapter-protocol-kit/tsconfig.cjs.json
@@ -2,6 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
+        // Temporary TS5 compatibility. TS6 prep uses bundler elsewhere, but TS5 rejects bundler + commonjs.
+        "moduleResolution": "node",
         "outDir": "lib/cjs"
     }
 }

--- a/js/packages/mobile-wallet-adapter-protocol-web3js/tsconfig.cjs.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/tsconfig.cjs.json
@@ -2,6 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
+        // Temporary TS5 compatibility. TS6 prep uses bundler elsewhere, but TS5 rejects bundler + commonjs.
+        "moduleResolution": "node",
         "outDir": "lib/cjs"
     }
 }

--- a/js/packages/mobile-wallet-adapter-protocol/tsconfig.cjs.json
+++ b/js/packages/mobile-wallet-adapter-protocol/tsconfig.cjs.json
@@ -2,6 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
+        // Temporary TS5 compatibility. TS6 prep uses bundler elsewhere, but TS5 rejects bundler + commonjs.
+        "moduleResolution": "node",
         "outDir": "lib/cjs"
     }
 }

--- a/js/packages/mobile-wallet-adapter-walletlib/tsconfig.cjs.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/tsconfig.cjs.json
@@ -2,6 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
+        // Temporary TS5 compatibility. TS6 prep uses bundler elsewhere, but TS5 rejects bundler + commonjs.
+        "moduleResolution": "node",
         "outDir": "lib/cjs"
     }
 }

--- a/js/packages/mobile-wallet-adapter-walletlib/tsconfig.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/tsconfig.json
@@ -1,31 +1,3 @@
-// {
-//     "compilerOptions": {
-//       "baseUrl": "./",
-//       "paths": {
-//         "react-native-test-library": ["./src/index"]
-//       },
-//       "allowUnreachableCode": false,
-//       "allowUnusedLabels": false,
-//       "esModuleInterop": true,
-//       "importsNotUsedAsValues": "error",
-//       "forceConsistentCasingInFileNames": true,
-//       "jsx": "react",
-//       "lib": ["esnext"],
-//       "module": "esnext",
-//       "moduleResolution": "node",
-//       "noFallthroughCasesInSwitch": true,
-//       "noImplicitReturns": true,
-//       "noImplicitUseStrict": false,
-//       "noStrictGenericChecks": false,
-//       "noUncheckedIndexedAccess": true,
-//       "noUnusedLocals": true,
-//       "noUnusedParameters": true,
-//       "resolveJsonModule": true,
-//       "skipLibCheck": true,
-//       "strict": true,
-//       "target": "esnext"
-//     }
-//   }
 {
     "extends": "../../tsconfig.json",
     "include": ["src", "test"],

--- a/js/packages/mobile-wallet-adapter-walletlib/tsdown.config.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/tsdown.config.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { defineConfig, type DtsOptions, type UserConfig } from 'tsdown';
 
 type Runtime = 'node' | 'react-native';
-type TsdownPlugin = NonNullable<UserConfig['plugins']>[number];
+type TsdownPlugin = NonNullable<UserConfig['plugins']>;
 
 const DTS_OPTIONS: DtsOptions = {
     emitDtsOnly: true,
@@ -36,7 +36,7 @@ function resolveSourcePath(importer: string, source: string): string | undefined
 function runtimeForkPlugin(runtime: Runtime): TsdownPlugin {
     return {
         name: `runtime-fork-${runtime}`,
-        resolveId(source, importer) {
+        resolveId(source: string, importer?: string) {
             if (importer == null || !source.startsWith('.')) {
                 return null;
             }

--- a/js/packages/wallet-adapter-mobile/tsconfig.cjs.json
+++ b/js/packages/wallet-adapter-mobile/tsconfig.cjs.json
@@ -2,6 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
+        // Temporary TS5 compatibility. TS6 prep uses bundler elsewhere, but TS5 rejects bundler + commonjs.
+        "moduleResolution": "node",
         "outDir": "lib/cjs"
     }
 }

--- a/js/packages/wallet-standard-mobile/tsconfig.cjs.json
+++ b/js/packages/wallet-standard-mobile/tsconfig.cjs.json
@@ -2,6 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
+        // Temporary TS5 compatibility. TS6 prep uses bundler elsewhere, but TS5 rejects bundler + commonjs.
+        "moduleResolution": "node",
         "outDir": "lib/cjs"
     }
 }

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -6,12 +6,14 @@
         "declarationMap": true,
         "isolatedModules": true,
         "esModuleInterop": true,
-        "module": "esnext",
-        "moduleResolution": "node",
+        "module": "preserve",
+        "moduleResolution": "bundler",
         "noEmitOnError": true,
+        "noUncheckedSideEffectImports": true,
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,
-        "target": "ES2022"
+        "target": "ES2022",
+        "types": ["node"]
     }
 }

--- a/js/tsdown.config.ts
+++ b/js/tsdown.config.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { defineConfig, type DtsOptions, type UserConfig } from 'tsdown';
 
 type Runtime = 'browser' | 'node' | 'react-native';
-type TsdownPlugin = NonNullable<UserConfig['plugins']>[number];
+type TsdownPlugin = NonNullable<UserConfig['plugins']>;
 
 const DTS_OPTIONS: DtsOptions = {
     emitDtsOnly: true,
@@ -36,7 +36,7 @@ function resolveSourcePath(importer: string, source: string): string | undefined
 function runtimeForkPlugin(runtime: Runtime): TsdownPlugin {
     return {
         name: `runtime-fork-${runtime}`,
-        resolveId(source, importer) {
+        resolveId(source: string, importer?: string) {
             if (importer == null || !source.startsWith('.')) {
                 return null;
             }


### PR DESCRIPTION
Switch the shared JS workspace and example web app tsconfig files to preserve/bundler, add explicit node types, and enable side-effect import checking while keeping the current TypeScript behavior explicit.

Keep each CommonJS package tsconfig on a temporary moduleResolution node override for TypeScript 5 compatibility, remove the stale deprecated walletlib tsconfig template block, and add the web CSS declaration plus tsdown config typing fixes needed for the stricter checks.

The recommendations here are taken from the [TypeScript 6 announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/).