### PR TITLE
Fix React Native example typechecks

### DIFF
--- a/.github/workflows/example-rn.yml
+++ b/.github/workflows/example-rn.yml
@@ -51,7 +51,6 @@ jobs:
       - name: '[Example App] Type Check'
         working-directory: 'examples/example-react-native-app/'
         run: npx tsc --noEmit
-        continue-on-error: true # TODO: fix all type issues and remove this line
       - name: '[Example App] Build'
         working-directory: 'examples/example-react-native-app/'
         run: pnpm android:build
@@ -62,7 +61,6 @@ jobs:
       - name: '[Example Wallet] Type Check'
         working-directory: 'examples/example-react-native-wallet/'
         run: npx tsc --noEmit
-        continue-on-error: true # TODO: fix all type issues and remove this line
       - name: '[Example Wallet] Build'
         working-directory: 'examples/example-react-native-wallet/'
         run: pnpm android:build

--- a/examples/example-react-native-app/components/RecordMessageButton.tsx
+++ b/examples/example-react-native-app/components/RecordMessageButton.tsx
@@ -1,11 +1,11 @@
-import { 
-  appendTransactionMessageInstruction, 
+import {
+  appendTransactionMessageInstruction,
   createTransactionMessage,
   pipe,
-  setTransactionMessageLifetimeUsingBlockhash,
-  TransactionSendingSigner,
   setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
   signAndSendTransactionMessageWithSigners,
+  type TransactionSendingSigner,
 } from '@solana/kit';
 import {
   createBlockHeightExceedencePromiseFactory,
@@ -13,10 +13,10 @@ import {
   waitForRecentTransactionConfirmation,
 } from '@solana/transaction-confirmation';
 import {
-  SignaturesMap,
+  type SignaturesMap,
   type Transaction,
-  TransactionWithBlockhashLifetime,
   compileTransaction,
+  type TransactionWithBlockhashLifetime,
 } from '@solana/transactions';
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { getAddMemoInstruction } from "@solana-program/memo";
@@ -63,8 +63,10 @@ export default function RecordMessageButton({children, message}: Props) {
         // create an MWA transaction signer
         const mwaTransactionSigner: TransactionSendingSigner = {
           address: selectedAccount?.publicKey ?? freshAccount.publicKey,
-          signAndSendTransactions: async (transactions: Transaction[]) => {
-            return await wallet.signAndSendTransactions({ transactions });
+          signAndSendTransactions: async (transactions) => {
+            return await wallet.signAndSendTransactions({
+              transactions: [...transactions],
+            });
           }
         };
 

--- a/examples/example-react-native-app/package.json
+++ b/examples/example-react-native-app/package.json
@@ -12,14 +12,14 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-vector-icons/material-icons": "^12.4.0",
-    "@solana/wallet-adapter-base": "^0.9.27",
-    "@solana/addresses": "^6.1.0",
-    "@solana/transactions": "^6.1.0",
-    "@solana/transaction-confirmation": "^6.1.0",
     "@solana-mobile/mobile-wallet-adapter-protocol": "file:../../js/packages/mobile-wallet-adapter-protocol",
     "@solana-mobile/mobile-wallet-adapter-protocol-kit": "file:../../js/packages/mobile-wallet-adapter-protocol-kit",
-    "@solana-program/memo": "^0.7.0",
-    "@solana/kit": "^2.3.0",
+    "@solana-program/memo": "^0.11.1",
+    "@solana/addresses": "^6.5.0",
+    "@solana/kit": "^6.5.0",
+    "@solana/transaction-confirmation": "^6.5.0",
+    "@solana/transactions": "^6.5.0",
+    "@solana/wallet-adapter-base": "^0.9.27",
     "@wallet-standard/react": "^1.0.1",
     "bs58": "^5.0.0",
     "js-base64": "^3.7.7",
@@ -47,6 +47,7 @@
     "@react-native/metro-config": "0.79.2",
     "@react-native/typescript-config": "0.79.2",
     "@types/jest": "^29.5.13",
+    "@types/react": "^19.0.0",
     "@types/react-native-vector-icons": "^6.4.18",
     "@types/react-test-renderer": "^19.0.0",
     "@types/text-encoding": "^0.0.39",
@@ -56,14 +57,13 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^29.6.3",
     "react-test-renderer": "19.0.0",
-    "typescript": "5.0.4"
+    "typescript": "5.6.3"
   },
   "engines": {
     "node": ">=20.18.0"
   },
   "pnpm": {
     "overrides": {
-      "@types/react": "^18",
       "@solana-mobile/mobile-wallet-adapter-protocol": "file:../../js/packages/mobile-wallet-adapter-protocol",
       "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "file:../../js/packages/mobile-wallet-adapter-protocol-web3js"
     }

--- a/examples/example-react-native-app/pnpm-lock.yaml
+++ b/examples/example-react-native-app/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@types/react': ^18
   '@solana-mobile/mobile-wallet-adapter-protocol': file:../../js/packages/mobile-wallet-adapter-protocol
   '@solana-mobile/mobile-wallet-adapter-protocol-web3js': file:../../js/packages/mobile-wallet-adapter-protocol-web3js
 
@@ -15,34 +14,34 @@ importers:
     dependencies:
       '@react-native-async-storage/async-storage':
         specifier: ^2.0.0
-        version: 2.2.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))
+        version: 2.2.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))
       '@react-native-vector-icons/material-icons':
         specifier: ^12.4.0
-        version: 12.4.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
+        version: 12.4.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
       '@solana-mobile/mobile-wallet-adapter-protocol':
         specifier: file:../../js/packages/mobile-wallet-adapter-protocol
-        version: file:../../js/packages/mobile-wallet-adapter-protocol(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.0.4)
+        version: file:../../js/packages/mobile-wallet-adapter-protocol(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana-mobile/mobile-wallet-adapter-protocol-kit':
         specifier: file:../../js/packages/mobile-wallet-adapter-protocol-kit
-        version: file:../../js/packages/mobile-wallet-adapter-protocol-kit(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.0.4)
+        version: file:../../js/packages/mobile-wallet-adapter-protocol-kit(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana-program/memo':
-        specifier: ^0.7.0
-        version: 0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))
+        specifier: ^0.11.1
+        version: 0.11.1(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))
       '@solana/addresses':
-        specifier: ^6.1.0
-        version: 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+        specifier: ^6.5.0
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/kit':
-        specifier: ^2.3.0
-        version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        specifier: ^6.5.0
+        version: 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/transaction-confirmation':
-        specifier: ^6.1.0
-        version: 6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(utf-8-validate@5.0.10)
+        specifier: ^6.5.0
+        version: 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/transactions':
-        specifier: ^6.1.0
-        version: 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+        specifier: ^6.5.0
+        version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
       '@solana/wallet-adapter-base':
         specifier: ^0.9.27
-        version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))
+        version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))
       '@wallet-standard/react':
         specifier: ^1.0.1
         version: 1.0.1(react-dom@19.2.4(react@19.0.0))(react@19.0.0)
@@ -60,19 +59,19 @@ importers:
         version: 19.0.0
       react-native:
         specifier: 0.79.2
-        version: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+        version: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
       react-native-get-random-values:
         specifier: ^1.11.0
-        version: 1.11.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))
+        version: 1.11.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))
       react-native-paper:
         specifier: ^5.12.5
-        version: 5.15.0(react-native-safe-area-context@5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
+        version: 5.15.0(react-native-safe-area-context@5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
       react-native-safe-area-context:
         specifier: ^5.4.1
-        version: 5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
+        version: 5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
       react-native-url-polyfill:
         specifier: ^2.0.0
-        version: 2.0.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))
+        version: 2.0.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))
       swr:
         specifier: ^2.2.5
         version: 2.4.0(react@19.0.0)
@@ -91,7 +90,7 @@ importers:
         version: 7.28.6
       '@react-native-community/cli':
         specifier: ^20.1.2
-        version: 20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
+        version: 20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@react-native-community/cli-platform-android':
         specifier: ^20.1.2
         version: 20.1.2
@@ -106,19 +105,22 @@ importers:
         version: 0.79.2(@babel/core@7.29.0)
       '@react-native/eslint-config':
         specifier: 0.79.2
