### PR TITLE
Add JS coverage tests across mobile wallet packages

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/test/createMobileWalletProxy.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/createMobileWalletProxy.test.ts
@@ -23,6 +23,13 @@ describe('createMobileWalletProxy', () => {
         expect(Reflect.deleteProperty(wallet, 'authorize')).toBe(false);
     });
 
+    it('reuses generated wallet method wrappers after the first access', () => {
+        const wallet = createMobileWalletProxy('v1', vi.fn());
+        const authorize = wallet.authorize;
+
+        expect(wallet.authorize).toBe(authorize);
+    });
+
     it('maps legacy authorize chains to clusters', async () => {
         const protocolRequestHandler = vi.fn().mockResolvedValue(AUTHORIZATION_RESULT);
         const wallet = createMobileWalletProxy('legacy', protocolRequestHandler);
@@ -240,7 +247,6 @@ describe('createMobileWalletProxy', () => {
             chain: 'solana:mainnet',
             identity: APP_IDENTITY,
             sign_in_payload: {
-                domain: 'example.test',
                 nonce: 'nonce-123',
             },
         });

--- a/js/packages/mobile-wallet-adapter-protocol/test/encryptedMessage.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/encryptedMessage.test.ts
@@ -44,6 +44,7 @@ describe('encryptedMessage', () => {
         const message = Uint8Array.of(...SEQUENCE_NUMBER_VECTOR, ...INITIALIZATION_VECTOR, ...CIPHERTEXT).buffer;
 
         await expect(decryptMessage(message, SHARED_SECRET)).resolves.toBe(PLAINTEXT);
+        await expect(decryptMessage(message, SHARED_SECRET)).resolves.toBe(PLAINTEXT);
 
         expect(mockDecrypt).toHaveBeenCalledWith(
             {

--- a/js/packages/mobile-wallet-adapter-protocol/test/startSession.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/startSession.test.ts
@@ -53,7 +53,7 @@ describe('startSession', () => {
         );
     });
 
-    it('launches custom protocol URLs through a hidden iframe in Firefox', async () => {
+    it('launches custom protocol URLs through a reused hidden iframe in Firefox', async () => {
         const associationUrl = new URL('solana-wallet:/v1/associate/local');
         const frame = {
             contentWindow: {
@@ -79,10 +79,13 @@ describe('startSession', () => {
         });
 
         await expect(startSession(ASSOCIATION_PUBLIC_KEY)).resolves.toBe(ASSOCIATION_PORT);
+        await expect(startSession(ASSOCIATION_PUBLIC_KEY)).resolves.toBe(ASSOCIATION_PORT);
 
         expect(frame.contentWindow.location.href).toBe(associationUrl.toString());
         expect(frame.style.display).toBe('none');
+        expect(mockAppendChild).toHaveBeenCalledTimes(1);
         expect(mockAppendChild).toHaveBeenCalledWith(frame);
+        expect(mockCreateElement).toHaveBeenCalledTimes(1);
         expect(mockCreateElement).toHaveBeenCalledWith('iframe');
     });
 

--- a/js/packages/mobile-wallet-adapter-protocol/test/transact.react-native.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/transact.react-native.test.ts
@@ -91,6 +91,37 @@ describe('react-native transact fork', () => {
         expect(nativeModule.endSession).not.toHaveBeenCalled();
     });
 
+    it('maps native module errors with recognized protocol codes', async () => {
+        const nativeModule = createNativeModule();
+        nativeModule.startSession.mockRejectedValue(
+            Object.assign(new Error('native session closed'), {
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_SESSION_CLOSED,
+                userInfo: { closeEvent: 'close' },
+            }),
+        );
+
+        const { transact } = await importReactNativeTransact({ nativeModule });
+
+        await expect(transact(vi.fn())).rejects.toEqual(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_SESSION_CLOSED,
+                message: 'native session closed',
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+        expect(nativeModule.endSession).not.toHaveBeenCalled();
+    });
+
+    it('rethrows native module failures that are not errors', async () => {
+        const nativeModule = createNativeModule();
+        nativeModule.startSession.mockRejectedValue('native failure');
+
+        const { transact } = await importReactNativeTransact({ nativeModule });
+
+        await expect(transact(vi.fn())).rejects.toBe('native failure');
+        expect(nativeModule.endSession).not.toHaveBeenCalled();
+    });
+
     it('maps native JSON-RPC errors thrown by invoke', async () => {
         const nativeModule = createNativeModule();
         let invokePromise: Promise<unknown> | undefined;

--- a/js/packages/mobile-wallet-adapter-protocol/test/transact.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/transact.test.ts
@@ -188,6 +188,39 @@ describe('startScenario', () => {
         await expect(responsePromise).resolves.toBe(responseResult);
     });
 
+    it('uses empty params for local JSON-RPC requests without inputs', async () => {
+        const scenario = await startScenario();
+        const socket = getOnlySocket();
+        await establishLocalSession(socket);
+        await scenario.wallet;
+
+        const requestHandler = getLastProtocolRequestHandler();
+        const responseResult = {
+            features: [],
+        };
+        const responsePromise = requestHandler('get_capabilities');
+        await flushPromises();
+
+        expect(mockEncryptJsonRpcMessage).toHaveBeenCalledWith(
+            {
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'get_capabilities',
+                params: {},
+            },
+            SHARED_SECRET,
+        );
+
+        mockDecryptJsonRpcMessage.mockResolvedValue({
+            id: 1,
+            jsonrpc: '2.0',
+            result: responseResult,
+        });
+        await socket.dispatch('message', createBlobMessageEvent(INBOUND_SEQUENCE_ONE));
+
+        await expect(responsePromise).resolves.toBe(responseResult);
+    });
+
     it('rejects the wallet promise when the local socket closes unexpectedly', async () => {
         const scenario = await startScenario();
         const socket = getOnlySocket();
@@ -266,6 +299,16 @@ describe('startScenario', () => {
 
         await expect(scenario.wallet).resolves.toBe(WALLET);
         expect(socket.sent).toEqual([HELLO_REQ, HELLO_REQ]);
+    });
+
+    it('throws when the local wallet sends a non-empty app ping while connecting', async () => {
+        const scenario = await startScenario();
+        const socket = getOnlySocket();
+
+        await expect(socket.dispatch('message', createBlobMessageEvent(Uint8Array.of(1)))).rejects.toThrow(
+            'Encountered unexpected message while connecting',
+        );
+        await expect(Promise.race([scenario.wallet, Promise.resolve('pending')])).resolves.toBe('pending');
     });
 
     it('throws when local encrypted messages arrive out of sequence', async () => {
@@ -478,6 +521,39 @@ describe('startRemoteScenario', () => {
         );
     });
 
+    it('rejects when the remote reflector socket connection times out', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const scenarioPromise = startRemoteScenario(createRemoteConfig());
+        await flushPromises();
+        const socket = getOnlySocket();
+
+        vi.setSystemTime(30000);
+        await socket.dispatch('error', new Event('error'));
+
+        await expect(scenarioPromise).rejects.toEqual(
+            expect.objectContaining({
+                code: SolanaMobileWalletAdapterErrorCode.ERROR_SESSION_TIMEOUT,
+                name: 'SolanaMobileWalletAdapterError',
+            }),
+        );
+    });
+
+    it('leaves the remote association pending when the reflector closes cleanly', async () => {
+        const scenarioPromise = startRemoteScenario(createRemoteConfig());
+        await flushPromises();
+        const socket = getOnlySocket();
+
+        await socket.dispatch(
+            'close',
+            new CloseEvent('close', {
+                wasClean: true,
+            }),
+        );
+
+        await expect(Promise.race([scenarioPromise, Promise.resolve('pending')])).resolves.toBe('pending');
+    });
+
     it('throws when the reflector sends an empty id message while connecting', async () => {
         const scenarioPromise = startRemoteScenario(createRemoteConfig());
         await flushPromises();
@@ -554,6 +630,47 @@ describe('startRemoteScenario', () => {
         await socket.dispatch('message', createBlobMessageEvent(INBOUND_SEQUENCE_ONE));
 
         await expect(responsePromise).rejects.toBe(protocolError);
+    });
+
+    it('throws when remote encrypted messages arrive out of sequence', async () => {
+        const scenarioPromise = startRemoteScenario(createRemoteConfig());
+        await flushPromises();
+        const socket = getOnlySocket();
+
+        await socket.dispatch('open', new Event('open'));
+        await socket.dispatch('message', createBlobMessageEvent(Uint8Array.of(3, 7, 8, 9)));
+
+        const scenario = await scenarioPromise;
+        const walletPromise = scenario.wallet;
+        await socket.dispatch('message', createBlobMessageEvent(Uint8Array.of()));
+        await socket.dispatch('message', createBlobMessageEvent(HELLO_RSP));
+        await walletPromise;
+
+        await expect(socket.dispatch('message', createBlobMessageEvent(Uint8Array.of(0, 0, 0, 2, 99)))).rejects.toThrow(
+            'Encrypted message has invalid sequence number',
+        );
+    });
+
+    it('throws non-protocol remote decrypt errors', async () => {
+        const scenarioPromise = startRemoteScenario(createRemoteConfig());
+        await flushPromises();
+        const socket = getOnlySocket();
+
+        await socket.dispatch('open', new Event('open'));
+        await socket.dispatch('message', createBlobMessageEvent(Uint8Array.of(3, 7, 8, 9)));
+
+        const scenario = await scenarioPromise;
+        const walletPromise = scenario.wallet;
+        await socket.dispatch('message', createBlobMessageEvent(Uint8Array.of()));
+        await socket.dispatch('message', createBlobMessageEvent(HELLO_RSP));
+        await walletPromise;
+
+        const thrownError = new Error('decrypt failed');
+        mockDecryptJsonRpcMessage.mockRejectedValue(thrownError);
+
+        await expect(socket.dispatch('message', createBlobMessageEvent(INBOUND_SEQUENCE_ONE))).rejects.toBe(
+            thrownError,
+        );
     });
 
     it('rejects remote authorization responses with insecure wallet base URLs', async () => {

--- a/js/packages/mobile-wallet-adapter-walletlib/test/initializeMobileWalletAdapterSession.test.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/test/initializeMobileWalletAdapterSession.test.ts
@@ -1,16 +1,23 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { mockCreateScenario, nativeModules, platform } = vi.hoisted(() => ({
-    mockCreateScenario: vi.fn(),
-    nativeModules: {
-        SolanaMobileWalletAdapterWalletLib: {
-            createScenario: vi.fn(),
-        },
-    },
-    platform: { OS: 'android' },
-}));
+const { mockCreateScenario, nativeModules, nativeWalletLib, platform } = vi.hoisted(() => {
+    const mockCreateScenario = vi.fn();
+    const nativeWalletLib = {
+        createScenario: vi.fn(),
+    };
+    nativeWalletLib.createScenario = mockCreateScenario;
 
-nativeModules.SolanaMobileWalletAdapterWalletLib.createScenario = mockCreateScenario;
+    return {
+        mockCreateScenario,
+        nativeModules: {
+            SolanaMobileWalletAdapterWalletLib: nativeWalletLib as
+                | { createScenario: ReturnType<typeof vi.fn> }
+                | undefined,
+        },
+        nativeWalletLib,
+        platform: { OS: 'android' },
+    };
+});
 
 vi.mock('react-native', () => ({
     NativeModules: nativeModules,
@@ -33,7 +40,9 @@ const CONFIG: MobileWalletAdapterConfig = {
 
 afterEach(() => {
     mockCreateScenario.mockReset();
+    nativeModules.SolanaMobileWalletAdapterWalletLib = nativeWalletLib;
     platform.OS = 'android';
+    vi.resetModules();
 });
 
 describe('initializeMobileWalletAdapterSession', () => {
@@ -69,5 +78,31 @@ describe('initializeMobileWalletAdapterSession', () => {
         mockCreateScenario.mockRejectedValue(error);
 
         await expect(initializeMobileWalletAdapterSession('Example Wallet', CONFIG)).rejects.toBe(error);
+    });
+
+    it('rethrows unknown native non-error rejections unchanged', async () => {
+        mockCreateScenario.mockRejectedValue('Unexpected failure');
+
+        await expect(initializeMobileWalletAdapterSession('Example Wallet', CONFIG)).rejects.toBe('Unexpected failure');
+    });
+
+    it('throws a linking error when the Android native module is missing', async () => {
+        nativeModules.SolanaMobileWalletAdapterWalletLib = undefined;
+        vi.resetModules();
+        const { initializeMobileWalletAdapterSession } = await import('../src/initializeMobileWalletAdapterSession.js');
+
+        await expect(initializeMobileWalletAdapterSession('Example Wallet', CONFIG)).rejects.toThrow(
+            "The package 'solana-mobile-wallet-adapter-walletlib' doesn't seem to be linked.",
+        );
+    });
+
+    it('throws a platform error outside Android', async () => {
+        platform.OS = 'ios';
+        vi.resetModules();
+        const { initializeMobileWalletAdapterSession } = await import('../src/initializeMobileWalletAdapterSession.js');
+
+        await expect(initializeMobileWalletAdapterSession('Example Wallet', CONFIG)).rejects.toThrow(
+            'is only compatible with React Native Android',
+        );
     });
 });

--- a/js/packages/mobile-wallet-adapter-walletlib/test/resolve.test.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/test/resolve.test.ts
@@ -1,16 +1,21 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { mockResolve, nativeModules, platform } = vi.hoisted(() => ({
-    mockResolve: vi.fn(),
-    nativeModules: {
-        SolanaMobileWalletAdapterWalletLib: {
-            resolve: vi.fn(),
-        },
-    },
-    platform: { OS: 'android' },
-}));
+const { mockResolve, nativeModules, nativeWalletLib, platform } = vi.hoisted(() => {
+    const mockResolve = vi.fn();
+    const nativeWalletLib = {
+        resolve: vi.fn(),
+    };
+    nativeWalletLib.resolve = mockResolve;
 
-nativeModules.SolanaMobileWalletAdapterWalletLib.resolve = mockResolve;
+    return {
+        mockResolve,
+        nativeModules: {
+            SolanaMobileWalletAdapterWalletLib: nativeWalletLib as { resolve: ReturnType<typeof vi.fn> } | undefined,
+        },
+        nativeWalletLib,
+        platform: { OS: 'android' },
+    };
+});
 
 vi.mock('react-native', () => ({
     NativeModules: nativeModules,
@@ -21,7 +26,9 @@ import { type AuthorizeDappRequest, type AuthorizeDappResponse, MWARequestType, 
 
 afterEach(() => {
     mockResolve.mockReset();
+    nativeModules.SolanaMobileWalletAdapterWalletLib = nativeWalletLib;
     platform.OS = 'android';
+    vi.resetModules();
 });
 
 describe('resolve', () => {
@@ -39,5 +46,41 @@ describe('resolve', () => {
         resolve(request, response);
 
         expect(mockResolve).toHaveBeenCalledWith(JSON.stringify(request), JSON.stringify(response));
+    });
+
+    it('throws a linking error when the Android native module is missing', async () => {
+        nativeModules.SolanaMobileWalletAdapterWalletLib = undefined;
+        vi.resetModules();
+        const { resolve } = await import('../src/resolve.js');
+        const request: AuthorizeDappRequest = {
+            __type: MWARequestType.AuthorizeDappRequest,
+            chain: 'solana:mainnet',
+            requestId: 'request-1',
+            sessionId: 'session-1',
+        };
+        const response: AuthorizeDappResponse = {
+            accounts: [],
+        };
+
+        expect(() => resolve(request, response)).toThrow(
+            "The package 'solana-mobile-wallet-adapter-walletlib' doesn't seem to be linked.",
+        );
+    });
+
+    it('throws a platform error outside Android', async () => {
+        platform.OS = 'ios';
+        vi.resetModules();
+        const { resolve } = await import('../src/resolve.js');
+        const request: AuthorizeDappRequest = {
+            __type: MWARequestType.AuthorizeDappRequest,
+            chain: 'solana:mainnet',
+            requestId: 'request-1',
+            sessionId: 'session-1',
+        };
+        const response: AuthorizeDappResponse = {
+            accounts: [],
+        };
+
+        expect(() => resolve(request, response)).toThrow('is only compatible with React Native Android');
     });
 });

--- a/js/packages/mobile-wallet-adapter-walletlib/test/useDigitalAssetLinks.test.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/test/useDigitalAssetLinks.test.ts
@@ -6,27 +6,43 @@ const {
     mockGetUidForPackage,
     mockVerifyCallingPackage,
     nativeModules,
+    nativeDigitalAssetLinks,
     platform,
-} = vi.hoisted(() => ({
-    mockGetCallingPackage: vi.fn(),
-    mockGetCallingPackageUid: vi.fn(),
-    mockGetUidForPackage: vi.fn(),
-    mockVerifyCallingPackage: vi.fn(),
-    nativeModules: {
-        SolanaMobileDigitalAssetLinks: {
-            getCallingPackage: vi.fn(),
-            getCallingPackageUid: vi.fn(),
-            getUidForPackage: vi.fn(),
-            verifyCallingPackage: vi.fn(),
-        },
-    },
-    platform: { OS: 'android' },
-}));
+} = vi.hoisted(() => {
+    const mockGetCallingPackage = vi.fn();
+    const mockGetCallingPackageUid = vi.fn();
+    const mockGetUidForPackage = vi.fn();
+    const mockVerifyCallingPackage = vi.fn();
+    const nativeDigitalAssetLinks = {
+        getCallingPackage: vi.fn(),
+        getCallingPackageUid: vi.fn(),
+        getUidForPackage: vi.fn(),
+        verifyCallingPackage: vi.fn(),
+    };
+    nativeDigitalAssetLinks.getCallingPackage = mockGetCallingPackage;
+    nativeDigitalAssetLinks.getCallingPackageUid = mockGetCallingPackageUid;
+    nativeDigitalAssetLinks.getUidForPackage = mockGetUidForPackage;
+    nativeDigitalAssetLinks.verifyCallingPackage = mockVerifyCallingPackage;
 
-nativeModules.SolanaMobileDigitalAssetLinks.getCallingPackage = mockGetCallingPackage;
-nativeModules.SolanaMobileDigitalAssetLinks.getCallingPackageUid = mockGetCallingPackageUid;
-nativeModules.SolanaMobileDigitalAssetLinks.getUidForPackage = mockGetUidForPackage;
-nativeModules.SolanaMobileDigitalAssetLinks.verifyCallingPackage = mockVerifyCallingPackage;
+    return {
+        mockGetCallingPackage,
+        mockGetCallingPackageUid,
+        mockGetUidForPackage,
+        mockVerifyCallingPackage,
+        nativeDigitalAssetLinks,
+        nativeModules: {
+            SolanaMobileDigitalAssetLinks: nativeDigitalAssetLinks as
+                | {
+                      getCallingPackage: ReturnType<typeof vi.fn>;
+                      getCallingPackageUid: ReturnType<typeof vi.fn>;
+                      getUidForPackage: ReturnType<typeof vi.fn>;
+                      verifyCallingPackage: ReturnType<typeof vi.fn>;
+                  }
+                | undefined,
+        },
+        platform: { OS: 'android' },
+    };
+});
 
 vi.mock('react-native', () => ({
     NativeModules: nativeModules,
@@ -45,7 +61,9 @@ afterEach(() => {
     mockGetCallingPackageUid.mockReset();
     mockGetUidForPackage.mockReset();
     mockVerifyCallingPackage.mockReset();
+    nativeModules.SolanaMobileDigitalAssetLinks = nativeDigitalAssetLinks;
     platform.OS = 'android';
+    vi.resetModules();
 });
 
 describe('useDigitalAssetLinks helpers', () => {
@@ -75,5 +93,23 @@ describe('useDigitalAssetLinks helpers', () => {
 
         await expect(verifyCallingPackage('https://example.com')).resolves.toBe(true);
         expect(mockVerifyCallingPackage).toHaveBeenCalledWith('https://example.com');
+    });
+
+    it('throws a linking error when the Android native module is missing', async () => {
+        nativeModules.SolanaMobileDigitalAssetLinks = undefined;
+        vi.resetModules();
+        const { getCallingPackage } = await import('../src/useDigitalAssetLinks.js');
+
+        await expect(getCallingPackage()).rejects.toThrow(
+            "The package 'solana-mobile-wallet-adapter-walletlib' doesn't seem to be linked.",
+        );
+    });
+
+    it('throws a platform error outside Android', async () => {
+        platform.OS = 'ios';
+        vi.resetModules();
+        const { getCallingPackage } = await import('../src/useDigitalAssetLinks.js');
+
+        await expect(getCallingPackage()).rejects.toThrow('is only compatible with React Native Android');
     });
 });

--- a/js/packages/mobile-wallet-adapter-walletlib/test/useMobileWalletAdapterSession.test.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/test/useMobileWalletAdapterSession.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockInitializeMWAEventListener, mockInitializeMobileWalletAdapterSession, mockRemove, mockUseEffect } =
+    vi.hoisted(() => ({
+        mockInitializeMWAEventListener: vi.fn(),
+        mockInitializeMobileWalletAdapterSession: vi.fn(),
+        mockRemove: vi.fn(),
+        mockUseEffect: vi.fn(),
+    }));
+
+vi.mock('react', () => ({
+    useEffect: mockUseEffect,
+}));
+
+vi.mock('../src/initializeMWAEventListener.js', () => ({
+    initializeMWAEventListener: mockInitializeMWAEventListener,
+}));
+
+vi.mock('../src/initializeMobileWalletAdapterSession.js', () => ({
+    initializeMobileWalletAdapterSession: mockInitializeMobileWalletAdapterSession,
+}));
+
+import { type MobileWalletAdapterConfig } from '../src/initializeMobileWalletAdapterSession.js';
+import { useMobileWalletAdapterSession } from '../src/useMobileWalletAdapterSession.js';
+
+const CONFIG: MobileWalletAdapterConfig = {
+    maxMessagesPerSigningRequest: 2,
+    maxTransactionsPerSigningRequest: 3,
+    noConnectionWarningTimeoutMs: 5000,
+    optionalFeatures: [],
+    supportedTransactionVersions: ['legacy'],
+};
+
+afterEach(() => {
+    mockInitializeMWAEventListener.mockReset();
+    mockInitializeMobileWalletAdapterSession.mockReset();
+    mockRemove.mockReset();
+    mockUseEffect.mockReset();
+    vi.restoreAllMocks();
+});
+
+describe('useMobileWalletAdapterSession', () => {
+    it('initializes the session and removes the listener on cleanup', () => {
+        const handleRequest = vi.fn();
+        const handleSessionEvent = vi.fn();
+        let cleanup: (() => void) | undefined;
+
+        mockInitializeMWAEventListener.mockReturnValue({ remove: mockRemove });
+        mockInitializeMobileWalletAdapterSession.mockResolvedValue('session-1');
+        mockUseEffect.mockImplementation((effect: () => void | (() => void)) => {
+            cleanup = effect() as (() => void) | undefined;
+        });
+
+        useMobileWalletAdapterSession('Example Wallet', CONFIG, handleRequest, handleSessionEvent);
+
+        expect(mockInitializeMWAEventListener).toHaveBeenCalledWith(handleRequest, handleSessionEvent);
+        expect(mockInitializeMobileWalletAdapterSession).toHaveBeenCalledWith('Example Wallet', CONFIG);
+        expect(cleanup).toBeTypeOf('function');
+
+        cleanup?.();
+
+        expect(mockRemove).toHaveBeenCalledWith();
+    });
+
+    it('logs session initialization errors', async () => {
+        const error = new Error('Session failed');
+        const handleRequest = vi.fn();
+        const handleSessionEvent = vi.fn();
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        mockInitializeMWAEventListener.mockReturnValue({ remove: mockRemove });
+        mockInitializeMobileWalletAdapterSession.mockRejectedValue(error);
+        mockUseEffect.mockImplementation((effect: () => void | (() => void)) => {
+            effect();
+        });
+
+        useMobileWalletAdapterSession('Example Wallet', CONFIG, handleRequest, handleSessionEvent);
+        await Promise.resolve();
+
+        expect(errorSpy).toHaveBeenCalledWith(error);
+    });
+});

--- a/js/packages/wallet-adapter-mobile/test/adapter.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/adapter.test.ts
@@ -2,13 +2,16 @@
 
 import {
     WalletConnectionError,
+    WalletError,
     WalletNotConnectedError,
     WalletNotReadyError,
     WalletReadyState,
+    WalletSendTransactionError,
     WalletSignMessageError,
+    WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import { SolanaSignAndSendTransaction } from '@solana/wallet-standard-features';
-import { PublicKey, Transaction, VersionedMessage } from '@solana/web3.js';
+import { SolanaSignAndSendTransaction, SolanaSignTransaction } from '@solana/wallet-standard-features';
+import { PublicKey, Transaction, VersionedMessage, VersionedTransaction } from '@solana/web3.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
@@ -153,6 +156,7 @@ type MockWalletInstance = {
     emitAccounts: (accounts: unknown[], chain?: string) => void;
     features: Record<PropertyKey, unknown>;
     isAuthorized: boolean;
+    listeners: Array<(properties: { accounts?: unknown[] }) => unknown>;
     signAndSendImpl: ReturnType<typeof vi.fn>;
     signInImpl: ReturnType<typeof vi.fn>;
     signMessageImpl: ReturnType<typeof vi.fn>;
@@ -191,6 +195,22 @@ describe('adapter', () => {
         expect(getLastItem(localWalletConfigs)).toEqual(
             expect.objectContaining({
                 chains: ['solana:devnet'],
+            }),
+        );
+    });
+
+    it('configures the local wallet with a mapped testnet chain', () => {
+        new LocalSolanaMobileWalletAdapter({
+            addressSelector: createAddressSelector(),
+            appIdentity: createAppIdentity(),
+            authorizationResultCache: createAuthorizationResultCache(),
+            chain: 'testnet',
+            onWalletNotFound: createLocalWalletNotFoundHandler(),
+        });
+
+        expect(getLastItem(localWalletConfigs)).toEqual(
+            expect.objectContaining({
+                chains: ['solana:testnet'],
             }),
         );
     });
@@ -245,10 +265,97 @@ describe('adapter', () => {
         expect(readyStateChangeListener).toHaveBeenCalledWith(WalletReadyState.Installed);
     });
 
+    it('falls back to the first account when the address selector returns an unknown address', async () => {
+        const firstAccount = createWalletAccount(17);
+        const secondAccount = createWalletAccount(18);
+        const addressSelector = createAddressSelector(encodeAddress(createPublicKey(19)));
+        const { adapter, wallet } = createLocalAdapter({ addressSelector });
+        const connectListener = vi.fn();
+
+        adapter.on('connect', connectListener);
+        wallet.emitAccounts([firstAccount, secondAccount]);
+        await flushPromises();
+
+        expect(adapter.publicKey?.toBase58()).toBe(new PublicKey(firstAccount.publicKey).toBase58());
+        expect(connectListener.mock.calls[0][0].toBase58()).toBe(new PublicKey(firstAccount.publicKey).toBase58());
+    });
+
+    it('does not emit connect again when the selected account is unchanged', async () => {
+        const account = createWalletAccount(8);
+        const { adapter, wallet } = createLocalAdapter();
+        const connectListener = vi.fn();
+        const readyStateChangeListener = vi.fn();
+
+        adapter.on('connect', connectListener);
+        adapter.on('readyStateChange', readyStateChangeListener);
+        wallet.emitAccounts([account]);
+        await flushPromises();
+        wallet.emitAccounts([account]);
+        await flushPromises();
+
+        expect(connectListener).toHaveBeenCalledTimes(1);
+        expect(readyStateChangeListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores change events without accounts', async () => {
+        const { adapter, wallet } = createLocalAdapter();
+        const connectListener = vi.fn();
+        const readyStateChangeListener = vi.fn();
+
+        adapter.on('connect', connectListener);
+        adapter.on('readyStateChange', readyStateChangeListener);
+        wallet.listeners.forEach((listener) => {
+            listener({});
+        });
+        await flushPromises();
+
+        expect(adapter.readyState).toBe(WalletReadyState.Loadable);
+        expect(connectListener).not.toHaveBeenCalled();
+        expect(readyStateChangeListener).not.toHaveBeenCalled();
+    });
+
+    it('does not attempt to connect when already connected', async () => {
+        const account = createWalletAccount(9);
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.emitAccounts([account]);
+        await flushPromises();
+        wallet.connectImpl.mockClear();
+
+        await adapter.connect();
+
+        expect(wallet.connectImpl).not.toHaveBeenCalled();
+    });
+
+    it('does not start a second connection while one is pending', async () => {
+        const pendingConnect = createDeferred<void>();
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.connectImpl.mockImplementation(async () => pendingConnect.promise);
+
+        const firstConnect = adapter.connect();
+        const secondConnect = adapter.connect();
+        await flushPromises();
+
+        expect(wallet.connectImpl).toHaveBeenCalledTimes(1);
+
+        pendingConnect.resolve();
+        await expect(firstConnect).resolves.toBeUndefined();
+        await expect(secondConnect).resolves.toBeUndefined();
+    });
+
     it('passes a silent connect request during autoConnect', async () => {
         const { adapter, wallet } = createLocalAdapter();
 
         await adapter.autoConnect();
+
+        expect(wallet.connectImpl).toHaveBeenCalledWith({ silent: true });
+    });
+
+    it('supports the deprecated autoConnect alias', async () => {
+        const { adapter, wallet } = createLocalAdapter();
+
+        await adapter.autoConnect_DO_NOT_USE_OR_YOU_WILL_BE_FIRED();
 
         expect(wallet.connectImpl).toHaveBeenCalledWith({ silent: true });
     });
@@ -312,6 +419,16 @@ describe('adapter', () => {
         expect(wallet.connectImpl).toHaveBeenCalledWith({ silent: true });
     });
 
+    it('wraps authorization failures in WalletConnectionError', async () => {
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.signInImpl.mockRejectedValue('rejected');
+
+        await expect(adapter.performAuthorization({ domain: 'example.test' })).rejects.toBeInstanceOf(
+            WalletConnectionError,
+        );
+    });
+
     it('clears the selected account and emits disconnect', async () => {
         const account = createWalletAccount(3);
         const { adapter, wallet } = createLocalAdapter();
@@ -329,6 +446,18 @@ describe('adapter', () => {
         expect(adapter.publicKey).toBeNull();
         expect(disconnectListener).toHaveBeenCalledTimes(1);
         expect(wallet.disconnectImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits a generic wallet error when disconnect rejects with a non-error value', async () => {
+        const { adapter, wallet } = createLocalAdapter();
+        const errorListener = vi.fn();
+
+        adapter.on('error', errorListener);
+        wallet.disconnectImpl.mockRejectedValue('disconnect failed');
+
+        await expect(adapter.disconnect()).rejects.toBe('disconnect failed');
+        expect(errorListener.mock.calls[0][0]).toBeInstanceOf(WalletError);
+        expect(errorListener.mock.calls[0][0]).not.toBeInstanceOf(WalletConnectionError);
     });
 
     it('defaults signIn to the current location host and returns the first result', async () => {
@@ -376,6 +505,21 @@ describe('adapter', () => {
         await expect(adapter.signMessage(Uint8Array.of(1, 2, 3))).rejects.toBeInstanceOf(WalletNotConnectedError);
         expect(errorListener).toHaveBeenCalledTimes(1);
         expect(errorListener.mock.calls[0][0]).toBeInstanceOf(WalletNotConnectedError);
+    });
+
+    it('returns the signature from signMessage', async () => {
+        const account = createWalletAccount(20);
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.emitAccounts([account]);
+        wallet.signMessageImpl.mockResolvedValue([{ signature: Uint8Array.of(21, 22, 23) }]);
+        await flushPromises();
+
+        await expect(adapter.signMessage(Uint8Array.of(24, 25, 26))).resolves.toEqual(Uint8Array.of(21, 22, 23));
+        expect(wallet.signMessageImpl).toHaveBeenCalledWith({
+            account,
+            message: Uint8Array.of(24, 25, 26),
+        });
     });
 
     it('wraps signMessage failures in WalletSignMessageError', async () => {
@@ -450,7 +594,259 @@ describe('adapter', () => {
             transaction: Uint8Array.of(1, 2, 3),
         });
     });
+
+    it('defaults unknown sendTransaction commitments to finalized', async () => {
+        const account = createWalletAccount(10);
+        const connection = {
+            commitment: 'singleGossip',
+            sendRawTransaction: vi.fn().mockResolvedValue('signature'),
+        };
+        const signedTransaction = {
+            serialize: vi.fn(() => Uint8Array.of(4, 5, 6)),
+        };
+        const transaction = {
+            serialize: vi.fn(() => Uint8Array.of(1, 2, 3)),
+        };
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.emitAccounts([account]);
+        delete wallet.features[SolanaSignAndSendTransaction];
+        wallet.signTransactionImpl.mockResolvedValue([{ signedTransaction: Uint8Array.of(1) }]);
+        vi.spyOn(Transaction, 'from').mockReturnValue(signedTransaction as never);
+        vi.spyOn(VersionedMessage, 'deserializeMessageVersion').mockReturnValue('legacy');
+        await flushPromises();
+
+        await expect(adapter.sendTransaction(transaction as never, connection as never)).resolves.toBe('signature');
+        expect(connection.sendRawTransaction).toHaveBeenCalledWith(Uint8Array.of(4, 5, 6), {
+            preflightCommitment: 'finalized',
+        });
+    });
+
+    it('defaults unknown preflight commitments before comparing finality', async () => {
+        const account = createWalletAccount(11);
+        const connection = {
+            commitment: 'processed',
+            sendRawTransaction: vi.fn().mockResolvedValue('signature'),
+        };
+        const signedTransaction = {
+            serialize: vi.fn(() => Uint8Array.of(4, 5, 6)),
+        };
+        const transaction = {
+            serialize: vi.fn(() => Uint8Array.of(1, 2, 3)),
+        };
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.emitAccounts([account]);
+        delete wallet.features[SolanaSignAndSendTransaction];
+        wallet.signTransactionImpl.mockResolvedValue([{ signedTransaction: Uint8Array.of(1) }]);
+        vi.spyOn(Transaction, 'from').mockReturnValue(signedTransaction as never);
+        vi.spyOn(VersionedMessage, 'deserializeMessageVersion').mockReturnValue('legacy');
+        await flushPromises();
+
+        await expect(
+            adapter.sendTransaction(transaction as never, connection as never, {
+                preflightCommitment: 'singleGossip' as never,
+            }),
+        ).resolves.toBe('signature');
+        expect(connection.sendRawTransaction).toHaveBeenCalledWith(Uint8Array.of(4, 5, 6), {
+            preflightCommitment: 'processed',
+        });
+    });
+
+    it('uses the confirmed preflight commitment when it is lower than the connection commitment', async () => {
+        const account = createWalletAccount(21);
+        const connection = {
+            commitment: 'finalized',
+            sendRawTransaction: vi.fn().mockResolvedValue('signature'),
+        };
+        const signedTransaction = {
+            serialize: vi.fn(() => Uint8Array.of(4, 5, 6)),
+        };
+        const transaction = {
+            serialize: vi.fn(() => Uint8Array.of(1, 2, 3)),
+        };
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.emitAccounts([account]);
+        delete wallet.features[SolanaSignAndSendTransaction];
+        wallet.signTransactionImpl.mockResolvedValue([{ signedTransaction: Uint8Array.of(1) }]);
+        vi.spyOn(Transaction, 'from').mockReturnValue(signedTransaction as never);
+        vi.spyOn(VersionedMessage, 'deserializeMessageVersion').mockReturnValue('legacy');
+        await flushPromises();
+
+        await expect(
+            adapter.sendTransaction(transaction as never, connection as never, {
+                preflightCommitment: 'confirmed',
+            }),
+        ).resolves.toBe('signature');
+        expect(connection.sendRawTransaction).toHaveBeenCalledWith(Uint8Array.of(4, 5, 6), {
+            preflightCommitment: 'confirmed',
+        });
+    });
+
+    it('sends versioned transactions with connection.sendTransaction when signAndSend is unavailable', async () => {
+        const account = createWalletAccount(12);
+        const connection = {
+            commitment: 'confirmed',
+            sendTransaction: vi.fn().mockResolvedValue('versioned-signature'),
+        };
+        const transaction = {
+            serialize: vi.fn(() => Uint8Array.of(1, 2, 3)),
+        };
+        const versionedTransaction = {
+            version: 0,
+        };
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.emitAccounts([account]);
+        delete wallet.features[SolanaSignAndSendTransaction];
+        wallet.signTransactionImpl.mockResolvedValue([{ signedTransaction: Uint8Array.of(1) }]);
+        vi.spyOn(VersionedMessage, 'deserializeMessageVersion').mockReturnValue(0);
+        vi.spyOn(VersionedTransaction, 'deserialize').mockReturnValue(versionedTransaction as never);
+        await flushPromises();
+
+        await expect(adapter.sendTransaction(transaction as never, connection as never)).resolves.toBe(
+            'versioned-signature',
+        );
+        expect(connection.sendTransaction).toHaveBeenCalledWith(versionedTransaction);
+    });
+
+    it('wraps sendTransaction failures in WalletSendTransactionError', async () => {
+        const account = createWalletAccount(13);
+        const transaction = {
+            serialize: vi.fn(() => Uint8Array.of(1, 2, 3)),
+        };
+        const { adapter, wallet } = createLocalAdapter();
+        const errorListener = vi.fn();
+
+        adapter.on('error', errorListener);
+        wallet.emitAccounts([account]);
+        wallet.signAndSendImpl.mockRejectedValue('rejected');
+        await flushPromises();
+
+        await expect(adapter.sendTransaction(transaction as never, {} as never)).rejects.toBeInstanceOf(
+            WalletSendTransactionError,
+        );
+        expect(errorListener.mock.calls[0][0]).toBeInstanceOf(WalletSendTransactionError);
+    });
+
+    it('signs a single transaction through signTransaction', async () => {
+        const account = createWalletAccount(14);
+        const signedTransaction = {
+            serialize: vi.fn(() => Uint8Array.of(4, 5, 6)),
+        };
+        const transaction = {
+            serialize: vi.fn(() => Uint8Array.of(1, 2, 3)),
+        };
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.emitAccounts([account]);
+        wallet.signTransactionImpl.mockResolvedValue([{ signedTransaction: Uint8Array.of(1) }]);
+        vi.spyOn(Transaction, 'from').mockReturnValue(signedTransaction as never);
+        vi.spyOn(VersionedMessage, 'deserializeMessageVersion').mockReturnValue('legacy');
+        await flushPromises();
+
+        await expect(adapter.signTransaction(transaction as never)).resolves.toBe(signedTransaction);
+        expect(wallet.signTransactionImpl).toHaveBeenCalledWith({
+            account,
+            transaction: Uint8Array.of(1, 2, 3),
+        });
+    });
+
+    it('signs multiple transactions through signAllTransactions', async () => {
+        const account = createWalletAccount(15);
+        const firstSignedTransaction = {
+            serialize: vi.fn(() => Uint8Array.of(4, 5, 6)),
+        };
+        const secondSignedTransaction = {
+            serialize: vi.fn(() => Uint8Array.of(7, 8, 9)),
+        };
+        const transactions = [
+            {
+                serialize: vi.fn(() => Uint8Array.of(1, 2, 3)),
+            },
+            {
+                serialize: vi.fn(() => Uint8Array.of(4, 5, 6)),
+            },
+        ];
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.emitAccounts([account]);
+        wallet.signTransactionImpl.mockResolvedValue([
+            { signedTransaction: Uint8Array.of(1) },
+            { signedTransaction: Uint8Array.of(2) },
+        ]);
+        vi.spyOn(Transaction, 'from')
+            .mockReturnValueOnce(firstSignedTransaction as never)
+            .mockReturnValueOnce(secondSignedTransaction as never);
+        vi.spyOn(VersionedMessage, 'deserializeMessageVersion').mockReturnValue('legacy');
+        await flushPromises();
+
+        await expect(adapter.signAllTransactions(transactions as never)).resolves.toEqual([
+            firstSignedTransaction,
+            secondSignedTransaction,
+        ]);
+        expect(wallet.signTransactionImpl).toHaveBeenCalledWith(
+            {
+                account,
+                transaction: Uint8Array.of(1, 2, 3),
+            },
+            {
+                account,
+                transaction: Uint8Array.of(4, 5, 6),
+            },
+        );
+    });
+
+    it('wraps missing signTransaction support in WalletSignTransactionError', async () => {
+        const account = createWalletAccount(16);
+        const transaction = {
+            serialize: vi.fn(() => Uint8Array.of(1, 2, 3)),
+        };
+        const { adapter, wallet } = createLocalAdapter();
+        const errorListener = vi.fn();
+
+        adapter.on('error', errorListener);
+        wallet.emitAccounts([account]);
+        delete wallet.features[SolanaSignTransaction];
+        await flushPromises();
+
+        await expect(adapter.signTransaction(transaction as never)).rejects.toBeInstanceOf(WalletSignTransactionError);
+        expect(errorListener.mock.calls[0][0]).toBeInstanceOf(WalletSignTransactionError);
+    });
+
+    it('adapts the local authorization cache interface', async () => {
+        const authorization = { auth_token: 'token' };
+        const authorizationResultCache = createAuthorizationResultCache();
+
+        authorizationResultCache.get.mockResolvedValue(authorization);
+        createLocalAdapter({ authorizationResultCache });
+
+        const authorizationCache = (getLastItem(localWalletConfigs) as { authorizationCache: AuthorizationCache })
+            .authorizationCache;
+
+        await expect(authorizationCache.get()).resolves.toBe(authorization);
+        expect(authorizationResultCache.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('adapts the remote authorization cache interface', async () => {
+        const authorization = { auth_token: 'token' };
+        const authorizationResultCache = createAuthorizationResultCache();
+
+        authorizationResultCache.get.mockResolvedValue(authorization);
+        createRemoteAdapter({ authorizationResultCache });
+
+        const authorizationCache = (getLastItem(remoteWalletConfigs) as { authorizationCache: AuthorizationCache })
+            .authorizationCache;
+
+        await expect(authorizationCache.get()).resolves.toBe(authorization);
+        expect(authorizationResultCache.get).toHaveBeenCalledTimes(1);
+    });
 });
+
+type AuthorizationCache = {
+    get: () => Promise<unknown>;
+};
 
 function createAddressSelector(selectedAddress?: string) {
     return {
@@ -480,15 +876,17 @@ function createLocalWalletNotFoundHandler() {
 
 function createLocalAdapter({
     addressSelector = createAddressSelector(),
+    authorizationResultCache = createAuthorizationResultCache(),
     onWalletNotFound = createLocalWalletNotFoundHandler(),
 }: {
     addressSelector?: ReturnType<typeof createAddressSelector>;
+    authorizationResultCache?: ReturnType<typeof createAuthorizationResultCache>;
     onWalletNotFound?: (mobileWalletAdapter: LocalSolanaMobileWalletAdapter) => Promise<void>;
 } = {}) {
     const adapter = new LocalSolanaMobileWalletAdapter({
         addressSelector,
         appIdentity: createAppIdentity(),
-        authorizationResultCache: createAuthorizationResultCache(),
+        authorizationResultCache,
         chain: 'solana:mainnet',
         onWalletNotFound,
     });
@@ -505,15 +903,17 @@ function createRemoteWalletNotFoundHandler() {
 
 function createRemoteAdapter({
     addressSelector = createAddressSelector(),
+    authorizationResultCache = createAuthorizationResultCache(),
     onWalletNotFound = createRemoteWalletNotFoundHandler(),
 }: {
     addressSelector?: ReturnType<typeof createAddressSelector>;
+    authorizationResultCache?: ReturnType<typeof createAuthorizationResultCache>;
     onWalletNotFound?: (mobileWalletAdapter: RemoteSolanaMobileWalletAdapter) => Promise<void>;
 } = {}) {
     const adapter = new RemoteSolanaMobileWalletAdapter({
         addressSelector,
         appIdentity: createAppIdentity(),
-        authorizationResultCache: createAuthorizationResultCache(),
+        authorizationResultCache,
         chain: 'solana:mainnet',
         onWalletNotFound,
         remoteHostAuthority: 'remote.example.com',
@@ -547,6 +947,17 @@ function encodeAddress(byteArray: Uint8Array) {
 async function flushPromises() {
     await Promise.resolve();
     await Promise.resolve();
+}
+
+function createDeferred<T>() {
+    let reject!: (reason?: unknown) => void;
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+        reject = promiseReject;
+        resolve = promiseResolve;
+    });
+
+    return { promise, reject, resolve };
 }
 
 function getLastItem<T>(items: T[]) {

--- a/js/packages/wallet-standard-mobile/test/embeddedModal.test.ts
+++ b/js/packages/wallet-standard-mobile/test/embeddedModal.test.ts
@@ -142,6 +142,19 @@ describe('EmbeddedLoadingSpinner', () => {
         expect(document.body.children).toHaveLength(1);
         expect(root.style.display).toBe('flex');
 
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        expect(root.style.display).toBe('flex');
+        expect(closeListener).not.toHaveBeenCalled();
+
+        getDom(spinner)
+            .querySelector('[data-modal-close]')
+            ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(root.style.display).toBe('none');
+        expect(closeListener).toHaveBeenCalledWith(expect.any(MouseEvent));
+
+        spinner.open();
+
         const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape' });
 
         document.dispatchEvent(escapeEvent);

--- a/js/packages/wallet-standard-mobile/test/wallet.test.ts
+++ b/js/packages/wallet-standard-mobile/test/wallet.test.ts
@@ -238,6 +238,8 @@ describe('LocalSolanaMobileWalletAdapterWallet', () => {
         const spinnerCloseListener = loadingSpinnerInstances[0].addEventListener.mock.calls[0][1];
         spinnerCloseListener(new Event('close'));
         expect(scenarioClose).toHaveBeenCalledTimes(2);
+        spinnerCloseListener(undefined);
+        expect(scenarioClose).toHaveBeenCalledTimes(2);
 
         await expect(wallet.features[StandardConnect].connect()).resolves.toEqual({ accounts: wallet.accounts });
         expect(mockStartScenario).toHaveBeenCalledTimes(1);
@@ -274,6 +276,21 @@ describe('LocalSolanaMobileWalletAdapterWallet', () => {
         expect(authorizationCache.get).toHaveBeenCalledTimes(1);
         expect(changeListener).toHaveBeenCalledWith({ features: wallet.features });
         expect(changeListener).toHaveBeenCalledWith({ accounts: wallet.accounts });
+    });
+
+    it('uses cached authorization for interactive local connects without starting association', async () => {
+        const cachedAuthorization = createCachedAuthorization(Uint8Array.of(131, 132, 133));
+        const { authorizationCache, wallet } = createLocalWallet({
+            cachedAuthorization,
+        });
+
+        await expect(wallet.features[StandardConnect].connect()).resolves.toEqual({
+            accounts: [cachedAuthorization.accounts[0]],
+        });
+
+        expect(authorizationCache.get).toHaveBeenCalledTimes(1);
+        expect(mockStartScenario).not.toHaveBeenCalled();
+        expect(wallet.connected).toBe(true);
     });
 
     it('returns existing accounts without association for silent connects when nothing is cached', async () => {
@@ -560,6 +577,95 @@ describe('LocalSolanaMobileWalletAdapterWallet', () => {
             },
         ]);
     });
+
+    it('defaults local account chains and features when authorization omits them', async () => {
+        const accountPublicKey = Uint8Array.of(122, 123, 124);
+        const authorization = createMwaAuthorization(accountPublicKey);
+        const authorizationAccount = authorization.accounts[0] as Partial<(typeof authorization.accounts)[number]>;
+        const mobileWallet = createMobileWallet({ authorization });
+        const { wallet } = createLocalWallet();
+
+        delete authorizationAccount.chains;
+        delete authorizationAccount.features;
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockResolvedValue({
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await wallet.features[StandardConnect].connect();
+
+        expect(wallet.accounts[0].chains).toEqual([SOLANA_MAINNET_CHAIN]);
+        expect(wallet.accounts[0].features).toEqual(
+            expect.arrayContaining([
+                SolanaSignAndSendTransaction,
+                SolanaSignIn,
+                SolanaSignMessage,
+                SolanaSignTransaction,
+            ]),
+        );
+    });
+
+    it('wraps local transaction signing failures', async () => {
+        const accountPublicKey = Uint8Array.of(125, 126, 127);
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(accountPublicKey),
+        });
+        const { wallet } = createLocalWallet();
+
+        mobileWallet.signAndSendTransactions.mockRejectedValueOnce(new Error('sign and send failed'));
+        mobileWallet.signTransactions.mockRejectedValueOnce(new Error('sign transaction failed'));
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockResolvedValue({
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await wallet.features[StandardConnect].connect();
+
+        await expect(
+            getSignTransactionFeature(wallet).signTransaction({
+                account: wallet.accounts[0],
+                transaction: Uint8Array.of(1, 2, 3),
+            }),
+        ).rejects.toThrow('sign transaction failed');
+        await expect(
+            getSignAndSendFeature(wallet).signAndSendTransaction({
+                account: wallet.accounts[0],
+                chain: SOLANA_MAINNET_CHAIN,
+                transaction: Uint8Array.of(4, 5, 6),
+            }),
+        ).rejects.toThrow('sign and send failed');
+    });
+
+    it('disconnects local authorization when reauthorization fails', async () => {
+        const accountPublicKey = Uint8Array.of(134, 135, 136);
+        const mobileWallet = createMobileWallet({
+            authorization: createMwaAuthorization(accountPublicKey),
+        });
+        const { authorizationCache, wallet } = createLocalWallet();
+
+        mobileWallet.authorize
+            .mockResolvedValueOnce(createMwaAuthorization(accountPublicKey))
+            .mockRejectedValueOnce(new Error('reauthorize failed'));
+        mockCheckLocalNetworkAccessPermission.mockResolvedValue(undefined);
+        mockStartScenario.mockResolvedValue({
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+
+        await wallet.features[StandardConnect].connect();
+
+        void wallet.features[SolanaSignMessage].signMessage({
+            account: wallet.accounts[0],
+            message: Uint8Array.of(1, 2, 3),
+        });
+
+        await vi.waitFor(() => {
+            expect(authorizationCache.clear).toHaveBeenCalledTimes(1);
+        });
+        expect(wallet.connected).toBe(false);
+    });
 });
 
 describe('RemoteSolanaMobileWalletAdapterWallet', () => {
@@ -616,6 +722,8 @@ describe('RemoteSolanaMobileWalletAdapterWallet', () => {
         expect(remoteModalInstances[0].populateQRCode).toHaveBeenCalledWith('https://example.test/associate');
         expect(remoteModalInstances[0].close).toHaveBeenCalledTimes(1);
         remoteModalInstances[0].addEventListener.mock.calls[0][1](new Event('close'));
+        expect(scenarioClose).toHaveBeenCalledTimes(1);
+        remoteModalInstances[0].addEventListener.mock.calls[0][1](undefined);
         expect(scenarioClose).toHaveBeenCalledTimes(1);
         expect(wallet.connected).toBe(true);
         expect(getSignAndSendFeature(wallet).supportedTransactionVersions).toEqual(['legacy', 0]);
@@ -777,6 +885,17 @@ describe('RemoteSolanaMobileWalletAdapterWallet', () => {
         expect(mockStartRemoteScenario).not.toHaveBeenCalled();
     });
 
+    it('closes the remote modal for generic association failures', async () => {
+        const onWalletNotFound = vi.fn<WalletNotFoundHandler>().mockResolvedValue(undefined);
+        const { wallet } = createRemoteWallet({ onWalletNotFound });
+
+        mockStartRemoteScenario.mockRejectedValue(new Error('association failed'));
+
+        await expect(wallet.features[StandardConnect].connect()).rejects.toThrow('association failed');
+        expect(onWalletNotFound).not.toHaveBeenCalled();
+        expect(remoteModalInstances[0].close).toHaveBeenCalledTimes(1);
+    });
+
     it('runs the wallet-not-found handler for remote association failures', async () => {
         const onWalletNotFound = vi.fn<WalletNotFoundHandler>().mockResolvedValue(undefined);
         const { wallet } = createRemoteWallet({ onWalletNotFound });
@@ -868,6 +987,46 @@ describe('RemoteSolanaMobileWalletAdapterWallet', () => {
 
         await expect(wallet.features[SolanaSignIn].signIn()).rejects.toThrow(
             'Sign in failed, no sign in result returned by wallet',
+        );
+    });
+
+    it('updates remote features and defaults account metadata from wallet capabilities', async () => {
+        const accountPublicKey = Uint8Array.of(128, 129, 130);
+        const authorization = createMwaAuthorization(accountPublicKey);
+        const authorizationAccount = authorization.accounts[0] as Partial<(typeof authorization.accounts)[number]>;
+        const mobileWallet = createMobileWallet({
+            authorization,
+            capabilities: {
+                ...DEFAULT_CAPABILITIES,
+                features: [],
+                supports_sign_and_send_transactions: false,
+            },
+        });
+        const { wallet } = createRemoteWallet();
+        const changeListener = vi.fn();
+
+        delete authorizationAccount.chains;
+        delete authorizationAccount.features;
+        mockStartRemoteScenario.mockResolvedValue({
+            associationUrl: new URL('https://example.test/associate'),
+            close: vi.fn(),
+            wallet: Promise.resolve(mobileWallet),
+        });
+        wallet.features[StandardEvents].on('change', changeListener);
+
+        await wallet.features[StandardConnect].connect();
+
+        expect(SolanaSignAndSendTransaction in wallet.features).toBe(false);
+        expect(SolanaSignTransaction in wallet.features).toBe(false);
+        expect(changeListener).toHaveBeenCalledWith({ features: wallet.features });
+        expect(wallet.accounts[0].chains).toEqual([SOLANA_MAINNET_CHAIN]);
+        expect(wallet.accounts[0].features).toEqual(
+            expect.arrayContaining([
+                SolanaSignAndSendTransaction,
+                SolanaSignIn,
+                SolanaSignMessage,
+                SolanaSignTransaction,
+            ]),
         );
     });
 


### PR DESCRIPTION
## Summary
- add wallet adapter mobile coverage for account selection, adapter errors, signing, and transaction commitment behavior
- add wallet-standard mobile coverage for cached authorization, association flows, modal behavior, signing, and reauthorization failures
- add walletlib coverage for native-module error handling, request resolution, digital asset links, and session hook cleanup
- add protocol coverage for wallet proxy branches, session startup, React Native transact handling, and websocket transaction flows