### PR TITLE
Deprecate JS default export helpers

### DIFF
--- a/js/packages/mobile-wallet-adapter-protocol/src/__forks__/react-native/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/__forks__/react-native/transact.ts
@@ -1,7 +1,7 @@
 import { AppRegistry, Platform } from 'react-native';
 
 import NativeSolanaMobileWalletAdapter from '../../codegenSpec/NativeSolanaMobileWalletAdapter.js';
-import createMobileWalletProxy from '../../createMobileWalletProxy.js';
+import { createMobileWalletProxy } from '../../createMobileWalletProxy.js';
 import { SolanaMobileWalletAdapterError, SolanaMobileWalletAdapterProtocolError } from '../../errors.js';
 import { MobileWallet, SessionProperties, WalletAssociationConfig } from '../../types.js';
 

--- a/js/packages/mobile-wallet-adapter-protocol/src/arrayBufferToBase64String.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/arrayBufferToBase64String.ts
@@ -4,4 +4,7 @@ export function arrayBufferToBase64String(buffer: ArrayBuffer): string {
     return fromUint8Array(new Uint8Array(buffer));
 }
 
+/**
+ * @deprecated Use {@link arrayBufferToBase64String} instead.
+ */
 export default arrayBufferToBase64String;

--- a/js/packages/mobile-wallet-adapter-protocol/src/createMobileWalletProxy.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/createMobileWalletProxy.ts
@@ -21,7 +21,7 @@ import {
  * @param protocolRequestHandler callback function that handles sending the RPC request to the wallet endpoint.
  * @returns a {@link MobileWallet} proxy
  */
-export default function createMobileWalletProxy<
+export function createMobileWalletProxy<
     TMethodName extends keyof MobileWallet,
     TReturn extends Awaited<ReturnType<MobileWallet[TMethodName]>>,
 >(
@@ -66,6 +66,11 @@ export default function createMobileWalletProxy<
         },
     });
 }
+
+/**
+ * @deprecated Use {@link createMobileWalletProxy} instead.
+ */
+export default createMobileWalletProxy;
 
 /**
  * Handles all {@link MobileWallet} API requests and determines the correct MWA RPC method and params to call.

--- a/js/packages/mobile-wallet-adapter-protocol/src/createSequenceNumberVector.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/createSequenceNumberVector.ts
@@ -1,6 +1,6 @@
 export const SEQUENCE_NUMBER_BYTES = 4;
 
-export default function createSequenceNumberVector(sequenceNumber: number): Uint8Array {
+export function createSequenceNumberVector(sequenceNumber: number): Uint8Array {
     if (sequenceNumber >= 4294967296) {
         throw new Error('Outbound sequence number overflow. The maximum sequence number is 32-bytes.');
     }
@@ -9,3 +9,8 @@ export default function createSequenceNumberVector(sequenceNumber: number): Uint
     view.setUint32(0, sequenceNumber, /* littleEndian */ false);
     return new Uint8Array(byteArray);
 }
+
+/**
+ * @deprecated Use {@link createSequenceNumberVector} instead.
+ */
+export default createSequenceNumberVector;

--- a/js/packages/mobile-wallet-adapter-protocol/src/encryptedMessage.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/encryptedMessage.ts
@@ -1,4 +1,4 @@
-import createSequenceNumberVector, { SEQUENCE_NUMBER_BYTES } from './createSequenceNumberVector.js';
+import { createSequenceNumberVector, SEQUENCE_NUMBER_BYTES } from './createSequenceNumberVector.js';
 import { utf8FromUint8Array, utf8ToUint8Array } from './encoding.js';
 import { SharedSecret } from './parseHelloRsp.js';
 

--- a/js/packages/mobile-wallet-adapter-protocol/src/getAssociateAndroidIntentURL.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/getAssociateAndroidIntentURL.ts
@@ -1,8 +1,8 @@
-import arrayBufferToBase64String from './arrayBufferToBase64String.js';
+import { arrayBufferToBase64String } from './arrayBufferToBase64String.js';
 import { assertAssociationPort } from './associationPort.js';
 import { fromUint8Array } from './base64Utils.js';
 import { SolanaMobileWalletAdapterError, SolanaMobileWalletAdapterErrorCode } from './errors.js';
