### PR TITLE
fix: cancel coroutine scope on RESULT_CANCELED in associate()

### DIFF
--- a/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/MobileWalletAdapter.kt
+++ b/android/clientlib-ktx/src/main/java/com/solana/mobilewalletadapter/clientlib/MobileWalletAdapter.kt
@@ -162,13 +162,12 @@ class MobileWalletAdapter(
                 withTimeout(ASSOCIATION_SEND_INTENT_TIMEOUT_MS) {
                     sender.startActivityForResult(intent) {
                         if (it == RESULT_CANCELED) {
-                            this.launch {
-                                throw InterruptedException()
+                            this.cancel()
+                        } else {
+                            launch {
+                                delay(5000L)
+                                scenario.close()
                             }
-                        }
-                        launch {
-                            delay(5000L)
-                            scenario.close()
                         }
                     }
                 }


### PR DESCRIPTION
When the wallet activity returns RESULT_CANCELED, the current code launches a child coroutine that throws InterruptedException. This bypasses Kotlin structured concurrency: the exception can propagate unpredictably out of the coroutine scope and crash the host activity, particularly on devices where the wallet session is interrupted mid-flow (e.g. USB disconnected, wallet process killed).

Replace with this.cancel(), which is the idiomatic way to cancel a CoroutineScope in Kotlin. This:
- Immediately cancels the running withContext(ioDispatcher) block
- Triggers the finally block so scenario.close() still runs
- Surfaces as CancellationException, caught by the existing handler that returns TransactionResult.Failure("Request was cancelled")
- Moves the delayed scenario.close() into the else branch so it only runs on RESULT_OK, not on cancellation

Tested on Solana Seeker (SM02G, Android 14) with clientlib-ktx 2.0.3 where RESULT_CANCELED was reproducible by disconnecting USB mid-session.