### PR TITLE
Add protocol coverage tests

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/test/createMobileWalletProxy.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/createMobileWalletProxy.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import createMobileWalletProxy from '../src/createMobileWalletProxy.js';
+import { SolanaCloneAuthorization, SolanaSignTransactions } from '../src/types.js';
+
+const APP_IDENTITY = {
+    name: 'Test App',
+} as const;
+const AUTHORIZATION_RESULT = {
+    accounts: [],
+    auth_token: 'auth-token',
+    wallet_uri_base: 'https://wallet.example',
+} as const;
+
+describe('createMobileWalletProxy', () => {
+    it('does not behave like a promise and rejects proxy shape mutations', async () => {
+        const wallet = createMobileWalletProxy('v1', vi.fn());
+
+        await expect(Promise.resolve(wallet)).resolves.toBe(wallet);
+        expect(Reflect.defineProperty(wallet, 'authorize', { value: vi.fn() })).toBe(false);
+        expect(Reflect.deleteProperty(wallet, 'authorize')).toBe(false);
+    });
+
+    it('maps legacy authorize chains to clusters', async () => {
+        const protocolRequestHandler = vi.fn().mockResolvedValue(AUTHORIZATION_RESULT);
+        const wallet = createMobileWalletProxy('legacy', protocolRequestHandler);
+
+        await expect(
+            wallet.authorize({
+                chain: 'solana:mainnet',
+                identity: APP_IDENTITY,
+            }),
+        ).resolves.toBe(AUTHORIZATION_RESULT);
+
+        expect(protocolRequestHandler).toHaveBeenCalledWith('authorize', {
+            chain: 'solana:mainnet',
+            cluster: 'mainnet-beta',
+            identity: APP_IDENTITY,
+        });
+    });
+
+    it('maps v1 authorize clusters to chains', async () => {
+        const protocolRequestHandler = vi.fn().mockResolvedValue(AUTHORIZATION_RESULT);
+        const wallet = createMobileWalletProxy('v1', protocolRequestHandler);
+
+        await expect(
+            wallet.authorize({
+                chain: 'devnet',
+                identity: APP_IDENTITY,
+            }),
+        ).resolves.toBe(AUTHORIZATION_RESULT);
+
+        expect(protocolRequestHandler).toHaveBeenCalledWith('authorize', {
+            chain: 'solana:devnet',
+            identity: APP_IDENTITY,
+        });
+    });
+
+    it('maps legacy authorize with an auth token to reauthorize', async () => {
+        const protocolRequestHandler = vi.fn().mockResolvedValue(AUTHORIZATION_RESULT);
+        const wallet = createMobileWalletProxy('legacy', protocolRequestHandler);
+
+        await expect(
+            wallet.authorize({
+                auth_token: 'auth-token',
+                identity: APP_IDENTITY,
+            }),
+        ).resolves.toBe(AUTHORIZATION_RESULT);
+
+        expect(protocolRequestHandler).toHaveBeenCalledWith('reauthorize', {
+            auth_token: 'auth-token',
+            identity: APP_IDENTITY,
+        });
+    });
+
+    it('maps v1 reauthorize to authorize', async () => {
+        const protocolRequestHandler = vi.fn().mockResolvedValue(AUTHORIZATION_RESULT);
+        const wallet = createMobileWalletProxy('v1', protocolRequestHandler);
+
+        await expect(
+            wallet.reauthorize({
+                auth_token: 'auth-token',
+                identity: APP_IDENTITY,
+            }),
+        ).resolves.toBe(AUTHORIZATION_RESULT);
+
+        expect(protocolRequestHandler).toHaveBeenCalledWith('authorize', {
+            auth_token: 'auth-token',
+            identity: APP_IDENTITY,
+        });
+    });
+
+    it('maps camel-case method names to snake-case RPC methods', async () => {
+        const protocolRequestHandler = vi.fn().mockResolvedValue({ signatures: ['signature'] });
+        const wallet = createMobileWalletProxy('v1', protocolRequestHandler);
+
+        await expect(
+            wallet.signAndSendTransactions({
+                payloads: ['transaction'],
+            }),
+        ).resolves.toEqual({ signatures: ['signature'] });
+
+        expect(protocolRequestHandler).toHaveBeenCalledWith('sign_and_send_transactions', {
+            payloads: ['transaction'],
+        });
+    });
+
+    it('adds feature identifiers to legacy capabilities responses', async () => {
+        const protocolRequestHandler = vi.fn().mockResolvedValue({
+            max_messages_per_request: 1,
+            max_transactions_per_request: 2,
+            supported_transaction_versions: ['legacy'],
+            supports_clone_authorization: true,
+            supports_sign_and_send_transactions: false,
+        });
+        const wallet = createMobileWalletProxy('legacy', protocolRequestHandler);
+
+        await expect(wallet.getCapabilities()).resolves.toEqual({
+            features: [SolanaSignTransactions, SolanaCloneAuthorization],
+            max_messages_per_request: 1,
+            max_transactions_per_request: 2,
+            supported_transaction_versions: ['legacy'],
+            supports_clone_authorization: true,
+            supports_sign_and_send_transactions: false,
+        });
+    });
+
+    it('adds legacy support booleans to v1 capabilities responses', async () => {
+        const protocolRequestHandler = vi.fn().mockResolvedValue({
+            features: [SolanaCloneAuthorization],
+            max_messages_per_request: 1,
+            max_transactions_per_request: 2,
+            supported_transaction_versions: ['legacy'],
+            supports_clone_authorization: false,
+            supports_sign_and_send_transactions: false,
+        });
+        const wallet = createMobileWalletProxy('v1', protocolRequestHandler);
+
+        await expect(wallet.getCapabilities()).resolves.toEqual({
+            features: [SolanaCloneAuthorization],
+            max_messages_per_request: 1,
+            max_transactions_per_request: 2,
+            supported_transaction_versions: ['legacy'],
+            supports_clone_authorization: true,
+            supports_sign_and_send_transactions: true,
+        });
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/encryptedMessage.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/encryptedMessage.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { decryptMessage, encryptMessage } from '../src/encryptedMessage.js';
+
+const CIPHERTEXT = Uint8Array.of(9, 10);
+const INITIALIZATION_VECTOR = Uint8Array.of(11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22);
+const PLAINTEXT = 'hello';
+const SEQUENCE_NUMBER = 0x01020304;
+const SEQUENCE_NUMBER_VECTOR = Uint8Array.of(1, 2, 3, 4);
+const SHARED_SECRET = {} as CryptoKey;
+
+const { mockDecrypt, mockEncrypt, mockGetRandomValues } = vi.hoisted(() => ({
+    mockDecrypt: vi.fn(),
+    mockEncrypt: vi.fn(),
+    mockGetRandomValues: vi.fn(),
+}));
+
+beforeEach(() => {
+    mockDecrypt.mockResolvedValue(new TextEncoder().encode(PLAINTEXT).buffer);
+    mockEncrypt.mockResolvedValue(CIPHERTEXT.buffer);
+    mockGetRandomValues.mockImplementation((array: Uint8Array) => {
+        array.set(INITIALIZATION_VECTOR);
+        return array;
+    });
+    vi.stubGlobal('crypto', {
+        getRandomValues: mockGetRandomValues,
+        subtle: {
+            decrypt: mockDecrypt,
+            encrypt: mockEncrypt,
+        },
+    });
+});
+
+afterEach(() => {
+    mockDecrypt.mockReset();
+    mockEncrypt.mockReset();
+    mockGetRandomValues.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('encryptedMessage', () => {
+    it('decrypts the message ciphertext with the sequence number as additional data', async () => {
+        const message = Uint8Array.of(...SEQUENCE_NUMBER_VECTOR, ...INITIALIZATION_VECTOR, ...CIPHERTEXT).buffer;
+
+        await expect(decryptMessage(message, SHARED_SECRET)).resolves.toBe(PLAINTEXT);
+
+        expect(mockDecrypt).toHaveBeenCalledWith(
+            {
+                additionalData: message.slice(0, SEQUENCE_NUMBER_VECTOR.byteLength),
+                iv: message.slice(
+                    SEQUENCE_NUMBER_VECTOR.byteLength,
+                    SEQUENCE_NUMBER_VECTOR.byteLength + INITIALIZATION_VECTOR.byteLength,
+                ),
+                name: 'AES-GCM',
+                tagLength: 128,
+            },
+            SHARED_SECRET,
+            message.slice(SEQUENCE_NUMBER_VECTOR.byteLength + INITIALIZATION_VECTOR.byteLength),
+        );
+    });
+
+    it('encrypts the plaintext and prefixes the sequence number and initialization vector', async () => {
+        await expect(encryptMessage(PLAINTEXT, SEQUENCE_NUMBER, SHARED_SECRET)).resolves.toEqual(
+            Uint8Array.of(...SEQUENCE_NUMBER_VECTOR, ...INITIALIZATION_VECTOR, ...CIPHERTEXT),
+        );
+
+        expect(mockGetRandomValues).toHaveBeenCalledWith(expect.any(Uint8Array));
+        expect(mockEncrypt).toHaveBeenCalledWith(
+            {
+                additionalData: SEQUENCE_NUMBER_VECTOR,
+                iv: INITIALIZATION_VECTOR,
+                name: 'AES-GCM',
+                tagLength: 128,
+            },
+            SHARED_SECRET,
+            new TextEncoder().encode(PLAINTEXT),
+        );
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/parseHelloRsp.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/parseHelloRsp.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ENCODED_PUBLIC_KEY_LENGTH_BYTES } from '../src/encryptedMessage.js';
+import parseHelloRsp from '../src/parseHelloRsp.js';
+
+const AES_KEY = {} as CryptoKey;
+const ASSOCIATION_PUBLIC_KEY = {} as CryptoKey;
+const ASSOCIATION_PUBLIC_KEY_BYTES = Uint8Array.of(4, 5, 6);
+const ECDH_PRIVATE_KEY = {} as CryptoKey;
+const ECDH_SECRET_KEY = {} as CryptoKey;
+const PAYLOAD_BUFFER = Uint8Array.from({ length: ENCODED_PUBLIC_KEY_LENGTH_BYTES + 1 }, (_, index) => index).buffer;
+const SHARED_SECRET_BITS = Uint8Array.of(1, 2, 3).buffer;
+const WALLET_PUBLIC_KEY = {} as CryptoKey;
+
+const { mockDeriveBits, mockDeriveKey, mockExportKey, mockImportKey } = vi.hoisted(() => ({
+    mockDeriveBits: vi.fn(),
+    mockDeriveKey: vi.fn(),
+    mockExportKey: vi.fn(),
+    mockImportKey: vi.fn(),
+}));
+
+beforeEach(() => {
+    mockDeriveBits.mockResolvedValue(SHARED_SECRET_BITS);
+    mockDeriveKey.mockResolvedValue(AES_KEY);
+    mockExportKey.mockResolvedValue(ASSOCIATION_PUBLIC_KEY_BYTES.buffer);
+    mockImportKey.mockResolvedValueOnce(WALLET_PUBLIC_KEY).mockResolvedValueOnce(ECDH_SECRET_KEY);
+    vi.stubGlobal('crypto', {
+        subtle: {
+            deriveBits: mockDeriveBits,
+            deriveKey: mockDeriveKey,
+            exportKey: mockExportKey,
+            importKey: mockImportKey,
+        },
+    });
+});
+
+afterEach(() => {
+    mockDeriveBits.mockReset();
+    mockDeriveKey.mockReset();
+    mockExportKey.mockReset();
+    mockImportKey.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('parseHelloRsp', () => {
+    it('derives a shared AES-GCM key from the wallet public key and association public key', async () => {
+        await expect(parseHelloRsp(PAYLOAD_BUFFER, ASSOCIATION_PUBLIC_KEY, ECDH_PRIVATE_KEY)).resolves.toBe(AES_KEY);
+
+        expect(mockExportKey).toHaveBeenCalledWith('raw', ASSOCIATION_PUBLIC_KEY);
+        expect(mockImportKey).toHaveBeenNthCalledWith(
+            1,
+            'raw',
+            expect.any(ArrayBuffer),
+            {
+                name: 'ECDH',
+                namedCurve: 'P-256',
+            },
+            false,
+            [],
+        );
+        expect(new Uint8Array(mockImportKey.mock.calls[0][1] as ArrayBuffer)).toEqual(
+            new Uint8Array(PAYLOAD_BUFFER.slice(0, ENCODED_PUBLIC_KEY_LENGTH_BYTES)),
+        );
+        expect(mockDeriveBits).toHaveBeenCalledWith(
+            {
+                name: 'ECDH',
+                public: WALLET_PUBLIC_KEY,
+            },
+            ECDH_PRIVATE_KEY,
+            256,
+        );
+        expect(mockImportKey).toHaveBeenNthCalledWith(2, 'raw', SHARED_SECRET_BITS, 'HKDF', false, ['deriveKey']);
+        expect(mockDeriveKey).toHaveBeenCalledWith(
+            {
+                hash: 'SHA-256',
+                info: new Uint8Array(),
+                name: 'HKDF',
+                salt: ASSOCIATION_PUBLIC_KEY_BYTES,
+            },
+            ECDH_SECRET_KEY,
+            {
+                length: 128,
+                name: 'AES-GCM',
+            },
+            false,
+            ['encrypt', 'decrypt'],
+        );
+    });
+});

--- a/js/packages/mobile-wallet-adapter-protocol/test/startSession.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/startSession.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ASSOCIATION_PORT = 51234;
+const ASSOCIATION_PUBLIC_KEY = {} as CryptoKey;
+const ASSOCIATION_URL_BASE = 'https://wallet.example';
+
+const { mockGetAssociateAndroidIntentURL, mockGetRandomAssociationPort } = vi.hoisted(() => ({
+    mockGetAssociateAndroidIntentURL: vi.fn(),
+    mockGetRandomAssociationPort: vi.fn(),
+}));
+
+vi.mock('../src/associationPort.js', () => ({
+    getRandomAssociationPort: mockGetRandomAssociationPort,
+}));
+
+vi.mock('../src/getAssociateAndroidIntentURL.js', () => ({
+    default: mockGetAssociateAndroidIntentURL,
+}));
+
+import { SolanaMobileWalletAdapterErrorCode } from '../src/errors.js';
+import { startSession } from '../src/startSession.js';
+
+beforeEach(() => {
+    mockGetRandomAssociationPort.mockReturnValue(ASSOCIATION_PORT);
+});
+
+afterEach(() => {
+    mockGetAssociateAndroidIntentURL.mockReset();
+    mockGetRandomAssociationPort.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+});
+
+describe('startSession', () => {
+    it('launches https association URLs directly', async () => {
+        const associationUrl = new URL('https://wallet.example/v1/associate/local');
+        const mockAssign = vi.fn();
+        mockGetAssociateAndroidIntentURL.mockResolvedValue(associationUrl);
+        vi.stubGlobal('window', {
+            location: {
+                assign: mockAssign,
+            },
+        });
+
+        await expect(startSession(ASSOCIATION_PUBLIC_KEY, ASSOCIATION_URL_BASE)).resolves.toBe(ASSOCIATION_PORT);
+
+        expect(mockAssign).toHaveBeenCalledWith(associationUrl);
+        expect(mockGetAssociateAndroidIntentURL).toHaveBeenCalledWith(
+            ASSOCIATION_PUBLIC_KEY,
+            ASSOCIATION_PORT,
+            ASSOCIATION_URL_BASE,
+        );
+    });
+
+    it('launches custom protocol URLs through a hidden iframe in Firefox', async () => {
+        const associationUrl = new URL('solana-wallet:/v1/associate/local');
+        const frame = {
+            contentWindow: {
+                location: {
+                    href: '',
+                },
+            },
+            style: {
+                display: '',
+            },
+        };
+        const mockAppendChild = vi.fn();
+        const mockCreateElement = vi.fn(() => frame);
+        mockGetAssociateAndroidIntentURL.mockResolvedValue(associationUrl);
+        vi.stubGlobal('document', {
+            body: {
+                appendChild: mockAppendChild,
+            },
+            createElement: mockCreateElement,
+        });
+        vi.stubGlobal('navigator', {
+            userAgent: 'Firefox/123',
+        });
+
+        await expect(startSession(ASSOCIATION_PUBLIC_KEY)).resolves.toBe(ASSOCIATION_PORT);
+
+        expect(frame.contentWindow.location.href).toBe(associationUrl.toString());
+        expect(frame.style.display).toBe('none');
+        expect(mockAppendChild).toHaveBeenCalledWith(frame);
+        expect(mockCreateElement).toHaveBeenCalledWith('iframe');
+    });
+
+    it('waits for blur after assigning custom protocol URLs in other browsers', async () => {
+        const associationUrl = new URL('solana-wallet:/v1/associate/local');
+        let blurHandler: (() => void) | undefined;
+        const mockAddEventListener = vi.fn((eventName: string, handler: () => void) => {
+            if (eventName === 'blur') {
+                blurHandler = handler;
+            }
+        });
+        const mockAssign = vi.fn(() => {
+            blurHandler?.();
+        });
+        const mockRemoveEventListener = vi.fn();
+        mockGetAssociateAndroidIntentURL.mockResolvedValue(associationUrl);
+        vi.stubGlobal('navigator', {
+            userAgent: 'Chrome/123',
+        });
+        vi.stubGlobal('window', {
+            addEventListener: mockAddEventListener,
+            location: {
+                assign: mockAssign,
+            },
+            removeEventListener: mockRemoveEventListener,
+        });
+
+        await expect(startSession(ASSOCIATION_PUBLIC_KEY)).resolves.toBe(ASSOCIATION_PORT);
+
+        expect(mockAddEventListener).toHaveBeenCalledWith('blur', expect.any(Function));
+        expect(mockAssign).toHaveBeenCalledWith(associationUrl);
+        expect(mockRemoveEventListener).toHaveBeenCalledWith('blur', blurHandler);
+    });
+
+    it('rejects when a custom protocol URL does not navigate away', async () => {
+        const associationUrl = new URL('solana-wallet:/v1/associate/local');
+        const mockAddEventListener = vi.fn();
+        const mockAssign = vi.fn();
+        const mockRemoveEventListener = vi.fn();
+        mockGetAssociateAndroidIntentURL.mockResolvedValue(associationUrl);
+        vi.stubGlobal('navigator', {
+            userAgent: 'Chrome/123',
+        });
+        vi.stubGlobal('window', {
+            addEventListener: mockAddEventListener,
+            location: {
+                assign: mockAssign,
+            },
+            removeEventListener: mockRemoveEventListener,
+        });
+        vi.useFakeTimers();
+
+        const sessionPromise = startSession(ASSOCIATION_PUBLIC_KEY);
+        const expectation = expect(sessionPromise).rejects.toEqual(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_WALLET_NOT_FOUND,
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+        await vi.advanceTimersByTimeAsync(3000);
+        await expectation;
+
+        expect(mockAssign).toHaveBeenCalledWith(associationUrl);
+        expect(mockRemoveEventListener).toHaveBeenCalledWith('blur', expect.any(Function));
+    });
+});


### PR DESCRIPTION
Add focused unit coverage for mobile wallet proxy request mapping, encrypted message framing, hello response parsing, and session launch handling.