-import getStringWithURLUnsafeBase64CharactersReplaced from './getStringWithURLUnsafeBase64CharactersReplaced.js';
+import { getStringWithURLUnsafeBase64CharactersReplaced } from './getStringWithURLUnsafeBase64CharactersReplaced.js';
 import { ProtocolVersion } from './types.js';
 
 const INTENT_NAME = 'solana-wallet';

--- a/js/packages/mobile-wallet-adapter-protocol/src/getStringWithURLUnsafeBase64CharactersReplaced.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/getStringWithURLUnsafeBase64CharactersReplaced.ts
@@ -1,4 +1,4 @@
-export default function getStringWithURLUnsafeCharactersReplaced(unsafeBase64EncodedString: string): string {
+export function getStringWithURLUnsafeBase64CharactersReplaced(unsafeBase64EncodedString: string): string {
     return unsafeBase64EncodedString.replace(
         /[/+=]/g,
         (m) =>
@@ -9,3 +9,8 @@ export default function getStringWithURLUnsafeCharactersReplaced(unsafeBase64Enc
             })[m] as string,
     );
 }
+
+/**
+ * @deprecated Use {@link getStringWithURLUnsafeBase64CharactersReplaced} instead.
+ */
+export default getStringWithURLUnsafeBase64CharactersReplaced;

--- a/js/packages/mobile-wallet-adapter-protocol/src/transact.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/src/transact.ts
@@ -1,6 +1,6 @@
 import { fromUint8Array, toUint8Array } from './base64Utils.js';
 import createHelloReq from './createHelloReq.js';
