### PR TITLE
Fix clientlib-ktx sample Hilt version

### DIFF
--- a/examples/example-clientlib-ktx-app/app/build.gradle
+++ b/examples/example-clientlib-ktx-app/app/build.gradle
@@ -76,8 +76,8 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.13.0'
     implementation "androidx.hilt:hilt-navigation-compose:1.3.0"
 
-    implementation "com.google.dagger:hilt-android:2.59.2"
-    kapt "com.google.dagger:hilt-compiler:2.59.2"
+    implementation "com.google.dagger:hilt-android:2.57.2"
+    kapt "com.google.dagger:hilt-compiler:2.57.2"
 
     implementation 'com.solanamobile:rpc-core:0.2.11'
     implementation 'com.solanamobile:rpc-solana:0.2.11'

--- a/examples/example-clientlib-ktx-app/build.gradle
+++ b/examples/example-clientlib-ktx-app/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.google.dagger:hilt-android-gradle-plugin:2.59.2"
+        classpath "com.google.dagger:hilt-android-gradle-plugin:2.57.2"
     }
 }
 


### PR DESCRIPTION
Pin the sample app Hilt Gradle plugin, runtime, and compiler to 2.57.2 so it remains compatible with the shared Android Gradle Plugin 8.13.1 version catalog.

This regressed in bf871b28 / PR #1394, which bumped hilt-android-gradle-plugin to 2.59.2. Dagger 2.59 requires AGP 9 for the Hilt Gradle plugin, but this repo is still on AGP 8.13.1.
