### PR TITLE
Fix changeset formatting and add linter

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -36,6 +36,9 @@ jobs:
       - name: '[js] Lint'
         working-directory: 'js/'
         run: pnpm lint:check
+      - name: '[js] Changeset Check'
+        working-directory: 'js/'
+        run: pnpm changeset:check
       - name: '[js] Format Check'
         working-directory: 'js/'
         run: pnpm format:check

--- a/js/.changeset/five-cars-fail.md
+++ b/js/.changeset/five-cars-fail.md
@@ -1,10 +1,10 @@
-"@solana-mobile/mobile-wallet-adapter-protocol": patch
-"@solana-mobile/mobile-wallet-adapter-protocol-kit": patch
-"@solana-mobile/mobile-wallet-adapter-protocol-web3js": patch
-"@solana-mobile/mobile-wallet-adapter-walletlib": patch
-"@solana-mobile/wallet-adapter-mobile": patch
-"@solana-mobile/wallet-standard-mobile": patch
-
+---
+'@solana-mobile/mobile-wallet-adapter-protocol': patch
+'@solana-mobile/mobile-wallet-adapter-protocol-kit': patch
+'@solana-mobile/mobile-wallet-adapter-protocol-web3js': patch
+'@solana-mobile/mobile-wallet-adapter-walletlib': patch
+'@solana-mobile/wallet-adapter-mobile': patch
+'@solana-mobile/wallet-standard-mobile': patch
 ---
 
 Prepare the JS packages for a future TypeScript 6 upgrade without changing the current TypeScript version.

--- a/js/package.json
+++ b/js/package.json
@@ -4,6 +4,7 @@
     "packageManager": "pnpm@10.30.0",
     "scripts": {
         "build": "turbo run build",
+        "changeset:check": "node ./scripts/check-changesets.mjs",
         "check-types": "turbo run check-types",
         "clean": "turbo run clean",
         "format:check": "prettier . --check --cache",

--- a/js/scripts/check-changesets.mjs
+++ b/js/scripts/check-changesets.mjs
@@ -1,0 +1,11 @@
+import { createRequire } from 'node:module';
+import process from 'node:process';
+
+const require = createRequire(import.meta.url);
+const requireFromChangesetsCli = createRequire(require.resolve('@changesets/cli/package.json'));
+const readChangesets = requireFromChangesetsCli('@changesets/read').default;
+
+const changesets = await readChangesets(process.cwd());
+const suffix = changesets.length === 1 ? '' : 's';
+
+process.stdout.write(`Validated ${changesets.length} changeset${suffix}.\n`);


### PR DESCRIPTION
Fix the malformed Changesets frontmatter in the pending TypeScript 6 changeset so release jobs can parse it.

Add a JS CI check that runs Changesets status when pending changesets exist, catching manually edited changeset formatting before publish jobs run.