-import createMobileWalletProxy from './createMobileWalletProxy.js';
+import { createMobileWalletProxy } from './createMobileWalletProxy.js';
 import { SEQUENCE_NUMBER_BYTES } from './createSequenceNumberVector.js';
 import { ENCODED_PUBLIC_KEY_LENGTH_BYTES } from './encryptedMessage.js';
 import {

--- a/js/packages/mobile-wallet-adapter-protocol/test/arrayBufferToBase64String.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/arrayBufferToBase64String.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 
-import arrayBufferToBase64String from '../src/arrayBufferToBase64String.js';
+import { arrayBufferToBase64String } from '../src/arrayBufferToBase64String.js';
 
 describe('arrayBufferToBase64String', () => {
     it('encodes an array buffer to base64', () => {

--- a/js/packages/mobile-wallet-adapter-protocol/test/createMobileWalletProxy.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/createMobileWalletProxy.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { fromUint8Array } from '../src/base64Utils.js';
-import createMobileWalletProxy from '../src/createMobileWalletProxy.js';
+import { createMobileWalletProxy } from '../src/createMobileWalletProxy.js';
 import { SolanaCloneAuthorization, SolanaSignTransactions } from '../src/types.js';
 
 const APP_IDENTITY = {

--- a/js/packages/mobile-wallet-adapter-protocol/test/createSequenceNumberVector.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/createSequenceNumberVector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import createSequenceNumberVector from '../src/createSequenceNumberVector.js';
+import { createSequenceNumberVector } from '../src/createSequenceNumberVector.js';
 
 describe('createSequenceNumberVector', () => {
     it('encodes a sequence number in big-endian byte order', () => {

--- a/js/packages/mobile-wallet-adapter-protocol/test/getStringWithURLUnsafeBase64CharactersReplaced.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/getStringWithURLUnsafeBase64CharactersReplaced.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import getStringWithURLUnsafeBase64CharactersReplaced from '../src/getStringWithURLUnsafeBase64CharactersReplaced.js';
+import { getStringWithURLUnsafeBase64CharactersReplaced } from '../src/getStringWithURLUnsafeBase64CharactersReplaced.js';
 
 describe('getStringWithURLUnsafeBase64CharactersReplaced', () => {
     it('replaces URL-unsafe base64 characters', () => {

--- a/js/packages/mobile-wallet-adapter-protocol/test/transact.react-native.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/transact.react-native.test.ts
@@ -213,7 +213,7 @@ async function importReactNativeTransact({
         default: nativeModule,
     }));
     vi.doMock('../src/createMobileWalletProxy.js', () => ({
-        default: mockCreateMobileWalletProxy,
+        createMobileWalletProxy: mockCreateMobileWalletProxy,
     }));
 
     const module = await import('../src/__forks__/react-native/transact.js');

--- a/js/packages/mobile-wallet-adapter-protocol/test/transact.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/transact.test.ts
@@ -50,7 +50,7 @@ vi.mock('../src/createHelloReq.js', () => ({
 }));
 
 vi.mock('../src/createMobileWalletProxy.js', () => ({
-    default: mockCreateMobileWalletProxy,
+    createMobileWalletProxy: mockCreateMobileWalletProxy,
 }));
 
 vi.mock('../src/generateAssociationKeypair.js', () => ({

--- a/js/packages/wallet-adapter-mobile/src/__forks__/react-native/createDefaultAuthorizationResultCache.ts
+++ b/js/packages/wallet-adapter-mobile/src/__forks__/react-native/createDefaultAuthorizationResultCache.ts
@@ -5,7 +5,7 @@ import { AuthorizationResultCache } from '../../adapter.js';
 
 const CACHE_KEY = 'SolanaMobileWalletAdapterDefaultAuthorizationCache';
 
-export default function createDefaultAuthorizationResultCache(): AuthorizationResultCache {
+export function createDefaultAuthorizationResultCache(): AuthorizationResultCache {
     return {
         async clear() {
             try {
@@ -29,3 +29,8 @@ export default function createDefaultAuthorizationResultCache(): AuthorizationRe
         },
     };
 }
+
+/**
+ * @deprecated Use {@link createDefaultAuthorizationResultCache} instead.
+ */
+export default createDefaultAuthorizationResultCache;

--- a/js/packages/wallet-adapter-mobile/src/__forks__/react-native/getIsSupported.ts
+++ b/js/packages/wallet-adapter-mobile/src/__forks__/react-native/getIsSupported.ts
@@ -1,5 +1,10 @@
 import { Platform } from 'react-native';
 
-export default function getIsSupported() {
+export function getIsSupported() {
     return Platform.OS === 'android';
 }
+
+/**
+ * @deprecated Use {@link getIsSupported} instead.
+ */
+export default getIsSupported;

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -58,7 +58,7 @@ import {
     WalletAccount,
 } from '@wallet-standard/core';
 
-import getIsSupported from './getIsSupported.js';
+import { getIsSupported } from './getIsSupported.js';
 
 export interface AuthorizationResultCache {
     clear(): Promise<void>;

--- a/js/packages/wallet-adapter-mobile/src/createDefaultAddressSelector.ts
+++ b/js/packages/wallet-adapter-mobile/src/createDefaultAddressSelector.ts
@@ -1,9 +1,14 @@
 import { AddressSelector } from './adapter.js';
 
-export default function createDefaultAddressSelector(): AddressSelector {
+export function createDefaultAddressSelector(): AddressSelector {
     return {
         async select(addresses) {
             return addresses[0];
         },
     };
 }
+
+/**
+ * @deprecated Use {@link createDefaultAddressSelector} instead.
+ */
+export default createDefaultAddressSelector;

--- a/js/packages/wallet-adapter-mobile/src/createDefaultAuthorizationResultCache.ts
+++ b/js/packages/wallet-adapter-mobile/src/createDefaultAuthorizationResultCache.ts
@@ -2,6 +2,11 @@ import { createDefaultAuthorizationCache as baseCreateDefaultAuthorizationCache 
 
 import { AuthorizationResultCache } from './adapter.js';
 
-export default function createDefaultAuthorizationResultCache(): AuthorizationResultCache {
+export function createDefaultAuthorizationResultCache(): AuthorizationResultCache {
     return baseCreateDefaultAuthorizationCache();
 }
+
+/**
+ * @deprecated Use {@link createDefaultAuthorizationResultCache} instead.
+ */
+export default createDefaultAuthorizationResultCache;

--- a/js/packages/wallet-adapter-mobile/src/createDefaultWalletNotFoundHandler.ts
+++ b/js/packages/wallet-adapter-mobile/src/createDefaultWalletNotFoundHandler.ts
@@ -6,8 +6,13 @@ async function defaultWalletNotFoundHandler(_mobileWalletAdapter: SolanaMobileWa
     return defaultErrorModalWalletNotFoundHandler();
 }
 
-export default function createDefaultWalletNotFoundHandler(): (
+export function createDefaultWalletNotFoundHandler(): (
     mobileWalletAdapter: SolanaMobileWalletAdapter,
 ) => Promise<void> {
     return defaultWalletNotFoundHandler;
 }
+
+/**
+ * @deprecated Use {@link createDefaultWalletNotFoundHandler} instead.
+ */
+export default createDefaultWalletNotFoundHandler;

--- a/js/packages/wallet-adapter-mobile/src/getIsSupported.ts
+++ b/js/packages/wallet-adapter-mobile/src/getIsSupported.ts
@@ -1,4 +1,4 @@
-export default function getIsSupported() {
+export function getIsSupported() {
     return (
         typeof window !== 'undefined' &&
         window.isSecureContext &&
@@ -6,3 +6,8 @@ export default function getIsSupported() {
         /android/i.test(navigator.userAgent)
     );
 }
+
+/**
+ * @deprecated Use {@link getIsSupported} instead.
+ */
+export default getIsSupported;

--- a/js/packages/wallet-adapter-mobile/src/index.ts
+++ b/js/packages/wallet-adapter-mobile/src/index.ts
@@ -1,4 +1,4 @@
 export * from './adapter.js';
-export { default as createDefaultAddressSelector } from './createDefaultAddressSelector.js';
-export { default as createDefaultAuthorizationResultCache } from './createDefaultAuthorizationResultCache.js';
-export { default as createDefaultWalletNotFoundHandler } from './createDefaultWalletNotFoundHandler.js';
+export { createDefaultAddressSelector } from './createDefaultAddressSelector.js';
+export { createDefaultAuthorizationResultCache } from './createDefaultAuthorizationResultCache.js';
+export { createDefaultWalletNotFoundHandler } from './createDefaultWalletNotFoundHandler.js';

--- a/js/packages/wallet-adapter-mobile/test/__forks__react-native-createDefaultAuthorizationResultCache.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/__forks__react-native-createDefaultAuthorizationResultCache.test.ts
@@ -25,7 +25,7 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
     default: asyncStorage,
 }));
 
-import createDefaultAuthorizationResultCache from '../src/__forks__/react-native/createDefaultAuthorizationResultCache.js';
+import { createDefaultAuthorizationResultCache } from '../src/__forks__/react-native/createDefaultAuthorizationResultCache.js';
 
 beforeEach(() => {
     resetAsyncStorage();

--- a/js/packages/wallet-adapter-mobile/test/__forks__react-native-getIsSupported.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/__forks__react-native-getIsSupported.test.ts
@@ -8,7 +8,7 @@ vi.mock('react-native', () => ({
     Platform: platform,
 }));
 
-import getIsSupported from '../src/__forks__/react-native/getIsSupported.js';
+import { getIsSupported } from '../src/__forks__/react-native/getIsSupported.js';
 
 afterEach(() => {
     platform.OS = 'android';

--- a/js/packages/wallet-adapter-mobile/test/adapter.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/adapter.test.ts
@@ -31,7 +31,7 @@ const {
 }));
 
 vi.mock('../src/getIsSupported.js', () => ({
-    default: getIsSupportedMock,
+    getIsSupported: getIsSupportedMock,
 }));
 
 vi.mock('@solana-mobile/wallet-standard-mobile', async () => {

--- a/js/packages/wallet-adapter-mobile/test/createDefaultAddressSelector.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/createDefaultAddressSelector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import createDefaultAddressSelector from '../src/createDefaultAddressSelector.js';
+import { createDefaultAddressSelector } from '../src/createDefaultAddressSelector.js';
 
 describe('createDefaultAddressSelector', () => {
     it('falls back to the first address when there are multiple options', async () => {

--- a/js/packages/wallet-adapter-mobile/test/createDefaultAuthorizationResultCache.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/createDefaultAuthorizationResultCache.test.ts
@@ -4,7 +4,7 @@ import { base58FromUint8Array } from '@solana-mobile/mobile-wallet-adapter-proto
 import { type Authorization } from '@solana-mobile/wallet-standard-mobile';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import createDefaultAuthorizationResultCache from '../src/createDefaultAuthorizationResultCache.js';
+import { createDefaultAuthorizationResultCache } from '../src/createDefaultAuthorizationResultCache.js';
 
 const AUTHORIZATION_CACHE_KEY = 'SolanaMobileWalletAdapterDefaultAuthorizationCache';
 const SOLANA_MAINNET_CHAIN = 'solana:mainnet';

--- a/js/packages/wallet-adapter-mobile/test/createDefaultWalletNotFoundHandler.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/createDefaultWalletNotFoundHandler.test.ts
@@ -8,7 +8,7 @@ vi.mock('@solana-mobile/wallet-standard-mobile', () => ({
     defaultErrorModalWalletNotFoundHandler: mockDefaultErrorModalWalletNotFoundHandler,
 }));
 
-import createDefaultWalletNotFoundHandler from '../src/createDefaultWalletNotFoundHandler.js';
+import { createDefaultWalletNotFoundHandler } from '../src/createDefaultWalletNotFoundHandler.js';
 
 afterEach(() => {
     mockDefaultErrorModalWalletNotFoundHandler.mockReset();

--- a/js/packages/wallet-adapter-mobile/test/getIsSupported.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/getIsSupported.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import getIsSupported from '../src/getIsSupported.js';
+import { getIsSupported } from '../src/getIsSupported.js';
 
 const ANDROID_BROWSER_USER_AGENT =
     'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36';

--- a/js/packages/wallet-standard-mobile/src/__forks__/react-native/createDefaultAuthorizationCache.ts
+++ b/js/packages/wallet-standard-mobile/src/__forks__/react-native/createDefaultAuthorizationCache.ts
@@ -5,7 +5,7 @@ import { Authorization, AuthorizationCache } from '../../wallet.js';
 
 const CACHE_KEY = 'SolanaMobileWalletAdapterWalletStandardDefaultAuthorizationCache';
 
-export default function createDefaultAuthorizationCache(): AuthorizationCache {
+export function createDefaultAuthorizationCache(): AuthorizationCache {
     return {
         async clear() {
             try {
@@ -39,3 +39,8 @@ export default function createDefaultAuthorizationCache(): AuthorizationCache {
         },
     };
 }
+
+/**
+ * @deprecated Use {@link createDefaultAuthorizationCache} instead.
+ */
+export default createDefaultAuthorizationCache;

--- a/js/packages/wallet-standard-mobile/src/createDefaultAuthorizationCache.ts
+++ b/js/packages/wallet-standard-mobile/src/createDefaultAuthorizationCache.ts
@@ -4,7 +4,7 @@ import { Authorization, AuthorizationCache } from './wallet.js';
 
 const CACHE_KEY = 'SolanaMobileWalletAdapterDefaultAuthorizationCache';
 
-export default function createDefaultAuthorizationCache(): AuthorizationCache {
+export function createDefaultAuthorizationCache(): AuthorizationCache {
     let storage: Storage | null | undefined;
     try {
         storage = window.localStorage;
@@ -52,3 +52,8 @@ export default function createDefaultAuthorizationCache(): AuthorizationCache {
         },
     };
 }
+
+/**
+ * @deprecated Use {@link createDefaultAuthorizationCache} instead.
+ */
+export default createDefaultAuthorizationCache;

--- a/js/packages/wallet-standard-mobile/src/createDefaultChainSelector.ts
+++ b/js/packages/wallet-standard-mobile/src/createDefaultChainSelector.ts
@@ -2,7 +2,7 @@ import { SOLANA_MAINNET_CHAIN } from '@solana/wallet-standard-chains';
 
 import { ChainSelector } from './wallet.js';
 
-export default function createDefaultChainSelector(): ChainSelector {
+export function createDefaultChainSelector(): ChainSelector {
     return {
         async select(chains) {
             if (chains.length === 1) {
@@ -13,3 +13,8 @@ export default function createDefaultChainSelector(): ChainSelector {
         },
     };
 }
+
+/**
+ * @deprecated Use {@link createDefaultChainSelector} instead.
+ */
+export default createDefaultChainSelector;

--- a/js/packages/wallet-standard-mobile/src/createDefaultWalletNotFoundHandler.ts
+++ b/js/packages/wallet-standard-mobile/src/createDefaultWalletNotFoundHandler.ts
@@ -48,10 +48,15 @@ export async function defaultErrorModalWalletNotFoundHandler() {
     }
 }
 
-export default function createDefaultWalletNotFoundHandler(): (
+export function createDefaultWalletNotFoundHandler(): (
     mobileWalletAdapter: SolanaMobileWalletAdapterWallet,
 ) => Promise<void> {
     return async () => {
         defaultErrorModalWalletNotFoundHandler();
     };
 }
+
+/**
+ * @deprecated Use {@link createDefaultWalletNotFoundHandler} instead.
+ */
+export default createDefaultWalletNotFoundHandler;

--- a/js/packages/wallet-standard-mobile/src/index.ts
+++ b/js/packages/wallet-standard-mobile/src/index.ts
@@ -1,6 +1,5 @@
-export * from './wallet.js';
-export * from './initialize.js';
+export { createDefaultAuthorizationCache } from './createDefaultAuthorizationCache.js';
+export { createDefaultChainSelector } from './createDefaultChainSelector.js';
 export * from './createDefaultWalletNotFoundHandler.js';
-export { default as createDefaultAuthorizationCache } from './createDefaultAuthorizationCache.js';
-export { default as createDefaultChainSelector } from './createDefaultChainSelector.js';
-export { default as createDefaultWalletNotFoundHandler } from './createDefaultWalletNotFoundHandler.js';
+export * from './initialize.js';
+export * from './wallet.js';

--- a/js/packages/wallet-standard-mobile/test/createDefaultAuthorizationCache.react-native.test.ts
+++ b/js/packages/wallet-standard-mobile/test/createDefaultAuthorizationCache.react-native.test.ts
@@ -37,7 +37,7 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
     default: asyncStorage,
 }));
 
-import createDefaultAuthorizationCache from '../src/__forks__/react-native/createDefaultAuthorizationCache.js';
+import { createDefaultAuthorizationCache } from '../src/__forks__/react-native/createDefaultAuthorizationCache.js';
 
 beforeEach(() => {
     resetAsyncStorage();

--- a/js/packages/wallet-standard-mobile/test/createDefaultAuthorizationCache.test.ts
+++ b/js/packages/wallet-standard-mobile/test/createDefaultAuthorizationCache.test.ts
@@ -4,7 +4,7 @@ import { SOLANA_MAINNET_CHAIN } from '@solana/wallet-standard-chains';
 import { base58FromUint8Array } from '@solana-mobile/mobile-wallet-adapter-protocol/encoding';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import createDefaultAuthorizationCache from '../src/createDefaultAuthorizationCache.js';
+import { createDefaultAuthorizationCache } from '../src/createDefaultAuthorizationCache.js';
 import type { Authorization } from '../src/wallet.js';
 
 const AUTHORIZATION_CACHE_KEY = 'SolanaMobileWalletAdapterDefaultAuthorizationCache';

--- a/js/packages/wallet-standard-mobile/test/createDefaultChainSelector.test.ts
+++ b/js/packages/wallet-standard-mobile/test/createDefaultChainSelector.test.ts
@@ -1,7 +1,7 @@
 import { SOLANA_DEVNET_CHAIN, SOLANA_MAINNET_CHAIN, SOLANA_TESTNET_CHAIN } from '@solana/wallet-standard-chains';
 import { describe, expect, it } from 'vitest';
 
-import createDefaultChainSelector from '../src/createDefaultChainSelector.js';
+import { createDefaultChainSelector } from '../src/createDefaultChainSelector.js';
 
 describe('createDefaultChainSelector', () => {
     it('falls back to the first chain when mainnet is absent', async () => {

--- a/js/packages/wallet-standard-mobile/test/createDefaultWalletNotFoundHandler.test.ts
+++ b/js/packages/wallet-standard-mobile/test/createDefaultWalletNotFoundHandler.test.ts
@@ -37,7 +37,8 @@ vi.mock('../src/wallet.js', () => ({
     SolanaMobileWalletAdapterWallet: class SolanaMobileWalletAdapterWallet {},
 }));
 
-import createDefaultWalletNotFoundHandler, {
+import {
+    createDefaultWalletNotFoundHandler,
     defaultErrorModalWalletNotFoundHandler,
 } from '../src/createDefaultWalletNotFoundHandler.js';
 


### PR DESCRIPTION
Add named exports for the default-export helper modules in the protocol, wallet adapter, and wallet standard packages.

Keep the existing default aliases with JSDoc deprecation annotations and update internal imports, root re-exports, tests, and mocks to use the named exports.