### PR TITLE
Add wallet standard branch coverage tests

### DIFF
--- a/js/packages/wallet-standard-mobile/test/createDefaultAuthorizationCache.react-native.test.ts
+++ b/js/packages/wallet-standard-mobile/test/createDefaultAuthorizationCache.react-native.test.ts
@@ -1,13 +1,10 @@
-// @vitest-environment jsdom
-
 import { SOLANA_MAINNET_CHAIN } from '@solana/wallet-standard-chains';
 import base58 from 'bs58';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import createDefaultAuthorizationCache from '../src/createDefaultAuthorizationCache.js';
 import type { Authorization } from '../src/wallet.js';
 
-const AUTHORIZATION_CACHE_KEY = 'SolanaMobileWalletAdapterDefaultAuthorizationCache';
+const AUTHORIZATION_CACHE_KEY = 'SolanaMobileWalletAdapterWalletStandardDefaultAuthorizationCache';
 const DEFAULT_CAPABILITIES: Authorization['capabilities'] = {
     features: [],
     max_messages_per_request: 1,
@@ -17,21 +14,67 @@ const DEFAULT_CAPABILITIES: Authorization['capabilities'] = {
     supports_sign_and_send_transactions: false,
 };
 
+const { asyncStorage, resetAsyncStorage } = vi.hoisted(() => {
+    let store = new Map<string, string>();
+
+    return {
+        asyncStorage: {
+            getItem: vi.fn(async (key: string) => store.get(key) ?? null),
+            removeItem: vi.fn(async (key: string) => {
+                store.delete(key);
+            }),
+            setItem: vi.fn(async (key: string, value: string) => {
+                store.set(key, value);
+            }),
+        },
+        resetAsyncStorage: () => {
+            store = new Map();
+        },
+    };
+});
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+    default: asyncStorage,
+}));
+
+import createDefaultAuthorizationCache from '../src/__forks__/react-native/createDefaultAuthorizationCache.js';
+
 beforeEach(() => {
-    window.localStorage.clear();
+    resetAsyncStorage();
 });
 
 afterEach(() => {
+    asyncStorage.getItem.mockReset();
+    asyncStorage.removeItem.mockReset();
+    asyncStorage.setItem.mockReset();
     vi.restoreAllMocks();
-    window.localStorage.clear();
 });
 