-        version: 0.79.2(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(prettier@3.8.1)(typescript@5.0.4)
+        version: 0.79.2(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(prettier@3.8.1)(typescript@5.6.3)
       '@react-native/gradle-plugin':
         specifier: 0.79.2
         version: 0.79.2
       '@react-native/metro-config':
         specifier: 0.79.2
-        version: 0.79.2(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        version: 0.79.2(@babel/core@7.29.0)
       '@react-native/typescript-config':
         specifier: 0.79.2
         version: 0.79.2
       '@types/jest':
         specifier: ^29.5.13
         version: 29.5.14
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.16
       '@types/react-native-vector-icons':
         specifier: ^6.4.18
         version: 6.4.18
@@ -130,10 +132,10 @@ importers:
         version: 0.0.39
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.14.0
-        version: 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4)
+        version: 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3)
       '@typescript-eslint/parser':
         specifier: ^8.14.0
-        version: 8.56.0(eslint@10.0.2)(typescript@5.0.4)
+        version: 8.56.0(eslint@10.0.2)(typescript@5.6.3)
       eslint:
         specifier: ^10.0.2
         version: 10.0.2
@@ -147,8 +149,8 @@ importers:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
       typescript:
-        specifier: 5.0.4
-        version: 5.0.4
+        specifier: 5.6.3
+        version: 5.6.3
 
 packages:
 
@@ -1126,7 +1128,7 @@ packages:
     resolution: {integrity: sha512-9G6ROJeP+rdw9Bvr5ruOlag11ET7j1z/En1riFFNo6W3xZvJY+alCuH1ttm12y9+zBm4n8jwCk4lGhjYaV4dKw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/react': ^18
+      '@types/react': ^19.0.0
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
@@ -1154,29 +1156,26 @@ packages:
   '@solana-mobile/mobile-wallet-adapter-protocol-kit@file:../../js/packages/mobile-wallet-adapter-protocol-kit':
     resolution: {directory: ../../js/packages/mobile-wallet-adapter-protocol-kit, type: directory}
     peerDependencies:
-      '@solana/kit': ^2.1.0
+      '@solana/kit': ^6.0.0
 
   '@solana-mobile/mobile-wallet-adapter-protocol@file:../../js/packages/mobile-wallet-adapter-protocol':
     resolution: {directory: ../../js/packages/mobile-wallet-adapter-protocol, type: directory}
     peerDependencies:
       react-native: '>0.74'
 
-  '@solana-program/memo@0.7.0':
-    resolution: {integrity: sha512-3T9iUjWSYtN/5S5jzJuasD2yQfVfFAQ9yTwIE25+P9peWqz4oarn6ZQvRj/FLcBqaMLtSqLhU1hN2cyVBS6hyg==}
+  '@solana-program/memo@0.11.1':
+    resolution: {integrity: sha512-acVlHWhGcRqwsTfCE0EpHasQbho1iHAd0s1a43GP2DZ3WIyYEu3Z+FETbQxT0kh1o3vVr1AWMADKUB7mgSRr5Q==}
     peerDependencies:
-      '@solana/kit': ^2.1.0
+      '@solana/kit': ^6.4.0
 
-  '@solana/accounts@2.3.0':
-    resolution: {integrity: sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==}
+  '@solana/accounts@6.9.0':
+    resolution: {integrity: sha512-g36AJreJrgf9AAjOfbdFHEFUTymBgzbWHoEDElZ+fDKvqBINDiUVKzDApwc7C7kGPMFqQBaoEHnQRxf2IqfKZQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/addresses@2.3.0':
-    resolution: {integrity: sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/addresses@6.1.0':
     resolution: {integrity: sha512-QT04Vie4iICaalQQRJFMGj/P56IxXiwFtVuZHu1qjZUNmuGTOvX6G98b27RaGtLzpJ3NIku/6OtKxLUBqAKAyQ==}
@@ -1187,17 +1186,29 @@ packages:
       typescript:
         optional: true
 
-  '@solana/assertions@2.3.0':
-    resolution: {integrity: sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==}
+  '@solana/addresses@6.9.0':
+    resolution: {integrity: sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/assertions@6.1.0':
     resolution: {integrity: sha512-pLgxB2xxTk2QfTaWpnRpSMYgaPkKYDQgptRvbwmuDQnOW1Zopg+42MT2UrDGd3UFMML1uOFPxIwKM6m51H0uXw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/assertions@6.9.0':
+    resolution: {integrity: sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1212,12 +1223,6 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-core@4.0.0':
-    resolution: {integrity: sha512-28kNUsyIlhU3MO3/7ZLDqeJf2YAm32B4tnTjl5A9HrbBqsTZ+upT/RzxZGP1MMm7jnPuIKCMwmTpsyqyR6IUpw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
   '@solana/codecs-core@6.1.0':
     resolution: {integrity: sha512-5rNnDOOm2GRFMJbd9imYCPNvGOrQ+TZ53NCkFFWbbB7f+L9KkLeuuAsDMFN1lCziJFlymvN785YtDnMeWj2W+g==}
     engines: {node: '>=20.18.0'}
@@ -1227,11 +1232,14 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-data-structures@2.3.0':
-    resolution: {integrity: sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==}
+  '@solana/codecs-core@6.9.0':
+    resolution: {integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/codecs-data-structures@6.1.0':
     resolution: {integrity: sha512-1cb9g5hrrucTuGkGxqVVq7dCwSMnn4YqwTe365iKkK8HBpLBmUl8XATf1MUs5UtDun1g9eNWOL72Psr8mIUqTQ==}
@@ -1242,14 +1250,17 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@2.3.0':
-    resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
+  '@solana/codecs-data-structures@6.9.0':
+    resolution: {integrity: sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/codecs-numbers@4.0.0':
-    resolution: {integrity: sha512-z9zpjtcwzqT9rbkKVZpkWB5/0V7+6YRKs6BccHkGJlaDx8Pe/+XOvPi2rEdXPqrPd9QWb5Xp1iBfcgaDMyiOiA==}
+  '@solana/codecs-numbers@2.3.0':
+    resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -1263,19 +1274,14 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@2.3.0':
-    resolution: {integrity: sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==}
+  '@solana/codecs-numbers@6.9.0':
+    resolution: {integrity: sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5.3.3'
-
-  '@solana/codecs-strings@4.0.0':
-    resolution: {integrity: sha512-XvyD+sQ1zyA0amfxbpoFZsucLoe+yASQtDiLUGMDg5TZ82IHE3B7n82jE8d8cTAqi0HgqQiwU13snPhvg1O0Ow==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/codecs-strings@6.1.0':
     resolution: {integrity: sha512-pRH5uAn4VCFUs2rYiDITyWsRnpvs3Uh/nhSc6OSP/kusghcCcCJcUzHBIjT4x08MVacXmGUlSLe/9qPQO+QK3Q==}
@@ -1289,21 +1295,29 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs@2.3.0':
-    resolution: {integrity: sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==}
+  '@solana/codecs-strings@6.9.0':
+    resolution: {integrity: sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+      typescript:
+        optional: true
+
+  '@solana/codecs@6.9.0':
+    resolution: {integrity: sha512-oWOybKa1PTGI1D/FyrvGKralADM1jmVZC2AtgEo+4JTKG0+i1p9ZbwNY2UcJqdYsDMDaGHAx0LMAid9LDCxXTQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/errors@2.3.0':
     resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/errors@4.0.0':
-    resolution: {integrity: sha512-3YEtvcMvtcnTl4HahqLt0VnaGVf7vVWOnt6/uPky5e0qV6BlxDSbGkbBzttNjxLXHognV0AQi3pjvrtfUnZmbg==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -1319,26 +1333,33 @@ packages:
       typescript:
         optional: true
 
-  '@solana/fast-stable-stringify@2.3.0':
-    resolution: {integrity: sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==}
+  '@solana/errors@6.9.0':
+    resolution: {integrity: sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==}
     engines: {node: '>=20.18.0'}
+    hasBin: true
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/fast-stable-stringify@6.1.0':
-    resolution: {integrity: sha512-QXUfDFaJCFeARsxJgScWmJ153Tit7Cimk9y0UWWreNBr2Aphi67Nlcj/tr7UABTO0Qaw/0gwrK76zz3m1t3nIw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/functional@2.3.0':
-    resolution: {integrity: sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==}
+  '@solana/fast-stable-stringify@6.9.0':
+    resolution: {integrity: sha512-l14zGVsURbT5Aox/kLFQywqV4VaE9/j3h2EvCu9oULVPMwzQB6yezJb1/KyiDwhm/RscooPd0gFQFIKEGQbayw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fixed-points@6.9.0':
+    resolution: {integrity: sha512-0K7mbYC4jdAZFlXqXjpNanmEyZxk7K9NtXDLc1zuhGuxwH8J9guvohwdw2V7TQ9bfjCYsprY3Tp2kUVQpECGmA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/functional@6.1.0':
     resolution: {integrity: sha512-+Sm8ldVxSTHIKaZDvcBu81FPjknXx6OMPlakkKmXjKxPgVLl86ruqMo2yEwoDUHV7DysLrLLcRNn13rfulomRw==}
@@ -1349,11 +1370,23 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instructions@2.3.0':
-    resolution: {integrity: sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==}
+  '@solana/functional@6.9.0':
+    resolution: {integrity: sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instruction-plans@6.9.0':
+    resolution: {integrity: sha512-SxTSOetEKD+WPzvDuYRsP1+KkwUp8KqL1n7oFx9ThxjyfEY0ly0i9KdbvX5yYVDOA2TSwrltgdu14y/Pf6y3Cg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/instructions@6.1.0':
     resolution: {integrity: sha512-w1LdbJ3yanESckNTYC5KPckgN/25FyGCm07WWrs+dCnnpRNeLiVHIytXCPmArOVAXVkOYidXzhWmqCzqKUjYaA==}
@@ -1364,32 +1397,32 @@ packages:
       typescript:
         optional: true
 
-  '@solana/keys@2.3.0':
-    resolution: {integrity: sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==}
+  '@solana/instructions@6.9.0':
+    resolution: {integrity: sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/keys@6.1.0':
-    resolution: {integrity: sha512-C/SGCl3VOgBQZ0mLrMxCcJYnMsGpgE8wbx29jqRY+R91m5YhS1f/GfXJPR1lN/h7QGrJ6YDm8eI0Y3AZ7goKHg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/kit@2.3.0':
-    resolution: {integrity: sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==}
+  '@solana/keys@6.9.0':
+    resolution: {integrity: sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/nominal-types@2.3.0':
-    resolution: {integrity: sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==}
+  '@solana/kit@6.9.0':
+    resolution: {integrity: sha512-k7BRz7Akfv8wiRtlCR/xUyDLfuMfYMelMR1+AC5KgwaRRJReDF0BucMLNN1In7WoI+KuWwr1OKv4na/oKpyeAQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/nominal-types@6.1.0':
     resolution: {integrity: sha512-+skHjN0arNNB9TLsGqA94VCx7euyGURI+qG6wck6E4D7hH6i6DxGiVrtKRghx+smJkkLtTm9BvdVKGoeNQYr7Q==}
@@ -1400,189 +1433,167 @@ packages:
       typescript:
         optional: true
 
-  '@solana/options@2.3.0':
-    resolution: {integrity: sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==}
+  '@solana/nominal-types@6.9.0':
+    resolution: {integrity: sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/programs@2.3.0':
-    resolution: {integrity: sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/promises@2.3.0':
-    resolution: {integrity: sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/promises@6.1.0':
-    resolution: {integrity: sha512-/mUW6peXQiEOaylLpGv4vtkvPzQvSbfhX9j5PNIK/ry4S3SHRQ3j3W/oGy4y3LR5alwo7NcVbubrkh4e4xwcww==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-api@2.3.0':
-    resolution: {integrity: sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==}
+  '@solana/offchain-messages@6.9.0':
+    resolution: {integrity: sha512-qK3tqRPb+E0kmTz5qFXZbEdF4pyzfOWRZjyVESHVGemDDeGzZ1SV3zAxcA6HBCnv4wCBnlyaDPw8t+5sryNMAw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-api@6.1.0':
-    resolution: {integrity: sha512-+hO5+kZjJHuUNATUQxlJ1+ztXFkgn1j46zRwt3X7kF+VHkW3wsQ7up0JTS+Xsacmkrj1WKfymQweq8JTrsAG8A==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-parsed-types@2.3.0':
-    resolution: {integrity: sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==}
+  '@solana/options@6.9.0':
+    resolution: {integrity: sha512-H5ZRWNzzLMwHU/fRU9aVx+3TaMN4gDNCUYxsZxq0h7mqiwxFy6mpy95xPsfdldthCHDYtYnUTxe2sBatGbNHig==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-parsed-types@6.1.0':
-    resolution: {integrity: sha512-YKccynVgWt/gbs0tBYstNw6BSVuOeWdeAldTB2OgH95o2Q04DpO4v97X1MZDysA4SvSZM30Ek5Ni5ss3kskgdw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-spec-types@2.3.0':
-    resolution: {integrity: sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==}
+  '@solana/plugin-core@6.9.0':
+    resolution: {integrity: sha512-KslLSnzY8zbGZibEBVMVUm2ZS8T2xf+cut7F65VjWPoWNAxU+p7933wsMz/az6CF7b65RI7iU3HhCr5/5QF50w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-spec-types@6.1.0':
-    resolution: {integrity: sha512-tldMv1b6VGcvcRrY5MDWKlsyEKH6K96zE7gAIpKDX2G4T47ZOV+OMA3nh6xQpRgtyCUBsej0t80qmvTBDX/5IQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-spec@2.3.0':
-    resolution: {integrity: sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==}
+  '@solana/plugin-interfaces@6.9.0':
+    resolution: {integrity: sha512-Qj4sk9thkM1UgnFXvWIoezd/CbqpX/2jigLBDsMB5Ed/gmFlkBSTL127LFDSY3OtzBpXl4hROs+Zqv+5xqtguA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-spec@6.1.0':
-    resolution: {integrity: sha512-RxpkIGizCYhXGUcap7npV2S/rAXZ7P/liozY/ExjMmCxYTDwGIW33kp/uH/JRxuzrL8+f8FqY76VsqqIe+2VZw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-api@2.3.0':
-    resolution: {integrity: sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==}
+  '@solana/program-client-core@6.9.0':
+    resolution: {integrity: sha512-+iUnsddhs72QoBJoUO+/yHUXoBvYWa1sGCBRJk35zeg8j7ZXEwRkk6eX0VOrUPxhEpQbYJsIOCrIYApNIt8RFw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-subscriptions-api@6.1.0':
-    resolution: {integrity: sha512-I6J+3VU0dda6EySKbDyd+1urC7RGIRPRp0DcWRVcy68NOLbq0I5C40Dn9O2Zf8iCdK4PbQ7JKdCvZ/bDd45hdg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-channel-websocket@2.3.0':
-    resolution: {integrity: sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==}
+  '@solana/programs@6.9.0':
+    resolution: {integrity: sha512-L9LAnQtfFFcCDLcbbnxhUtgAmu/kS4aRmrVncdnX5CFyQshlpo0/Qhrq3UA7vnhute4gjYV4pFT+64onH5qGEQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-      ws: ^8.18.0
-
-  '@solana/rpc-subscriptions-channel-websocket@6.1.0':
-    resolution: {integrity: sha512-vsx9b+uyCr9L3giao/BTiBFA8DxV5+gDNFq0t5uL21uQ17JXzBektwzHuHoth9IjkvXV/h+IhwXfuLE9Qm4GQg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-spec@2.3.0':
-    resolution: {integrity: sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==}
+  '@solana/promises@6.9.0':
+    resolution: {integrity: sha512-227PlXRi6KZX4ODYTkJitr9InSa79NTquI72slay4gzxO9VmMepgvYdMAX6kawdN5pt+VzaklKhNhWXk50Pi9g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-subscriptions-spec@6.1.0':
-    resolution: {integrity: sha512-P06jhqzHpZGaLeJmIQkpDeMDD1xUp53ARpmXMsduMC+U5ZKQt29CLo+JrR18boNtls6WfttjVMEbzF25/4UPVA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions@2.3.0':
-    resolution: {integrity: sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==}
+  '@solana/rpc-api@6.9.0':
+    resolution: {integrity: sha512-3KhXS6A1ie6GqTywW/KEMSXJ1VJEU66fxjhuiiqPILuJstP7kex3ycr3H6DirKydUsy6gaKaPN43rE+LfyS7OA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-subscriptions@6.1.0':
-    resolution: {integrity: sha512-sqwj+cQinWcZ7M/9+cudKxMPTkTQyGP73980vPCWM7vCpPkp2qzgrEie4DdgDGo+NMwIjeFgu2kdUuLHI3GD/g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-transformers@2.3.0':
-    resolution: {integrity: sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==}
+  '@solana/rpc-parsed-types@6.9.0':
+    resolution: {integrity: sha512-6ThH8izY+DWDyrVOOlS40vTcFjwjCinjfqnId7zhRk8OxhkfHQ/iEj+OnGwD4Yhe8pGdVa7GNVYlrQgQgzQ3eQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-transformers@6.1.0':
-    resolution: {integrity: sha512-OsSuuRPmsmS02eR9Zz+4iTsr+21hvEMEex5vwbwN6LAGPFlQ4ohqGkxgZCwmYd+Q5HWpnn9Uuf1MDTLLrKQkig==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-transport-http@2.3.0':
-    resolution: {integrity: sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==}
+  '@solana/rpc-spec-types@6.9.0':
+    resolution: {integrity: sha512-A4fY1JRrcKqX3EfttO4Q8L97nGPqdjfekAV0eDyxN5nu9ngf5p7GKenkl7AYDoHLNr6ZX/C96cRADxXjsRJ0iA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-transport-http@6.1.0':
-    resolution: {integrity: sha512-3ebaTYuglLJagaXtjwDPVI7SQeeeFN2fpetpGKsuMAiti4fzYqEkNN8FIo+nXBzqqG/cVc2421xKjXl6sO1k/g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-types@2.3.0':
-    resolution: {integrity: sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==}
+  '@solana/rpc-spec@6.9.0':
+    resolution: {integrity: sha512-3yHRoChc0IpsJbUq0/94l+ar3t9U3Ax58W0HON7eyYe7zFP10UAxpkHn7DPch9DeALyuGph8kVnvl+kXRgJlGg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-api@6.9.0':
+    resolution: {integrity: sha512-UA/rPQeNx6zQMUFcS8PPPuB4vzUOtSzIY/igMH0DRoP020NyES2GguIb7Zo7sqDNi4n0gkQRhoW4dPVotcNKdA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-channel-websocket@6.9.0':
+    resolution: {integrity: sha512-kT8Yne9HjJD2gooaOFNSyKrvaIfOy2GR0Ymv8OfecBCwFStdz+SPo5eYXq8ZWoZbr5E/MMpHgqsHBanqa2Ffyg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-spec@6.9.0':
+    resolution: {integrity: sha512-DbaG67s99vRZQxFMK80UQ7DEKkRJK6JEZeYg/U5UttD6n7ax/vct7qopxGnrt4RCkaaac2fU8Sr+fcnvWQweUg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions@6.9.0':
+    resolution: {integrity: sha512-IMctZQaMxzvRACQ6ooW98lP+7tVoUJnRgOZtkAdzgBizldQAYPIKd3MulP0jbQPCMfdPsa2Hs0NBcUwfgonq3w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transformers@6.9.0':
+    resolution: {integrity: sha512-dg4LK2wEBpaY+KRk/SJIkYvrvjdsc1AwD4bkmGY4Fp7EwVlvwBQShAQn78Qi4IP0WQ/0n9ncFyUxgcB1Y01ZuQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transport-http@6.9.0':
+    resolution: {integrity: sha512-4gy30fWJcS6jrcXCoP/optFpGJ/gD9xdkE8wDbe1Ys/Y+e4XjyBt45xtTnbdmMdukvdRX+oXS3zgUIYoagpNzQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/rpc-types@6.1.0':
     resolution: {integrity: sha512-lR+Cb3v5Rpl49HsXWASy++TSE1AD86eRKabY+iuWnbBMYVGI4MamAvYwgBiygsCNc30nyO2TFNj9STMeSD/gAg==}
@@ -1593,68 +1604,59 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc@2.3.0':
-    resolution: {integrity: sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==}
+  '@solana/rpc-types@6.9.0':
+    resolution: {integrity: sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc@6.1.0':
-    resolution: {integrity: sha512-R3y5PklW9mPy5Y34hsXj40R28zN2N7AGLnHqYJVkXkllwVub/QCNpSdDxAnbbS5EGOYGoUOW8s5LFoXwMSr1LQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/signers@2.3.0':
-    resolution: {integrity: sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==}
+  '@solana/rpc@6.9.0':
+    resolution: {integrity: sha512-ny1Kt20+oq3xZErNA56+Magmb2JKYfQgHwZTsBmHKVl/9mBpv1y1+ygV+KNiiX/wWXWstLbdIo1jgPwZPbU2Vg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/subscribable@2.3.0':
-    resolution: {integrity: sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/subscribable@6.1.0':
-    resolution: {integrity: sha512-HiUfkxN7638uxPmY4t0gI4+yqnFLZYJKFaT9EpWIuGrOB1d9n+uOHNs3NU7cVMwWXgfZUbztTCKyCVTbcwesNg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/sysvars@2.3.0':
-    resolution: {integrity: sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==}
+  '@solana/signers@6.9.0':
+    resolution: {integrity: sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/transaction-confirmation@2.3.0':
-    resolution: {integrity: sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/transaction-confirmation@6.1.0':
-    resolution: {integrity: sha512-akSjcqAMOGPFvKctFDSzhjcRc/45WbEVdVQ9mjgH6OYo7B11WZZZaeGPlzAw5KyuG34Px941xmICkBmNqEH47Q==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/transaction-messages@2.3.0':
-    resolution: {integrity: sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==}
+  '@solana/subscribable@6.9.0':
+    resolution: {integrity: sha512-YV0/BrJNfepf10CTfLwD7kRY1kkELDHd+BbHJZhBeiuiXTY3xQTvvx1RFs3NtfFCcTHG25Uh8NpRacQJnxSSIQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/sysvars@6.9.0':
+    resolution: {integrity: sha512-e0e+QKr/th9t/O2N1oUoJmcodLghzAtWKUlGb1zyYub0/WJrPImnKqJqp/gDP4tK98mJxopPMcprCeHk4B+TQg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-confirmation@6.9.0':
+    resolution: {integrity: sha512-fzYCOih7hhtBzzNSkAnxMjeFeQ8U7e27k9i0RsgQc3/e3OCynF5HoIVNhhqZbwfIBKiaD4ginJR6slRnfqO32Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/transaction-messages@6.1.0':
     resolution: {integrity: sha512-Dpv54LRVcfFbFEa/uB53LaY/TRfKuPGMKR7Z4F290zBgkj9xkpZkI+WLiJBiSloI7Qo2KZqXj3514BIeZvJLcg==}
@@ -1665,17 +1667,20 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transactions@2.3.0':
-    resolution: {integrity: sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==}
+  '@solana/transaction-messages@6.9.0':
+    resolution: {integrity: sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/transactions@6.1.0':
-    resolution: {integrity: sha512-1dkiNJcTtlHm4Fvs5VohNVpv7RbvbUYYKV7lYXMPIskoLF1eZp0tVlEqD/cRl91RNz7HEysfHqBAwlcJcRmrRg==}
+  '@solana/transactions@6.9.0':
+    resolution: {integrity: sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1749,9 +1754,6 @@ packages:
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
   '@types/react-native-vector-icons@6.4.18':
     resolution: {integrity: sha512-YGlNWb+k5laTBHd7+uZowB9DpIK3SXUneZqAiKQaj1jnJCZM0x71GDim5JCTMi4IFkhc9m8H/Gm28T5BjyivUw==}
 
@@ -1761,8 +1763,8 @@ packages:
   '@types/react-test-renderer@19.1.0':
     resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
-  '@types/react@18.3.28':
-    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+  '@types/react@19.2.16':
+    resolution: {integrity: sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -2185,9 +2187,6 @@ packages:
   base-x@4.0.1:
     resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
 
-  base-x@5.0.1:
-    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2233,9 +2232,6 @@ packages:
 
   bs58@5.0.0:
     resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
-
-  bs58@6.0.0:
-    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -2384,10 +2380,6 @@ packages:
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
-
-  commander@14.0.1:
-    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
-    engines: {node: '>=20'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -3977,7 +3969,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      '@types/react': ^18
+      '@types/react': ^19.0.0
       react: ^19.0.0
     peerDependenciesMeta:
       '@types/react':
@@ -4416,9 +4408,9 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   unbox-primitive@1.1.0:
@@ -4428,8 +4420,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici-types@7.22.0:
-    resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -4491,6 +4483,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -5746,10 +5739,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@react-native-async-storage/async-storage@2.2.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))':
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
 
   '@react-native-community/cli-clean@20.1.2':
     dependencies:
@@ -5772,10 +5765,10 @@ snapshots:
       fast-glob: 3.3.3
       picocolors: 1.1.1
 
-  '@react-native-community/cli-config@20.1.2(typescript@5.0.4)':
+  '@react-native-community/cli-config@20.1.2(typescript@5.6.3)':
     dependencies:
       '@react-native-community/cli-tools': 20.1.2
-      cosmiconfig: 9.0.0(typescript@5.0.4)
+      cosmiconfig: 9.0.0(typescript@5.6.3)
       deepmerge: 4.3.1
       fast-glob: 3.3.3
       joi: 17.13.3
@@ -5783,9 +5776,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@react-native-community/cli-doctor@20.1.2(typescript@5.0.4)':
+  '@react-native-community/cli-doctor@20.1.2(typescript@5.6.3)':
     dependencies:
-      '@react-native-community/cli-config': 20.1.2(typescript@5.0.4)
+      '@react-native-community/cli-config': 20.1.2(typescript@5.6.3)
       '@react-native-community/cli-platform-android': 20.1.2
       '@react-native-community/cli-platform-apple': 20.1.2
       '@react-native-community/cli-platform-ios': 20.1.2
@@ -5858,11 +5851,11 @@ snapshots:
     dependencies:
       joi: 17.13.3
 
-  '@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)':
+  '@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@react-native-community/cli-clean': 20.1.2
-      '@react-native-community/cli-config': 20.1.2(typescript@5.0.4)
-      '@react-native-community/cli-doctor': 20.1.2(typescript@5.0.4)
+      '@react-native-community/cli-config': 20.1.2(typescript@5.6.3)
+      '@react-native-community/cli-doctor': 20.1.2(typescript@5.6.3)
       '@react-native-community/cli-server-api': 20.1.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@react-native-community/cli-tools': 20.1.2
       '@react-native-community/cli-types': 20.1.2
@@ -5881,19 +5874,19 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@react-native-vector-icons/common@12.4.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)':
+  '@react-native-vector-icons/common@12.4.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)':
     dependencies:
       find-up: 7.0.0
       picocolors: 1.1.1
       plist: 3.1.0
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
 
-  '@react-native-vector-icons/material-icons@12.4.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)':
+  '@react-native-vector-icons/material-icons@12.4.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)':
     dependencies:
-      '@react-native-vector-icons/common': 12.4.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
+      '@react-native-vector-icons/common': 12.4.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@react-native-vector-icons/get-image'
 
@@ -5966,7 +5959,7 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.79.2(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+  '@react-native/community-cli-plugin@0.79.2(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@react-native/dev-middleware': 0.79.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       chalk: 4.1.2
@@ -5977,7 +5970,7 @@ snapshots:
       metro-core: 0.82.5
       semver: 7.7.4
     optionalDependencies:
-      '@react-native-community/cli': 20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
+      '@react-native-community/cli': 20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6003,18 +5996,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/eslint-config@0.79.2(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(prettier@3.8.1)(typescript@5.0.4)':
+  '@react-native/eslint-config@0.79.2(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(prettier@3.8.1)(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@10.0.2)
       '@react-native/eslint-plugin': 0.79.2
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4)
-      '@typescript-eslint/parser': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
       eslint: 10.0.2
       eslint-config-prettier: 8.10.2(eslint@10.0.2)
       eslint-plugin-eslint-comments: 3.2.0(eslint@10.0.2)
       eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@10.0.2))(eslint@10.0.2)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(typescript@5.0.4)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(typescript@5.6.3)
       eslint-plugin-react: 7.37.5(eslint@10.0.2)
       eslint-plugin-react-hooks: 4.6.2(eslint@10.0.2)
       eslint-plugin-react-native: 4.1.0(eslint@10.0.2)
@@ -6039,7 +6032,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/metro-config@0.79.2(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+  '@react-native/metro-config@0.79.2(@babel/core@7.29.0)':
     dependencies:
       '@react-native/js-polyfills': 0.79.2
       '@react-native/metro-babel-transformer': 0.79.2(@babel/core@7.29.0)
@@ -6047,22 +6040,20 @@ snapshots:
       metro-runtime: 0.82.5
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.79.2': {}
 
   '@react-native/typescript-config@0.79.2': {}
 
-  '@react-native/virtualized-lists@0.79.2(@types/react@18.3.28)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)':
+  '@react-native/virtualized-lists@0.79.2(@types/react@19.2.16)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
     optionalDependencies:
-      '@types/react': 18.3.28
+      '@types/react': 19.2.16
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -6082,709 +6073,630 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana-mobile/mobile-wallet-adapter-protocol-kit@file:../../js/packages/mobile-wallet-adapter-protocol-kit(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.0.4)':
+  '@solana-mobile/mobile-wallet-adapter-protocol-kit@file:../../js/packages/mobile-wallet-adapter-protocol-kit(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana-mobile/mobile-wallet-adapter-protocol': file:../../js/packages/mobile-wallet-adapter-protocol(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.0.4)
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      bs58: 6.0.0
-      js-base64: 3.7.8
+      '@solana-mobile/mobile-wallet-adapter-protocol': file:../../js/packages/mobile-wallet-adapter-protocol(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/kit': 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     transitivePeerDependencies:
+      - bufferutil
       - fastestsmallesttextencoderdecoder
       - react-native
       - typescript
+      - utf-8-validate
 
-  '@solana-mobile/mobile-wallet-adapter-protocol@file:../../js/packages/mobile-wallet-adapter-protocol(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.0.4)':
+  '@solana-mobile/mobile-wallet-adapter-protocol@file:../../js/packages/mobile-wallet-adapter-protocol(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/codecs-strings': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/kit': 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@solana/wallet-standard-features': 1.3.0
       '@solana/wallet-standard-util': 1.1.2
       '@wallet-standard/core': 1.1.1
-      js-base64: 3.7.8
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
+      - bufferutil
       - fastestsmallesttextencoderdecoder
       - typescript
+      - utf-8-validate
 
-  '@solana-program/memo@0.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)))':
+  '@solana-program/memo@0.11.1(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/kit': 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
 
-  '@solana/accounts@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/accounts@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/addresses@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/assertions': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/nominal-types': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/addresses@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/assertions': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/nominal-types': 6.1.0(typescript@5.0.4)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@2.3.0(typescript@5.0.4)':
+  '@solana/addresses@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/assertions@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
+      '@solana/assertions': 6.1.0(typescript@5.6.3)
+      '@solana/codecs-core': 6.1.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.1.0(typescript@5.6.3)
+      '@solana/nominal-types': 6.1.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+    dependencies:
+      '@solana/assertions': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/assertions@6.1.0(typescript@5.6.3)':
+    dependencies:
+      '@solana/errors': 6.1.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/assertions@6.9.0(typescript@5.6.3)':
+    dependencies:
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
 
   '@solana/buffer-layout@4.0.1':
     dependencies:
       buffer: 6.0.3
 
-  '@solana/codecs-core@2.3.0(typescript@5.0.4)':
+  '@solana/codecs-core@2.3.0(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
+      '@solana/errors': 2.3.0(typescript@5.6.3)
+      typescript: 5.6.3
 
-  '@solana/codecs-core@4.0.0(typescript@5.0.4)':
+  '@solana/codecs-core@6.1.0(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 4.0.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/codecs-core@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
+      '@solana/errors': 6.1.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/codecs-data-structures@2.3.0(typescript@5.0.4)':
+  '@solana/codecs-core@6.9.0(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/codecs-data-structures@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 6.1.0(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/codecs-numbers@2.3.0(typescript@5.0.4)':
+  '@solana/codecs-data-structures@6.1.0(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/codecs-numbers@4.0.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/codecs-core': 4.0.0(typescript@5.0.4)
-      '@solana/errors': 4.0.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/codecs-numbers@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
+      '@solana/codecs-core': 6.1.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.6.3)
+      '@solana/errors': 6.1.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/codecs-strings@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/codecs-data-structures@6.9.0(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.0.4
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
 
-  '@solana/codecs-strings@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/codecs-numbers@2.3.0(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 4.0.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 4.0.0(typescript@5.0.4)
-      '@solana/errors': 4.0.0(typescript@5.0.4)
-      fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.0.4
+      '@solana/codecs-core': 2.3.0(typescript@5.6.3)
+      '@solana/errors': 2.3.0(typescript@5.6.3)
+      typescript: 5.6.3
 
-  '@solana/codecs-strings@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/codecs-numbers@6.1.0(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 6.1.0(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
+      '@solana/codecs-core': 6.1.0(typescript@5.6.3)
+      '@solana/errors': 6.1.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/codecs-numbers@6.9.0(typescript@5.6.3)':
+    dependencies:
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/codecs-strings@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+    dependencies:
+      '@solana/codecs-core': 6.1.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.6.3)
+      '@solana/errors': 6.1.0(typescript@5.6.3)
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/codecs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-data-structures': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/options': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.6.3
+
+  '@solana/codecs@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+    dependencies:
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-data-structures': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/fixed-points': 6.9.0(typescript@5.6.3)
+      '@solana/options': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@2.3.0(typescript@5.0.4)':
+  '@solana/errors@2.3.0(typescript@5.6.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/errors@4.0.0(typescript@5.0.4)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.1
-      typescript: 5.0.4
-
-  '@solana/errors@6.1.0(typescript@5.0.4)':
+  '@solana/errors@6.1.0(typescript@5.6.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/fast-stable-stringify@2.3.0(typescript@5.0.4)':
+  '@solana/errors@6.9.0(typescript@5.6.3)':
     dependencies:
-      typescript: 5.0.4
-
-  '@solana/fast-stable-stringify@6.1.0(typescript@5.0.4)':
+      chalk: 5.6.2
+      commander: 14.0.3
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/functional@2.3.0(typescript@5.0.4)':
-    dependencies:
-      typescript: 5.0.4
-
-  '@solana/functional@6.1.0(typescript@5.0.4)':
+  '@solana/fast-stable-stringify@6.9.0(typescript@5.6.3)':
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/instructions@2.3.0(typescript@5.0.4)':
+  '@solana/fixed-points@6.9.0(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/instructions@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/keys@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/functional@6.1.0(typescript@5.6.3)':
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/functional@6.9.0(typescript@5.6.3)':
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/instruction-plans@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/assertions': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/nominal-types': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/instructions': 6.9.0(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/promises': 6.9.0(typescript@5.6.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/keys@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/instructions@6.1.0(typescript@5.6.3)':
     dependencies:
-      '@solana/assertions': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/nominal-types': 6.1.0(typescript@5.0.4)
+      '@solana/codecs-core': 6.1.0(typescript@5.6.3)
+      '@solana/errors': 6.1.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
+
+  '@solana/instructions@6.9.0(typescript@5.6.3)':
+    dependencies:
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+    dependencies:
+      '@solana/assertions': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.6.3)
+      '@solana/promises': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/functional': 2.3.0(typescript@5.0.4)
-      '@solana/instructions': 2.3.0(typescript@5.0.4)
-      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/programs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-parsed-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/nominal-types@2.3.0(typescript@5.0.4)':
-    dependencies:
-      typescript: 5.0.4
-
-  '@solana/nominal-types@6.1.0(typescript@5.0.4)':
+      '@solana/accounts': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/functional': 6.9.0(typescript@5.6.3)
+      '@solana/instruction-plans': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/instructions': 6.9.0(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/offchain-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/plugin-core': 6.9.0(typescript@5.6.3)
+      '@solana/plugin-interfaces': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/program-client-core': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/programs': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-api': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-parsed-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-subscriptions': 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/subscribable': 6.9.0(typescript@5.6.3)
+      '@solana/sysvars': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transaction-confirmation': 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
-
-  '@solana/options@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-data-structures': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
+      - bufferutil
       - fastestsmallesttextencoderdecoder
+      - utf-8-validate
 
-  '@solana/programs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/promises@2.3.0(typescript@5.0.4)':
-    dependencies:
-      typescript: 5.0.4
-
-  '@solana/promises@6.1.0(typescript@5.0.4)':
+  '@solana/nominal-types@6.1.0(typescript@5.6.3)':
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/rpc-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/nominal-types@6.9.0(typescript@5.6.3)':
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/offchain-messages@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-parsed-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-data-structures': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-api@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/options@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-parsed-types': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-spec': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-transformers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-data-structures': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@2.3.0(typescript@5.0.4)':
-    dependencies:
-      typescript: 5.0.4
-
-  '@solana/rpc-parsed-types@6.1.0(typescript@5.0.4)':
+  '@solana/plugin-core@6.9.0(typescript@5.6.3)':
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/rpc-spec-types@2.3.0(typescript@5.0.4)':
+  '@solana/plugin-interfaces@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      typescript: 5.0.4
-
-  '@solana/rpc-spec-types@6.1.0(typescript@5.0.4)':
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/instruction-plans': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-spec': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-subscriptions-spec': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
-
-  '@solana/rpc-spec@2.3.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/rpc-spec@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 6.1.0(typescript@5.0.4)
-    optionalDependencies:
-      typescript: 5.0.4
-
-  '@solana/rpc-subscriptions-api@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-api@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/program-client-core@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-subscriptions-spec': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-transformers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/accounts': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/instruction-plans': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/instructions': 6.9.0(typescript@5.6.3)
+      '@solana/plugin-interfaces': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-api': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/signers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/programs@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/functional': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.0.4)
-      '@solana/subscribable': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/promises@6.9.0(typescript@5.6.3)':
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/rpc-api@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+    dependencies:
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-parsed-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-transformers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-parsed-types@6.9.0(typescript@5.6.3)':
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/rpc-spec-types@6.9.0(typescript@5.6.3)':
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/rpc-spec@6.9.0(typescript@5.6.3)':
+    dependencies:
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec-types': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/rpc-subscriptions-api@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+    dependencies:
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-subscriptions-spec': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-transformers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc-subscriptions-channel-websocket@6.9.0(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/functional': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-subscriptions-spec': 6.9.0(typescript@5.6.3)
+      '@solana/subscribable': 6.9.0(typescript@5.6.3)
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-
-  '@solana/rpc-subscriptions-channel-websocket@6.1.0(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/functional': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-subscriptions-spec': 6.1.0(typescript@5.0.4)
-      '@solana/subscribable': 6.1.0(typescript@5.0.4)
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@solana/rpc-subscriptions-spec@2.3.0(typescript@5.0.4)':
+  '@solana/rpc-subscriptions-spec@6.9.0(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/promises': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 2.3.0(typescript@5.0.4)
-      '@solana/subscribable': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/rpc-subscriptions-spec@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/promises': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 6.1.0(typescript@5.0.4)
-      '@solana/subscribable': 6.1.0(typescript@5.0.4)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/promises': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec-types': 6.9.0(typescript@5.6.3)
+      '@solana/subscribable': 6.9.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/fast-stable-stringify': 2.3.0(typescript@5.0.4)
-      '@solana/functional': 2.3.0(typescript@5.0.4)
-      '@solana/promises': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/subscribable': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/rpc-subscriptions@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/fast-stable-stringify': 6.1.0(typescript@5.0.4)
-      '@solana/functional': 6.1.0(typescript@5.0.4)
-      '@solana/promises': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-subscriptions-api': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-subscriptions-channel-websocket': 6.1.0(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
-      '@solana/rpc-subscriptions-spec': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-transformers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/subscribable': 6.1.0(typescript@5.0.4)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/fast-stable-stringify': 6.9.0(typescript@5.6.3)
+      '@solana/functional': 6.9.0(typescript@5.6.3)
+      '@solana/promises': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-subscriptions-api': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.9.0(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-subscriptions-spec': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-transformers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/subscribable': 6.9.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-transformers@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/rpc-transformers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/functional': 2.3.0(typescript@5.0.4)
-      '@solana/nominal-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc-transformers@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/functional': 6.1.0(typescript@5.0.4)
-      '@solana/nominal-types': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/functional': 6.9.0(typescript@5.6.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@2.3.0(typescript@5.0.4)':
+  '@solana/rpc-transport-http@6.9.0(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-      undici-types: 7.22.0
-
-  '@solana/rpc-transport-http@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-spec': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 6.1.0(typescript@5.0.4)
-      undici-types: 7.22.0
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec-types': 6.9.0(typescript@5.6.3)
+      undici-types: 8.3.0
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@solana/rpc-types@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/rpc-types@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/nominal-types': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc-types@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/nominal-types': 6.1.0(typescript@5.0.4)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.1.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.1.0(typescript@5.6.3)
+      '@solana/nominal-types': 6.1.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/rpc-types@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/fast-stable-stringify': 2.3.0(typescript@5.0.4)
-      '@solana/functional': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-spec': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-transport-http': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/fast-stable-stringify': 6.1.0(typescript@5.0.4)
-      '@solana/functional': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-api': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-spec': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-spec-types': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-transformers': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-transport-http': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/fixed-points': 6.9.0(typescript@5.6.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/rpc@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/instructions': 2.3.0(typescript@5.0.4)
-      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/nominal-types': 2.3.0(typescript@5.0.4)
-      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/subscribable@2.3.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
-
-  '@solana/subscribable@6.1.0(typescript@5.0.4)':
-    dependencies:
-      '@solana/errors': 6.1.0(typescript@5.0.4)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/fast-stable-stringify': 6.9.0(typescript@5.6.3)
+      '@solana/functional': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-api': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-spec': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-spec-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-transformers': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-transport-http': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
-
-  '@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/promises': 2.3.0(typescript@5.0.4)
-      '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/transaction-confirmation@6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/promises': 6.1.0(typescript@5.0.4)
-      '@solana/rpc': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/rpc-subscriptions': 6.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)(utf-8-validate@5.0.10)
-      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/instructions': 6.9.0(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.6.3)
+      '@solana/offchain-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/subscribable@6.9.0(typescript@5.6.3)':
+    dependencies:
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+
+  '@solana/sysvars@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+    dependencies:
+      '@solana/accounts': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-data-structures': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/promises': 6.9.0(typescript@5.6.3)
+      '@solana/rpc': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/rpc-subscriptions': 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transactions': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-messages@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/transaction-messages@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-data-structures': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/functional': 2.3.0(typescript@5.0.4)
-      '@solana/instructions': 2.3.0(typescript@5.0.4)
-      '@solana/nominal-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transaction-messages@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-data-structures': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 6.1.0(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/functional': 6.1.0(typescript@5.0.4)
-      '@solana/instructions': 6.1.0(typescript@5.0.4)
-      '@solana/nominal-types': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.1.0(typescript@5.6.3)
+      '@solana/codecs-data-structures': 6.1.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.1.0(typescript@5.6.3)
+      '@solana/errors': 6.1.0(typescript@5.6.3)
+      '@solana/functional': 6.1.0(typescript@5.6.3)
+      '@solana/instructions': 6.1.0(typescript@5.6.3)
+      '@solana/nominal-types': 6.1.0(typescript@5.6.3)
+      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
+  '@solana/transaction-messages@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
     dependencies:
-      '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-data-structures': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
-      '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      '@solana/functional': 2.3.0(typescript@5.0.4)
-      '@solana/instructions': 2.3.0(typescript@5.0.4)
-      '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/nominal-types': 2.3.0(typescript@5.0.4)
-      '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transactions@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)':
-    dependencies:
-      '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/codecs-core': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-data-structures': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-numbers': 6.1.0(typescript@5.0.4)
-      '@solana/codecs-strings': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/errors': 6.1.0(typescript@5.0.4)
-      '@solana/functional': 6.1.0(typescript@5.0.4)
-      '@solana/instructions': 6.1.0(typescript@5.0.4)
-      '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/nominal-types': 6.1.0(typescript@5.0.4)
-      '@solana/rpc-types': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
-      '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.0.4)
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-data-structures': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/functional': 6.9.0(typescript@5.6.3)
+      '@solana/instructions': 6.9.0(typescript@5.6.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))':
+  '@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)':
+    dependencies:
+      '@solana/addresses': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/codecs-core': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-data-structures': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.6.3)
+      '@solana/codecs-strings': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/errors': 6.9.0(typescript@5.6.3)
+      '@solana/functional': 6.9.0(typescript@5.6.3)
+      '@solana/instructions': 6.9.0(typescript@5.6.3)
+      '@solana/keys': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/nominal-types': 6.9.0(typescript@5.6.3)
+      '@solana/rpc-types': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+      '@solana/transaction-messages': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.3)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/wallet-standard-features': 1.3.0
-      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
       eventemitter3: 5.0.4
@@ -6804,13 +6716,13 @@ snapshots:
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
 
-  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)':
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
+      '@solana/codecs-numbers': 2.3.0(typescript@5.6.3)
       agentkeepalive: 4.6.0
       bn.js: 5.2.3
       borsh: 0.7.0
@@ -6887,24 +6799,21 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@types/prop-types@15.7.15': {}
-
   '@types/react-native-vector-icons@6.4.18':
     dependencies:
-      '@types/react': 18.3.28
+      '@types/react': 19.2.16
       '@types/react-native': 0.70.19
 
   '@types/react-native@0.70.19':
     dependencies:
-      '@types/react': 18.3.28
+      '@types/react': 19.2.16
 
   '@types/react-test-renderer@19.1.0':
     dependencies:
-      '@types/react': 18.3.28
+      '@types/react': 19.2.16
 
-  '@types/react@18.3.28':
+  '@types/react@19.2.16':
     dependencies:
-      '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
   '@types/semver@7.7.1': {}
@@ -6929,71 +6838,71 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/parser': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 10.0.2
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.0.4)
+      ts-api-utils: 1.4.3(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.0.2)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.56.0
-      '@typescript-eslint/type-utils': 8.56.0(eslint@10.0.2)(typescript@5.0.4)
-      '@typescript-eslint/utils': 8.56.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 8.56.0(eslint@10.0.2)(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.0.2)(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.56.0
       eslint: 10.0.2
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-api-utils: 2.4.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.3
       eslint: 10.0.2
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/parser@8.56.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
       eslint: 10.0.2
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.0(typescript@5.0.4)':
+  '@typescript-eslint/project-service@8.56.0(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.0.4)
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/types': 8.56.0
       debug: 4.4.3
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7012,31 +6921,31 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
 
-  '@typescript-eslint/tsconfig-utils@8.56.0(typescript@5.0.4)':
+  '@typescript-eslint/tsconfig-utils@8.56.0(typescript@5.6.3)':
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
       debug: 4.4.3
       eslint: 10.0.2
-      ts-api-utils: 1.4.3(typescript@5.0.4)
+      ts-api-utils: 1.4.3(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.56.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/type-utils@8.56.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.0.4)
-      '@typescript-eslint/utils': 8.56.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.0.2)(typescript@5.6.3)
       debug: 4.4.3
       eslint: 10.0.2
-      ts-api-utils: 2.4.0(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-api-utils: 2.4.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7046,7 +6955,7 @@ snapshots:
 
   '@typescript-eslint/types@8.56.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.0.4)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -7054,13 +6963,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
-      tsutils: 3.21.0(typescript@5.0.4)
+      tsutils: 3.21.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.0.4)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -7069,35 +6978,35 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.4
-      ts-api-utils: 1.4.3(typescript@5.0.4)
+      ts-api-utils: 1.4.3(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.0.4)':
+  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.0(typescript@5.0.4)
-      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.0.4)
+      '@typescript-eslint/project-service': 8.56.0(typescript@5.6.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
       minimatch: 9.0.5
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-api-utils: 2.4.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/utils@5.62.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.2)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
       eslint: 10.0.2
       eslint-scope: 5.1.1
       semver: 7.7.4
@@ -7105,25 +7014,25 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/utils@7.18.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.2)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       eslint: 10.0.2
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.56.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/utils@8.56.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.2)
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
       eslint: 10.0.2
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7470,8 +7379,6 @@ snapshots:
 
   base-x@4.0.1: {}
 
-  base-x@5.0.1: {}
-
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.0: {}
@@ -7536,10 +7443,6 @@ snapshots:
   bs58@5.0.0:
     dependencies:
       base-x: 4.0.1
-
-  bs58@6.0.0:
-    dependencies:
-      base-x: 5.0.1
 
   bser@2.1.1:
     dependencies:
@@ -7688,8 +7591,6 @@ snapshots:
 
   commander@13.1.0: {}
 
-  commander@14.0.1: {}
-
   commander@14.0.3: {}
 
   commander@2.20.3: {}
@@ -7738,14 +7639,14 @@ snapshots:
       js-yaml: 3.14.2
       parse-json: 4.0.0
 
-  cosmiconfig@9.0.0(typescript@5.0.4):
+  cosmiconfig@9.0.0(typescript@5.6.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
   create-jest@29.7.0(@types/node@25.3.0):
     dependencies:
@@ -8013,12 +7914,12 @@ snapshots:
       lodash: 4.17.23
       string-natural-compare: 3.0.1
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(typescript@5.0.4):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@10.0.2)(typescript@5.6.3)
       eslint: 10.0.2
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3)
       jest: 29.7.0(@types/node@25.3.0)
     transitivePeerDependencies:
       - supports-color
@@ -8192,7 +8093,8 @@ snapshots:
     dependencies:
       strnum: 2.1.2
 
-  fastestsmallesttextencoderdecoder@1.0.22: {}
+  fastestsmallesttextencoderdecoder@1.0.22:
+    optional: true
 
   fastq@1.20.1:
     dependencies:
@@ -9610,40 +9512,40 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-native-get-random-values@1.11.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)):
+  react-native-get-random-values@1.11.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)):
     dependencies:
       fast-base64-decode: 1.0.0
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
 
-  react-native-paper@5.15.0(react-native-safe-area-context@5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0):
+  react-native-paper@5.15.0(react-native-safe-area-context@5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0):
     dependencies:
       '@callstack/react-theme-provider': 3.0.9(react@19.0.0)
       color: 3.2.1
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
-      react-native-safe-area-context: 5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native-safe-area-context: 5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
       use-latest-callback: 0.2.6(react@19.0.0)
 
-  react-native-safe-area-context@5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0):
+  react-native-safe-area-context@5.6.2(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0):
     dependencies:
       react: 19.0.0
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
 
-  react-native-url-polyfill@2.0.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)):
+  react-native-url-polyfill@2.0.0(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)):
     dependencies:
-      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10)
       whatwg-url-without-unicode: 8.0.0-3
 
-  react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10):
+  react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.79.2
       '@react-native/codegen': 0.79.2(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.79.2(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@react-native/community-cli-plugin': 0.79.2(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@react-native/gradle-plugin': 0.79.2
       '@react-native/js-polyfills': 0.79.2
       '@react-native/normalize-colors': 0.79.2
-      '@react-native/virtualized-lists': 0.79.2(@types/react@18.3.28)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10))(@types/react@18.3.28)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
+      '@react-native/virtualized-lists': 0.79.2(@types/react@19.2.16)(react-native@0.79.2(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -9674,7 +9576,7 @@ snapshots:
       ws: 6.2.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yargs: 17.7.2
     optionalDependencies:
-      '@types/react': 18.3.28
+      '@types/react': 19.2.16
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'
@@ -10110,22 +10012,22 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-api-utils@1.4.3(typescript@5.0.4):
+  ts-api-utils@1.4.3(typescript@5.6.3):
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
-  ts-api-utils@2.4.0(typescript@5.0.4):
+  ts-api-utils@2.4.0(typescript@5.6.3):
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
-  tsutils@3.21.0(typescript@5.0.4):
+  tsutils@3.21.0(typescript@5.6.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 5.6.3
 
   type-check@0.4.0:
     dependencies:
@@ -10176,7 +10078,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript@5.0.4: {}
+  typescript@5.6.3: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -10187,7 +10089,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.22.0: {}
+  undici-types@8.3.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/examples/example-react-native-wallet/package.json
+++ b/examples/example-react-native-wallet/package.json
@@ -32,6 +32,7 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.26.10",
+    "@jest/globals": "^29.7.0",
     "@react-native-community/cli": "20.1.2",
     "@react-native-community/cli-platform-android": "20.1.2",
     "@react-native-community/cli-platform-ios": "20.1.2",
@@ -48,7 +49,7 @@
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "18.3.1",
-    "typescript": "5.0.4"
+    "typescript": "5.6.3"
   },
   "engines": {
     "node": ">=18"

--- a/examples/example-react-native-wallet/pnpm-lock.yaml
+++ b/examples/example-react-native-wallet/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.1.2
       '@solana/web3.js':
         specifier: ^1.95.4
-        version: 1.98.4(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
+        version: 1.98.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)
       bs58:
         specifier: ^5.0.0
         version: 5.0.0
@@ -66,9 +66,12 @@ importers:
       '@babel/runtime':
         specifier: ^7.26.10
         version: 7.28.6
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
       '@react-native-community/cli':
         specifier: 20.1.2
-        version: 20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)
+        version: 20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@react-native-community/cli-platform-android':
         specifier: 20.1.2
         version: 20.1.2
@@ -83,7 +86,7 @@ importers:
         version: 0.79.1(@babel/core@7.29.0)
       '@react-native/eslint-config':
         specifier: 0.76.1
-        version: 0.76.1(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(prettier@2.8.8)(typescript@5.0.4)
+        version: 0.76.1(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(prettier@2.8.8)(typescript@5.6.3)
       '@react-native/gradle-plugin':
         specifier: 0.79.1
         version: 0.79.1
@@ -115,8 +118,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       typescript:
-        specifier: 5.0.4
-        version: 5.0.4
+        specifier: 5.6.3
+        version: 5.6.3
 
 packages:
 
@@ -3820,9 +3823,9 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   unbox-primitive@1.1.0:
@@ -5209,10 +5212,10 @@ snapshots:
       fast-glob: 3.3.3
       picocolors: 1.1.1
 
-  '@react-native-community/cli-config@20.1.2(typescript@5.0.4)':
+  '@react-native-community/cli-config@20.1.2(typescript@5.6.3)':
     dependencies:
       '@react-native-community/cli-tools': 20.1.2
-      cosmiconfig: 9.0.0(typescript@5.0.4)
+      cosmiconfig: 9.0.0(typescript@5.6.3)
       deepmerge: 4.3.1
       fast-glob: 3.3.3
       joi: 17.13.3
@@ -5220,9 +5223,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@react-native-community/cli-doctor@20.1.2(typescript@5.0.4)':
+  '@react-native-community/cli-doctor@20.1.2(typescript@5.6.3)':
     dependencies:
-      '@react-native-community/cli-config': 20.1.2(typescript@5.0.4)
+      '@react-native-community/cli-config': 20.1.2(typescript@5.6.3)
       '@react-native-community/cli-platform-android': 20.1.2
       '@react-native-community/cli-platform-apple': 20.1.2
       '@react-native-community/cli-platform-ios': 20.1.2
@@ -5295,11 +5298,11 @@ snapshots:
     dependencies:
       joi: 17.13.3
 
-  '@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)':
+  '@react-native-community/cli@20.1.2(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@react-native-community/cli-clean': 20.1.2
-      '@react-native-community/cli-config': 20.1.2(typescript@5.0.4)
-      '@react-native-community/cli-doctor': 20.1.2(typescript@5.0.4)
+      '@react-native-community/cli-config': 20.1.2(typescript@5.6.3)
+      '@react-native-community/cli-doctor': 20.1.2(typescript@5.6.3)
       '@react-native-community/cli-server-api': 20.1.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@react-native-community/cli-tools': 20.1.2
       '@react-native-community/cli-types': 20.1.2
@@ -5443,18 +5446,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/eslint-config@0.76.1(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(prettier@2.8.8)(typescript@5.0.4)':
+  '@react-native/eslint-config@0.76.1(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(prettier@2.8.8)(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@10.0.2)
       '@react-native/eslint-plugin': 0.76.1
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4)
-      '@typescript-eslint/parser': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
       eslint: 10.0.2
       eslint-config-prettier: 8.10.2(eslint@10.0.2)
       eslint-plugin-eslint-comments: 3.2.0(eslint@10.0.2)
       eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@10.0.2))(eslint@10.0.2)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(typescript@5.0.4)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(typescript@5.6.3)
       eslint-plugin-react: 7.37.5(eslint@10.0.2)
       eslint-plugin-react-hooks: 4.6.2(eslint@10.0.2)
       eslint-plugin-react-native: 4.1.0(eslint@10.0.2)
@@ -5535,22 +5538,22 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@solana/codecs-core@2.3.0(typescript@5.0.4)':
+  '@solana/codecs-core@2.3.0(typescript@5.6.3)':
     dependencies:
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
+      '@solana/errors': 2.3.0(typescript@5.6.3)
+      typescript: 5.6.3
 
-  '@solana/codecs-numbers@2.3.0(typescript@5.0.4)':
+  '@solana/codecs-numbers@2.3.0(typescript@5.6.3)':
     dependencies:
-      '@solana/codecs-core': 2.3.0(typescript@5.0.4)
-      '@solana/errors': 2.3.0(typescript@5.0.4)
-      typescript: 5.0.4
+      '@solana/codecs-core': 2.3.0(typescript@5.6.3)
+      '@solana/errors': 2.3.0(typescript@5.6.3)
+      typescript: 5.6.3
 
-  '@solana/errors@2.3.0(typescript@5.0.4)':
+  '@solana/errors@2.3.0(typescript@5.6.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
-      typescript: 5.0.4
+      typescript: 5.6.3
 
   '@solana/wallet-standard-chains@1.1.1':
     dependencies:
@@ -5567,13 +5570,13 @@ snapshots:
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
 
-  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.0.4)(utf-8-validate@5.0.10)':
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
-      '@solana/codecs-numbers': 2.3.0(typescript@5.0.4)
+      '@solana/codecs-numbers': 2.3.0(typescript@5.6.3)
       agentkeepalive: 4.6.0
       bn.js: 5.2.3
       borsh: 0.7.0
@@ -5680,34 +5683,34 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/parser': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 10.0.2
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.0.4)
+      ts-api-utils: 1.4.3(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.3
       eslint: 10.0.2
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5721,15 +5724,15 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
-      '@typescript-eslint/utils': 7.18.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@10.0.2)(typescript@5.6.3)
       debug: 4.4.3
       eslint: 10.0.2
-      ts-api-utils: 1.4.3(typescript@5.0.4)
+      ts-api-utils: 1.4.3(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5737,7 +5740,7 @@ snapshots:
 
   '@typescript-eslint/types@7.18.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.0.4)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -5745,13 +5748,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
-      tsutils: 3.21.0(typescript@5.0.4)
+      tsutils: 3.21.0(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.0.4)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -5760,20 +5763,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.4
-      ts-api-utils: 1.4.3(typescript@5.0.4)
+      ts-api-utils: 1.4.3(typescript@5.6.3)
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/utils@5.62.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.2)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
       eslint: 10.0.2
       eslint-scope: 5.1.1
       semver: 7.7.4
@@ -5781,12 +5784,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@10.0.2)(typescript@5.0.4)':
+  '@typescript-eslint/utils@7.18.0(eslint@10.0.2)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.2)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       eslint: 10.0.2
     transitivePeerDependencies:
       - supports-color
@@ -6327,14 +6330,14 @@ snapshots:
       js-yaml: 3.14.2
       parse-json: 4.0.0
 
-  cosmiconfig@9.0.0(typescript@5.0.4):
+  cosmiconfig@9.0.0(typescript@5.6.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
   create-jest@29.7.0(@types/node@25.3.0):
     dependencies:
@@ -6600,12 +6603,12 @@ snapshots:
       lodash: 4.17.23
       string-natural-compare: 3.0.1
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(typescript@5.0.4):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(jest@29.7.0(@types/node@25.3.0))(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@10.0.2)(typescript@5.6.3)
       eslint: 10.0.2
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.0.4))(eslint@10.0.2)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.0.2)(typescript@5.6.3))(eslint@10.0.2)(typescript@5.6.3)
       jest: 29.7.0(@types/node@25.3.0)
     transitivePeerDependencies:
       - supports-color
@@ -8773,18 +8776,18 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-api-utils@1.4.3(typescript@5.0.4):
+  ts-api-utils@1.4.3(typescript@5.6.3):
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.6.3
 
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
-  tsutils@3.21.0(typescript@5.0.4):
+  tsutils@3.21.0(typescript@5.6.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 5.6.3
 
   type-check@0.4.0:
     dependencies:
@@ -8835,7 +8838,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript@5.0.4: {}
+  typescript@5.6.3: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/examples/example-react-native-wallet/screens/TestingEntrypointBottomSheet.tsx
+++ b/examples/example-react-native-wallet/screens/TestingEntrypointBottomSheet.tsx
@@ -1,33 +1,26 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import {
-  StyleSheet,
-  View,
-  Text,
   BackHandler,
-  ActivityIndicator,
+  StyleSheet,
+  Text,
   TouchableOpacity,
+  View,
 } from 'react-native';
 import Modal from 'react-native-modal';
 import {
-  MobileWalletAdapterConfig,
   AuthorizeDappRequest,
   SignMessagesRequest,
   SignTransactionsRequest,
   SignAndSendTransactionsRequest,
-  useMobileWalletAdapterSession,
   MWARequestType,
-  MWARequest,
-  MWASessionEvent,
-  MWASessionEventType,
   resolve,
-  MWAResponse,
   AuthorizeDappResponse,
   MWARequestFailReason,
   SignAndSendTransactionsResponse,
   SignTransactionsResponse,
   SignMessagesResponse,
   UserDeclinedResponse,
-  AuthorizationNotValid,
+  AuthorizationNotValidResponse,
   InvalidSignaturesResponse,
   TooManyPayloadsResponse,
 } from '@solana-mobile/mobile-wallet-adapter-walletlib';
@@ -37,44 +30,52 @@ import {Keypair} from '@solana/web3.js';
 
 interface SendResponseButtonProps {
   title: string;
-  request: MWARequest;
-  response: MWAResponse;
 }
 
-const SendResponseButton = ({
-  title,
-  request,
-  response,
-}: SendResponseButtonProps) => {
-  let typedRequest;
-  let typedResponse;
-  switch (request.__type) {
-    case MWARequestType.AuthorizeDappRequest:
-      typedRequest = request as AuthorizeDappRequest;
-      typedResponse = response as AuthorizeDappResponse;
-      break;
-    case MWARequestType.SignMessagesRequest:
-      typedRequest = request as SignMessagesRequest;
-      typedResponse = response as SignMessagesResponse;
-      break;
-    case MWARequestType.SignTransactionsRequest:
-      typedRequest = request as SignTransactionsRequest;
-      typedResponse = response as SignTransactionsResponse;
-      break;
-    case MWARequestType.SignAndSendTransactionsRequest:
-      typedRequest = request as SignAndSendTransactionsRequest;
-      typedResponse = response as SignAndSendTransactionsResponse;
-      break;
-    default:
-      console.warn('Unsupported request type');
-      return null;
-  }
+type SendResponseButtonTypedProps =
+  | Readonly<{
+      requestType: MWARequestType.AuthorizeDappRequest;
+      request: AuthorizeDappRequest;
+      response: AuthorizeDappResponse;
+    }>
+  | Readonly<{
+      requestType: MWARequestType.SignAndSendTransactionsRequest;
+      request: SignAndSendTransactionsRequest;
+      response: SignAndSendTransactionsResponse;
+    }>
+  | Readonly<{
+      requestType: MWARequestType.SignMessagesRequest;
+      request: SignMessagesRequest;
+      response: SignMessagesResponse;
+    }>
+  | Readonly<{
+      requestType: MWARequestType.SignTransactionsRequest;
+      request: SignTransactionsRequest;
+      response: SignTransactionsResponse;
+    }>;
 
+const SendResponseButton = (
+  props: SendResponseButtonProps & SendResponseButtonTypedProps,
+) => {
+  const {title} = props;
   return (
     <TouchableOpacity
       style={styles.button}
       onPress={async () => {
-        await resolve(typedRequest, typedResponse);
+        switch (props.requestType) {
+          case MWARequestType.AuthorizeDappRequest:
+            await resolve(props.request, props.response);
+            break;
+          case MWARequestType.SignAndSendTransactionsRequest:
+            await resolve(props.request, props.response);
+            break;
+          case MWARequestType.SignMessagesRequest:
+            await resolve(props.request, props.response);
+            break;
+          case MWARequestType.SignTransactionsRequest:
+            await resolve(props.request, props.response);
+            break;
+        }
       }}>
       <Text style={styles.buttonText}>{title}</Text>
     </TouchableOpacity>
@@ -92,47 +93,53 @@ export default function TestingEntrypointBottomSheet() {
   }, []);
 
   const genericRequest = {
+    authorizationScope: new Uint8Array([1, 2, 3, 4]),
+    chain: 'solana:devnet',
+    cluster: 'devnet',
     requestId: 'reqid',
     sessionId: 'sessionid',
-    cluster: 'devnet',
-    authorizationScope: new Uint8Array([1, 2, 3, 4]),
   };
 
-  const authorizeDappResponse = {
-    publicKey: Keypair.generate().publicKey.toBytes(),
-    label: 'Wallet Label',
-  } as AuthorizeDappResponse;
+  const authorizeDappResponse: AuthorizeDappResponse = {
+    accounts: [
+      {
+        accountLabel: 'Wallet Label',
+        chains: ['solana:devnet'],
+        publicKey: Keypair.generate().publicKey.toBytes(),
+      },
+    ],
+  };
 
-  const signPayloadsResponse = {
+  const signPayloadsResponse: SignMessagesResponse = {
     signedPayloads: [
       new Uint8Array([1, 2, 3]),
       new Uint8Array([1, 2, 3, 4, 5]),
     ],
   };
 
-  const signAndSendTransactionsResponse = {
+  const signAndSendTransactionsResponse: SignAndSendTransactionsResponse = {
     signedTransactions: [
       new Uint8Array([1, 2, 3]),
       new Uint8Array([1, 2, 3, 4, 5]),
     ],
   };
 
-  const userDeclinedResponse = {
+  const userDeclinedResponse: UserDeclinedResponse = {
     failReason: MWARequestFailReason.UserDeclined,
-  } as UserDeclinedResponse;
+  };
 
-  const authorizationNotValidResponse = {
+  const authorizationNotValidResponse: AuthorizationNotValidResponse = {
     failReason: MWARequestFailReason.AuthorizationNotValid,
-  } as AuthorizationNotValidResponse;
+  };
 
-  const invalidSignaturesResponse = {
+  const invalidSignaturesResponse: InvalidSignaturesResponse = {
     failReason: MWARequestFailReason.InvalidSignatures,
     valid: [false, true],
-  } as InvalidSignaturesResponse;
+  };
 
-  const tooManyPayloadsResponse = {
+  const tooManyPayloadsResponse: TooManyPayloadsResponse = {
     failReason: MWARequestFailReason.TooManyPayloads,
-  } as TooManyPayloadsResponse;
+  };
 
   return (
     <Modal
@@ -144,15 +151,15 @@ export default function TestingEntrypointBottomSheet() {
       <WalletProvider>
         <View style={styles.bottomSheet}>
           <SendResponseButton
-            title="Authorize Dapp"
             request={{
               ...genericRequest,
               __type: MWARequestType.AuthorizeDappRequest,
             }}
+            requestType={MWARequestType.AuthorizeDappRequest}
             response={authorizeDappResponse}
+            title="Authorize Dapp"
           />
           <SendResponseButton
-            title="Sign Transaction"
             request={{
               ...genericRequest,
               __type: MWARequestType.SignTransactionsRequest,
@@ -161,10 +168,11 @@ export default function TestingEntrypointBottomSheet() {
                 new Uint8Array([1, 2, 3, 4, 5]),
               ],
             }}
+            requestType={MWARequestType.SignTransactionsRequest}
             response={signPayloadsResponse}
+            title="Sign Transaction"
           />
           <SendResponseButton
-            title="Sign Transaction"
             request={{
               ...genericRequest,
               __type: MWARequestType.SignMessagesRequest,
@@ -173,10 +181,11 @@ export default function TestingEntrypointBottomSheet() {
                 new Uint8Array([1, 2, 3, 4, 5]),
               ],
             }}
+            requestType={MWARequestType.SignMessagesRequest}
             response={signPayloadsResponse}
+            title="Sign Transaction"
           />
           <SendResponseButton
-            title="Sign And Send Transaction"
             request={{
               ...genericRequest,
               __type: MWARequestType.SignAndSendTransactionsRequest,
@@ -185,13 +194,14 @@ export default function TestingEntrypointBottomSheet() {
                 new Uint8Array([1, 2, 3, 4, 5]),
               ],
             }}
+            requestType={MWARequestType.SignAndSendTransactionsRequest}
             response={signAndSendTransactionsResponse}
+            title="Sign And Send Transaction"
           />
 
           <Text> Fail Responses </Text>
 
           <SendResponseButton
-            title="User Declined Sign And Send"
             request={{
               ...genericRequest,
               __type: MWARequestType.SignAndSendTransactionsRequest,
@@ -200,11 +210,12 @@ export default function TestingEntrypointBottomSheet() {
                 new Uint8Array([1, 2, 3, 4, 5]),
               ],
             }}
+            requestType={MWARequestType.SignAndSendTransactionsRequest}
             response={userDeclinedResponse}
+            title="User Declined Sign And Send"
           />
 
           <SendResponseButton
-            title="Too many payloads"
             request={{
               ...genericRequest,
               __type: MWARequestType.SignAndSendTransactionsRequest,
@@ -213,11 +224,12 @@ export default function TestingEntrypointBottomSheet() {
                 new Uint8Array([1, 2, 3, 4, 5]),
               ],
             }}
+            requestType={MWARequestType.SignAndSendTransactionsRequest}
             response={tooManyPayloadsResponse}
+            title="Too many payloads"
           />
 
           <SendResponseButton
-            title="Invalid Signatures"
             request={{
               ...genericRequest,
               __type: MWARequestType.SignAndSendTransactionsRequest,
@@ -226,11 +238,12 @@ export default function TestingEntrypointBottomSheet() {
                 new Uint8Array([1, 2, 3, 4, 5]),
               ],
             }}
+            requestType={MWARequestType.SignAndSendTransactionsRequest}
             response={invalidSignaturesResponse}
+            title="Invalid Signatures"
           />
 
           <SendResponseButton
-            title="Auth not valid"
             request={{
               ...genericRequest,
               __type: MWARequestType.SignAndSendTransactionsRequest,
@@ -239,7 +252,9 @@ export default function TestingEntrypointBottomSheet() {
                 new Uint8Array([1, 2, 3, 4, 5]),
               ],
             }}
+            requestType={MWARequestType.SignAndSendTransactionsRequest}
             response={authorizationNotValidResponse}
+            title="Auth not valid"
           />
         </View>
       </WalletProvider>


### PR DESCRIPTION
Align the React Native example dependency graphs with their React and Solana type peers, update stale walletlib testing responses, and remove the RN workflow typecheck continue-on-error gates.