-describe('createDefaultAuthorizationCache', () => {
+describe('react-native createDefaultAuthorizationCache fork', () => {
+    it('persists cached authorization, rehydrates serialized public keys, and clears the cache', async () => {
+        const publicKey = Uint8Array.of(1, 2, 3);
+        const authorization = createAuthorization(publicKey);
+        const cache = createDefaultAuthorizationCache();
+
+        await cache.set(authorization);
+
+        const cachedAuthorization = await cache.get();
+
+        expect(asyncStorage.setItem).toHaveBeenCalledWith(AUTHORIZATION_CACHE_KEY, JSON.stringify(authorization));
+        expectAccountPublicKey(cachedAuthorization?.accounts[0], publicKey);
+        expect(cachedAuthorization?.auth_token).toBe('token');
+        expect(cachedAuthorization?.chain).toBe(SOLANA_MAINNET_CHAIN);
+
+        await cache.clear();
+
+        expect(asyncStorage.removeItem).toHaveBeenCalledWith(AUTHORIZATION_CACHE_KEY);
+        await expect(cache.get()).resolves.toBeUndefined();
+    });
+
     it('falls back to decoding public keys from account addresses', async () => {
         const publicKey = Uint8Array.of(7, 8, 9);
 
-        window.localStorage.setItem(
-            AUTHORIZATION_CACHE_KEY,
+        asyncStorage.getItem.mockResolvedValue(
             JSON.stringify({
                 accounts: [
                     {
@@ -54,40 +97,6 @@ describe('createDefaultAuthorizationCache', () => {
         expectAccountPublicKey(authorization?.accounts[0], publicKey);
     });
 
-    it('persists cached authorization, rehydrates serialized public keys, and clears the cache', async () => {
-        const publicKey = Uint8Array.of(1, 2, 3);
-
-        const authorization = createAuthorization(publicKey);
-        const cache = createDefaultAuthorizationCache();
-
-        await cache.set(authorization);
-
-        const cachedAuthorization = await cache.get();
-
-        expect(window.localStorage.getItem(AUTHORIZATION_CACHE_KEY)).not.toBeNull();
-        expectAccountPublicKey(cachedAuthorization?.accounts[0], publicKey);
-        expect(cachedAuthorization?.auth_token).toBe('token');
-        expect(cachedAuthorization?.chain).toBe(SOLANA_MAINNET_CHAIN);
-
-        await cache.clear();
-
-        expect(window.localStorage.getItem(AUTHORIZATION_CACHE_KEY)).toBeNull();
-    });
-
-    it('returns undefined for invalid cached JSON', async () => {
-        window.localStorage.setItem(AUTHORIZATION_CACHE_KEY, '{');
-
-        await expect(createDefaultAuthorizationCache().get()).resolves.toBeUndefined();
-    });
-
-    it('returns undefined when localStorage is unavailable', async () => {
-        vi.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
-            throw new Error('localStorage unavailable');
-        });
-
-        await expect(createDefaultAuthorizationCache().get()).resolves.toBeUndefined();
-    });
-
     it('returns cached objects that do not include accounts', async () => {
         const authorization = {
             auth_token: 'token',
@@ -95,38 +104,30 @@ describe('createDefaultAuthorizationCache', () => {
             wallet_uri_base: 'https://example.com',
         };
 
-        window.localStorage.setItem(AUTHORIZATION_CACHE_KEY, JSON.stringify(authorization));
+        asyncStorage.getItem.mockResolvedValue(JSON.stringify(authorization));
 
         await expect(createDefaultAuthorizationCache().get()).resolves.toEqual(authorization);
     });
 
-    it('returns undefined when no cached authorization exists', async () => {
-        await expect(createDefaultAuthorizationCache().get()).resolves.toBeUndefined();
-    });
-
-    it('no-ops clear and set when localStorage is unavailable', async () => {
-        vi.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
-            throw new Error('localStorage unavailable');
-        });
-
+    it('returns undefined for missing or invalid cached JSON', async () => {
         const cache = createDefaultAuthorizationCache();
 
-        await expect(cache.clear()).resolves.toBeUndefined();
-        await expect(cache.set(createAuthorization(Uint8Array.of(1, 2, 3)))).resolves.toBeUndefined();
+        asyncStorage.getItem.mockResolvedValueOnce(null).mockResolvedValueOnce('{');
+
+        await expect(cache.get()).resolves.toBeUndefined();
+        await expect(cache.get()).resolves.toBeUndefined();
     });
 
-    it('swallows localStorage clear and set failures', async () => {
+    it('swallows AsyncStorage failures', async () => {
         const cache = createDefaultAuthorizationCache();
 
-        vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
-            throw new Error('remove failed');
-        });
-        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
-            throw new Error('set failed');
-        });
+        asyncStorage.setItem.mockRejectedValueOnce(new Error('set failed'));
+        asyncStorage.getItem.mockRejectedValueOnce(new Error('get failed'));
+        asyncStorage.removeItem.mockRejectedValueOnce(new Error('clear failed'));
 
-        await expect(cache.clear()).resolves.toBeUndefined();
         await expect(cache.set(createAuthorization(Uint8Array.of(1, 2, 3)))).resolves.toBeUndefined();
+        await expect(cache.get()).resolves.toBeUndefined();
+        await expect(cache.clear()).resolves.toBeUndefined();
     });
 });
 

--- a/js/packages/wallet-standard-mobile/test/embeddedModal.test.ts
+++ b/js/packages/wallet-standard-mobile/test/embeddedModal.test.ts
@@ -41,6 +41,13 @@ afterEach(() => {
 });
 
 describe('EmbeddedModal', () => {
+    it('no-ops open and close before initialization', () => {
+        const modal = new TestModal();
+
+        expect(() => modal.open()).not.toThrow();
+        expect(() => modal.close()).not.toThrow();
+    });
+
     it('injects modal content, opens, closes, and removes close listeners', async () => {
         const modal = new TestModal();
         const closeListener = vi.fn();
@@ -76,6 +83,25 @@ describe('EmbeddedModal', () => {
         expect(closeListener).toHaveBeenCalledTimes(1);
     });
 
+    it('reuses an existing embedded modal root when one is already present', async () => {
+        const existingRoot = document.createElement('div');
+        const modal = new TestModal();
+
+        existingRoot.id = 'mobile-wallet-adapter-embedded-root-ui';
+        document.body.appendChild(existingRoot);
+
+        await modal.init();
+
+        expect(existingRoot.style.display).toBe('');
+        expect(document.body.children).toHaveLength(1);
+
+        modal.open();
+        expect(existingRoot.style.display).toBe('flex');
+
+        modal.close();
+        expect(existingRoot.style.display).toBe('none');
+    });
+
     it('closes when the backdrop is clicked', async () => {
         const modal = new TestModal();
         const closeListener = vi.fn();
@@ -94,6 +120,13 @@ describe('EmbeddedModal', () => {
 });
 
 describe('EmbeddedLoadingSpinner', () => {
+    it('no-ops open and close before initialization', () => {
+        const spinner = new EmbeddedLoadingSpinner();
+
+        expect(() => spinner.open()).not.toThrow();
+        expect(() => spinner.close()).not.toThrow();
+    });
+
     it('injects, opens, closes, and handles escape key closure', async () => {
         const spinner = new EmbeddedLoadingSpinner();
         const closeListener = vi.fn();
@@ -101,10 +134,12 @@ describe('EmbeddedLoadingSpinner', () => {
         spinner.addEventListener('close', closeListener);
 
         await spinner.init();
+        await spinner.init();
         spinner.open();
 
         const root = getRoot(getDom(spinner));
 
+        expect(document.body.children).toHaveLength(1);
         expect(root.style.display).toBe('flex');
 
         const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape' });
@@ -204,12 +239,20 @@ describe('concrete embedded modals', () => {
         mockGetIsPwaLaunchedAsApp.mockReturnValueOnce(true);
 
         const appModal = new LoopbackPermissionBlockedModal();
+        const closeListener = vi.fn();
 
+        appModal.addEventListener('close', closeListener);
         await appModal.init();
 
         expect(getDom(appModal).textContent).toContain(
             'Long press the app icon on your home screen to open site settings',
         );
+
+        getDom(appModal)
+            .getElementById('mobile-wallet-adapter-launch-action')
+            ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(closeListener).toHaveBeenCalledWith(expect.any(MouseEvent));
 
         document.body.replaceChildren();
         mockGetIsPwaLaunchedAsApp.mockReturnValueOnce(false);
@@ -243,6 +286,16 @@ describe('concrete embedded modals', () => {
 
         expect(mockQrCodeToCanvas).toHaveBeenCalledWith('solana-wallet:/second', { margin: 0, width: 200 });
         expect(qrContainer?.firstElementChild).toBe(secondCanvas);
+    });
+
+    it('logs when the remote connection QR container is missing', async () => {
+        const modal = new RemoteConnectionModal();
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await modal.populateQRCode('solana-wallet:/missing-container');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('QRCode Container not found');
+        expect(mockQrCodeToCanvas).not.toHaveBeenCalled();
     });
 });
 

--- a/js/packages/wallet-standard-mobile/test/getIsSupported.test.ts
+++ b/js/packages/wallet-standard-mobile/test/getIsSupported.test.ts
@@ -125,6 +125,7 @@ beforeEach(() => {
 afterEach(() => {
     resetModalMocks();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
 });
 
 type MockPermissionStatus = {
@@ -157,6 +158,43 @@ describe('getIsSupported helpers', () => {
         expect(blockedModalInstances).toHaveLength(0);
         expect(localConnectionModalInstances).toHaveLength(0);
         expect(permissionModalInstances).toHaveLength(0);
+    });
+
+    it('covers the local network access API missing case with the alternate permission name', async () => {
+        installBrowserGlobals({
+            permissionQuery: vi
+                .fn()
+                .mockRejectedValue(new TypeError('local-network-access is not a valid permission name')),
+        });
+
+        await expect(checkLocalNetworkAccessPermission()).resolves.toBeUndefined();
+    });
+
+    it('covers prompt close events without cancellation payloads', async () => {
+        const permission = createPermissionStatus('prompt');
+
+        installBrowserGlobals({
+            permissionQuery: vi.fn().mockResolvedValue(permission),
+        });
+
+        const permissionPromise = checkLocalNetworkAccessPermission();
+
+        await vi.waitFor(() => {
+            expect(permissionModalInstances).toHaveLength(1);
+        });
+
+        permissionModalInstances[0].closeListener?.();
+        permission.state = 'granted';
+        permission.onchange?.(new Event('change'));
+
+        await vi.waitFor(() => {
+            expect(localConnectionModalInstances).toHaveLength(1);
+        });
+
+        localConnectionModalInstances[0].closeListener?.();
+        await localConnectionModalInstances[0].callback?.();
+
+        await expect(permissionPromise).resolves.toBeUndefined();
     });
 
     it('covers the prompt flow cancelling before permission is granted', async () => {
@@ -329,7 +367,35 @@ describe('getIsSupported helpers', () => {
         expect(getIsPwaLaunchedAsApp()).toBe(true);
     });
 
+    it('treats Android TWA referrers as app launches when window is unavailable', () => {
+        Object.defineProperty(document, 'referrer', {
+            configurable: true,
+            value: 'android-app://com.example.wallet',
+        });
+        vi.stubGlobal('window', undefined);
+
+        expect(getIsPwaLaunchedAsApp()).toBe(true);
+    });
+
     it('treats matching display modes as app launches', () => {
+        installBrowserGlobals({
+            displayMode: { fullscreen: true },
+            documentReferrer: '',
+            isSecureContext: true,
+            userAgent: DESKTOP_BROWSER_USER_AGENT,
+        });
+
+        expect(getIsPwaLaunchedAsApp()).toBe(true);
+
+        installBrowserGlobals({
+            displayMode: { minimalUI: true },
+            documentReferrer: '',
+            isSecureContext: true,
+            userAgent: DESKTOP_BROWSER_USER_AGENT,
+        });
+
+        expect(getIsPwaLaunchedAsApp()).toBe(true);
+
         installBrowserGlobals({
             displayMode: { standalone: true },
             documentReferrer: '',
@@ -389,6 +455,18 @@ describe('getIsSupported helpers', () => {
         await expect(checkLocalNetworkAccessPermission()).rejects.toMatchObject({
             code: SolanaMobileWalletAdapterErrorCode.ERROR_LOOPBACK_ACCESS_BLOCKED,
             message: 'permission service unavailable',
+            name: 'SolanaMobileWalletAdapterError',
+        });
+    });
+
+    it('wraps non-error permission failures with the fallback message', async () => {
+        installBrowserGlobals({
+            permissionQuery: vi.fn().mockRejectedValue('permission service unavailable'),
+        });
+
+        await expect(checkLocalNetworkAccessPermission()).rejects.toMatchObject({
+            code: SolanaMobileWalletAdapterErrorCode.ERROR_LOOPBACK_ACCESS_BLOCKED,
+            message: 'Local Network Access permission unknown',
             name: 'SolanaMobileWalletAdapterError',
         });
     });

--- a/js/packages/wallet-standard-mobile/test/wallet.test.ts
+++ b/js/packages/wallet-standard-mobile/test/wallet.test.ts
@@ -8,6 +8,10 @@ import {
     SolanaSignTransaction,
     type SolanaSignTransactionFeature,
 } from '@solana/wallet-standard-features';
+import {
+    SolanaMobileWalletAdapterError,
+    SolanaMobileWalletAdapterErrorCode,
+} from '@solana-mobile/mobile-wallet-adapter-protocol';
 import type { WalletAccount } from '@wallet-standard/base';
 import { StandardConnect, StandardDisconnect, StandardEvents } from '@wallet-standard/features';
 import base58 from 'bs58';
@@ -231,6 +235,13 @@ describe('LocalSolanaMobileWalletAdapterWallet', () => {
         expect(loadingSpinnerInstances[0].close).toHaveBeenCalledTimes(1);
         expect(scenarioClose).toHaveBeenCalledTimes(1);
 
+        const spinnerCloseListener = loadingSpinnerInstances[0].addEventListener.mock.calls[0][1];
+        spinnerCloseListener(new Event('close'));
+        expect(scenarioClose).toHaveBeenCalledTimes(2);
+
+        await expect(wallet.features[StandardConnect].connect()).resolves.toEqual({ accounts: wallet.accounts });
+        expect(mockStartScenario).toHaveBeenCalledTimes(1);
+
         removeListener();
         await wallet.features[StandardDisconnect].disconnect();
 
@@ -263,6 +274,16 @@ describe('LocalSolanaMobileWalletAdapterWallet', () => {
         expect(authorizationCache.get).toHaveBeenCalledTimes(1);
         expect(changeListener).toHaveBeenCalledWith({ features: wallet.features });
         expect(changeListener).toHaveBeenCalledWith({ accounts: wallet.accounts });
+    });
+
+    it('returns existing accounts without association for silent connects when nothing is cached', async () => {
+        const { authorizationCache, wallet } = createLocalWallet();
+
+        await expect(wallet.features[StandardConnect].connect({ silent: true })).resolves.toEqual({ accounts: [] });
+
+        expect(authorizationCache.get).toHaveBeenCalledTimes(1);
+        expect(mockStartScenario).not.toHaveBeenCalled();
+        expect(wallet.connected).toBe(false);
     });
 
     it('signs transactions, sends transactions, and signs messages after authorization', async () => {
@@ -388,6 +409,157 @@ describe('LocalSolanaMobileWalletAdapterWallet', () => {
         ).rejects.toThrow('Wallet not connected');
         expect(mockStartScenario).not.toHaveBeenCalled();
     });
+
+    it('rejects connect when local association times out', async () => {
+        vi.useFakeTimers();
+        const { wallet } = createLocalWallet();
+
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockReturnValue(new Promise(() => undefined));
+
+        const connectPromise = wallet.features[StandardConnect].connect();
+        const expectation = expect(connectPromise).rejects.toThrow('Wallet connection timed out');
+        await vi.advanceTimersByTimeAsync(30000);
+
+        await expectation;
+        expect(loadingSpinnerInstances[0].close).toHaveBeenCalledTimes(1);
+        vi.useRealTimers();
+    });
+
+    it('runs the wallet-not-found handler for local association failures', async () => {
+        const onWalletNotFound = vi.fn<WalletNotFoundHandler>().mockResolvedValue(undefined);
+        const { wallet } = createLocalWallet({ onWalletNotFound });
+
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockRejectedValue(
+            new SolanaMobileWalletAdapterError(
+                SolanaMobileWalletAdapterErrorCode.ERROR_WALLET_NOT_FOUND,
+                'Found no installed wallet that supports the mobile wallet protocol.',
+            ),
+        );
+
+        await expect(wallet.features[StandardConnect].connect()).rejects.toThrow(
+            'Found no installed wallet that supports the mobile wallet protocol.',
+        );
+        expect(onWalletNotFound).toHaveBeenCalledWith(wallet);
+    });
+
+    it('wraps non-error local authorization failures with an unknown-error message', async () => {
+        const { wallet } = createLocalWallet();
+
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockRejectedValue('association failed');
+
+        await expect(wallet.features[StandardConnect].connect()).rejects.toThrow('Unknown error');
+    });
+
+    it('rejects local sign-and-send when the connected wallet reports no support', async () => {
+        const accountPublicKey = Uint8Array.of(61, 62, 63);
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(accountPublicKey),
+        });
+        const { wallet } = createLocalWallet();
+
+        mobileWallet.getCapabilities.mockResolvedValueOnce(DEFAULT_CAPABILITIES).mockResolvedValueOnce({
+            ...DEFAULT_CAPABILITIES,
+            supports_sign_and_send_transactions: false,
+        });
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockResolvedValue({
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await wallet.features[StandardConnect].connect();
+
+        await expect(
+            getSignAndSendFeature(wallet).signAndSendTransaction({
+                account: wallet.accounts[0],
+                chain: SOLANA_MAINNET_CHAIN,
+                transaction: Uint8Array.of(1, 2, 3),
+            }),
+        ).rejects.toThrow('connected wallet does not support signAndSendTransaction');
+    });
+
+    it('signs in with multiple inputs', async () => {
+        const accountPublicKey = Uint8Array.of(71, 72, 73);
+        const signedMessage = Uint8Array.of(74, 75, 76);
+        const signature = Uint8Array.of(77, 78, 79);
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(accountPublicKey, {
+                sign_in_result: {
+                    address: encodeBytes(accountPublicKey),
+                    signature: encodeBytes(signature),
+                    signed_message: encodeBytes(signedMessage),
+                },
+            }),
+        });
+        const { wallet } = createLocalWallet();
+
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockResolvedValue({
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await expect(
+            wallet.features[SolanaSignIn].signIn({ domain: 'one.example' }, { domain: 'two.example' }),
+        ).resolves.toHaveLength(2);
+        expect(mobileWallet.authorize).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects sign-in when the wallet omits the sign-in result', async () => {
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(Uint8Array.of(81, 82, 83)),
+        });
+        const { wallet } = createLocalWallet();
+
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockResolvedValue({
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await expect(wallet.features[SolanaSignIn].signIn()).rejects.toThrow(
+            'Sign in failed, no sign in result returned by wallet',
+        );
+    });
+
+    it('builds fallback account details when sign-in returns an address outside the authorized accounts', async () => {
+        const accountPublicKey = Uint8Array.of(84, 85, 86);
+        const signedInPublicKey = Uint8Array.of(87, 88, 89);
+        const signedMessage = Uint8Array.of(90, 91, 92);
+        const signature = Uint8Array.of(93, 94, 95);
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(accountPublicKey, {
+                sign_in_result: {
+                    address: encodeBytes(signedInPublicKey),
+                    signature: encodeBytes(signature),
+                    signed_message: encodeBytes(signedMessage),
+                },
+            }),
+        });
+        const { wallet } = createLocalWallet();
+
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockResolvedValue({
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await expect(wallet.features[SolanaSignIn].signIn({ domain: 'app.example' })).resolves.toEqual([
+            {
+                account: {
+                    address: base58.encode(signedInPublicKey),
+                    chains: [SOLANA_MAINNET_CHAIN],
+                    features: DEFAULT_CAPABILITIES.features,
+                    publicKey: signedInPublicKey,
+                },
+                signature,
+                signedMessage,
+            },
+        ]);
+    });
 });
 
 describe('RemoteSolanaMobileWalletAdapterWallet', () => {
@@ -404,6 +576,9 @@ describe('RemoteSolanaMobileWalletAdapterWallet', () => {
         });
         const scenarioClose = vi.fn();
         const { authorizationCache, chainSelector, wallet } = createRemoteWallet();
+        const changeListener = vi.fn();
+
+        const removeListener = wallet.features[StandardEvents].on('change', changeListener);
 
         mobileWallet.signTransactions.mockResolvedValue({
             signed_payloads: [encodeBytes(Uint8Array.of(34, 35, 36))],
@@ -423,6 +598,14 @@ describe('RemoteSolanaMobileWalletAdapterWallet', () => {
             ],
         });
 
+        expect(wallet.version).toBe('1.0.0');
+        expect(wallet.name).toBe('Remote Mobile Wallet Adapter');
+        expect(wallet.url).toBe('https://solanamobile.com/wallets');
+        expect(wallet.icon).toMatch(/^data:image\/svg\+xml;base64,/);
+        expect(wallet.chains).toEqual([SOLANA_MAINNET_CHAIN]);
+        expect(wallet.currentAuthorization).toEqual(expect.objectContaining({ auth_token: 'auth-token' }));
+        expect(wallet.isAuthorized).toBe(true);
+        await expect(wallet.cachedAuthorizationResult).resolves.toBeUndefined();
         expect(mockStartRemoteScenario).toHaveBeenCalledWith({
             remoteHostAuthority: 'remote.example.com',
         });
@@ -432,6 +615,8 @@ describe('RemoteSolanaMobileWalletAdapterWallet', () => {
         expect(remoteModalInstances[0].open).toHaveBeenCalledTimes(1);
         expect(remoteModalInstances[0].populateQRCode).toHaveBeenCalledWith('https://example.test/associate');
         expect(remoteModalInstances[0].close).toHaveBeenCalledTimes(1);
+        remoteModalInstances[0].addEventListener.mock.calls[0][1](new Event('close'));
+        expect(scenarioClose).toHaveBeenCalledTimes(1);
         expect(wallet.connected).toBe(true);
         expect(getSignAndSendFeature(wallet).supportedTransactionVersions).toEqual(['legacy', 0]);
         expect(getSignTransactionFeature(wallet).supportedTransactionVersions).toEqual(['legacy', 0]);
@@ -448,11 +633,16 @@ describe('RemoteSolanaMobileWalletAdapterWallet', () => {
             payloads: [encodeBytes(Uint8Array.of(1, 2, 3))],
         });
 
+        await expect(wallet.features[StandardConnect].connect()).resolves.toEqual({ accounts: wallet.accounts });
+        expect(mockStartRemoteScenario).toHaveBeenCalledTimes(1);
+
+        removeListener();
         await wallet.features[StandardDisconnect].disconnect();
 
-        expect(scenarioClose).toHaveBeenCalledTimes(1);
+        expect(scenarioClose).toHaveBeenCalledTimes(2);
         expect(authorizationCache.clear).toHaveBeenCalledTimes(1);
         expect(wallet.connected).toBe(false);
+        expect(changeListener).toHaveBeenCalledWith({ accounts: expect.any(Array) });
     });
 
     it('uses an existing remote session to sign and send transactions and sign messages', async () => {
@@ -552,12 +742,169 @@ describe('RemoteSolanaMobileWalletAdapterWallet', () => {
             },
         });
     });
+
+    it('uses cached remote authorization results without starting a session', async () => {
+        const cachedAuthorization = createCachedAuthorization(Uint8Array.of(101, 102, 103), {
+            ...DEFAULT_CAPABILITIES,
+            features: [],
+            supports_sign_and_send_transactions: false,
+        });
+        const { authorizationCache, wallet } = createRemoteWallet({ cachedAuthorization });
+        const changeListener = vi.fn();
+
+        wallet.features[StandardEvents].on('change', changeListener);
+
+        await expect(wallet.features[StandardConnect].connect()).resolves.toEqual({
+            accounts: [cachedAuthorization.accounts[0]],
+        });
+
+        expect(authorizationCache.get).toHaveBeenCalledTimes(1);
+        expect(mockStartRemoteScenario).not.toHaveBeenCalled();
+        expect(getSignAndSendFeature(wallet)).toBeDefined();
+        expect(getSignTransactionFeature(wallet)).toBeDefined();
+        expect(changeListener).toHaveBeenCalledWith({ accounts: wallet.accounts });
+    });
+
+    it('rejects remote signing methods when the wallet is not connected', async () => {
+        const { wallet } = createRemoteWallet();
+
+        await expect(
+            wallet.features[SolanaSignMessage].signMessage({
+                account: createWalletAccount(Uint8Array.of(1, 2, 3)),
+                message: Uint8Array.of(1, 2, 3),
+            }),
+        ).rejects.toThrow('Wallet not connected');
+        expect(mockStartRemoteScenario).not.toHaveBeenCalled();
+    });
+
+    it('runs the wallet-not-found handler for remote association failures', async () => {
+        const onWalletNotFound = vi.fn<WalletNotFoundHandler>().mockResolvedValue(undefined);
+        const { wallet } = createRemoteWallet({ onWalletNotFound });
+
+        mockStartRemoteScenario.mockRejectedValue(
+            new SolanaMobileWalletAdapterError(
+                SolanaMobileWalletAdapterErrorCode.ERROR_WALLET_NOT_FOUND,
+                'Found no installed wallet that supports the mobile wallet protocol.',
+            ),
+        );
+
+        await expect(wallet.features[StandardConnect].connect()).rejects.toThrow(
+            'Found no installed wallet that supports the mobile wallet protocol.',
+        );
+        expect(remoteModalInstances[0].close).toHaveBeenCalledTimes(1);
+        expect(onWalletNotFound).toHaveBeenCalledWith(wallet);
+    });
+
+    it('disconnects remote authorization when reauthorization fails', async () => {
+        const accountPublicKey = Uint8Array.of(104, 105, 106);
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(accountPublicKey),
+        });
+        const scenarioClose = vi.fn();
+        const { authorizationCache, wallet } = createRemoteWallet();
+
+        mobileWallet.authorize
+            .mockResolvedValueOnce(createMwaAuthorization(accountPublicKey))
+            .mockRejectedValueOnce(new Error('reauthorize failed'));
+        mockStartRemoteScenario.mockResolvedValue({
+            associationUrl: new URL('https://example.test/associate'),
+            close: scenarioClose,
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await wallet.features[StandardConnect].connect();
+
+        await expect(
+            wallet.features[SolanaSignMessage].signMessage({
+                account: wallet.accounts[0],
+                message: Uint8Array.of(1, 2, 3),
+            }),
+        ).rejects.toThrow('reauthorize failed');
+
+        expect(scenarioClose).toHaveBeenCalledTimes(1);
+        expect(authorizationCache.clear).toHaveBeenCalledTimes(1);
+        expect(wallet.connected).toBe(false);
+    });
+
+    it('rejects remote sign-and-send when the connected wallet reports no support', async () => {
+        const accountPublicKey = Uint8Array.of(107, 108, 109);
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(accountPublicKey),
+        });
+        const { wallet } = createRemoteWallet();
+
+        mobileWallet.getCapabilities.mockResolvedValueOnce(DEFAULT_CAPABILITIES).mockResolvedValueOnce({
+            ...DEFAULT_CAPABILITIES,
+            supports_sign_and_send_transactions: false,
+        });
+        mockStartRemoteScenario.mockResolvedValue({
+            associationUrl: new URL('https://example.test/associate'),
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await wallet.features[StandardConnect].connect();
+
+        await expect(
+            getSignAndSendFeature(wallet).signAndSendTransaction({
+                account: wallet.accounts[0],
+                chain: SOLANA_MAINNET_CHAIN,
+                transaction: Uint8Array.of(1, 2, 3),
+            }),
+        ).rejects.toThrow('connected wallet does not support signAndSendTransaction');
+    });
+
+    it('rejects remote sign-in when the wallet omits the sign-in result', async () => {
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(Uint8Array.of(110, 111, 112)),
+        });
+        const { wallet } = createRemoteWallet();
+
+        mockStartRemoteScenario.mockResolvedValue({
+            associationUrl: new URL('https://example.test/associate'),
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await expect(wallet.features[SolanaSignIn].signIn()).rejects.toThrow(
+            'Sign in failed, no sign in result returned by wallet',
+        );
+    });
+
+    it('signs in remotely with multiple inputs', async () => {
+        const accountPublicKey = Uint8Array.of(113, 114, 115);
+        const signedMessage = Uint8Array.of(116, 117, 118);
+        const signature = Uint8Array.of(119, 120, 121);
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(accountPublicKey, {
+                sign_in_result: {
+                    address: encodeBytes(accountPublicKey),
+                    signature: encodeBytes(signature),
+                    signed_message: encodeBytes(signedMessage),
+                },
+            }),
+        });
+        const { wallet } = createRemoteWallet();
+
+        mockStartRemoteScenario.mockResolvedValue({
+            associationUrl: new URL('https://example.test/associate'),
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await expect(
+            wallet.features[SolanaSignIn].signIn({ domain: 'one.example' }, { domain: 'two.example' }),
+        ).resolves.toHaveLength(2);
+        expect(mobileWallet.authorize).toHaveBeenCalledTimes(2);
+    });
 });
 
 function createLocalWallet({
     cachedAuthorization,
+    onWalletNotFound = vi.fn<WalletNotFoundHandler>().mockResolvedValue(undefined),
 }: {
     cachedAuthorization?: Authorization;
+    onWalletNotFound?: WalletNotFoundHandler;
 } = {}) {
     const authorizationCache = createAuthorizationCache(cachedAuthorization);
     const chainSelector = {
@@ -572,14 +919,20 @@ function createLocalWallet({
         authorizationCache,
         chains: [SOLANA_MAINNET_CHAIN],
         chainSelector,
-        onWalletNotFound: vi.fn().mockResolvedValue(undefined),
+        onWalletNotFound,
     });
 
-    return { authorizationCache, chainSelector, wallet };
+    return { authorizationCache, chainSelector, onWalletNotFound, wallet };
 }
 
-function createRemoteWallet() {
-    const authorizationCache = createAuthorizationCache();
+function createRemoteWallet({
+    cachedAuthorization,
+    onWalletNotFound = vi.fn<WalletNotFoundHandler>().mockResolvedValue(undefined),
+}: {
+    cachedAuthorization?: Authorization;
+    onWalletNotFound?: WalletNotFoundHandler;
+} = {}) {
+    const authorizationCache = createAuthorizationCache(cachedAuthorization);
     const chainSelector = {
         select: vi.fn().mockResolvedValue(SOLANA_MAINNET_CHAIN),
     };
@@ -592,12 +945,14 @@ function createRemoteWallet() {
         authorizationCache,
         chains: [SOLANA_MAINNET_CHAIN],
         chainSelector,
-        onWalletNotFound: vi.fn().mockResolvedValue(undefined),
+        onWalletNotFound,
         remoteHostAuthority: 'remote.example.com',
     });
 
-    return { authorizationCache, chainSelector, wallet };
+    return { authorizationCache, chainSelector, onWalletNotFound, wallet };
 }
+
+type WalletNotFoundHandler = ConstructorParameters<typeof LocalSolanaMobileWalletAdapterWallet>[0]['onWalletNotFound'];
 
 function createAuthorizationCache(cachedAuthorization?: Authorization) {
     return {


### PR DESCRIPTION
Cover web and React Native authorization cache edge cases, getIsSupported permission branches, and embedded modal listener behavior.

Add local and remote wallet tests for cached authorization, sign-in edge cases, session reuse, and error handling.