### PR TITLE
chore(ci): pin workflow actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,9 +20,9 @@ jobs:
 
     steps:
       # Setup
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -46,7 +46,7 @@ jobs:
         run: ./gradlew build
 
       # Upload binaries to workflow artifacts
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ github.event_name != 'pull_request' }}
         with:
           name: binaries
@@ -61,7 +61,7 @@ jobs:
           retention-days: 5
 
       # Upload javadoc to workflow artifacts
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ github.event_name != 'pull_request' }}
         with:
           name: clientlib-javadoc
@@ -70,7 +70,7 @@ jobs:
             !android/clientlib/build/docs/**/*.zip
           if-no-files-found: error
           retention-days: 1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ github.event_name != 'pull_request' }}
         with:
           name: common-javadoc
@@ -79,7 +79,7 @@ jobs:
             !android/common/build/docs/**/*.zip
           if-no-files-found: error
           retention-days: 1
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ github.event_name != 'pull_request' }}
         with:
           name: walletlib-javadoc
@@ -112,28 +112,28 @@ jobs:
 
     steps:
       # Setup
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.9.16"
           architecture: "x64"
       - name: set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
       # Caching
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       # Create Genymotion instance
       - name: Start Genymotion Cloud SaaS instance
-        uses:  genymobile/genymotion-saas-github-action@v1
+        uses:  genymobile/genymotion-saas-github-action@2329faa7f6c4417645abaabfd2bd955f44149cf1 # v1
         with:
           api_token: ${{ secrets.GMSAAS_API_KEY }}
           recipe_uuid: ${{ matrix.recipe_uuid }}
@@ -149,14 +149,14 @@ jobs:
       # Archive test results
       - name: Archive fakewallet test results
         if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fakewallet-connected-test-results-${{ matrix.api-level }}
           path: android/fakewallet/build/reports/androidTests/connected/
           retention-days: 7
       - name: Archive fakedapp test results
         if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fakedapp-connected-test-results-${{ matrix.api-level }}
           path: android/fakedapp/build/reports/androidTests/connected/
@@ -171,7 +171,7 @@ jobs:
 
     steps:
       - name: Update clientlib javadoc
-        uses: solana-mobile/gha-commit-artifact-to-branch@v2
+        uses: solana-mobile/gha-commit-artifact-to-branch@4d6e4715d4d7eb83771e2e9d88bc11087c697682 # v2
         with:
           token: ${{ secrets.UPDATE_GITHUB_PAGES_TOKEN }}
           branch: gh-pages
@@ -179,7 +179,7 @@ jobs:
           dest: clientlib
           commit-message: 'Update clientlib javadoc'
       - name: Update common javadoc
-        uses: solana-mobile/gha-commit-artifact-to-branch@v2
+        uses: solana-mobile/gha-commit-artifact-to-branch@4d6e4715d4d7eb83771e2e9d88bc11087c697682 # v2
         with:
           token: ${{ secrets.UPDATE_GITHUB_PAGES_TOKEN }}
           branch: gh-pages
@@ -187,7 +187,7 @@ jobs:
           dest: common
           commit-message: 'Update common javadoc'
       - name: Update walletlib javadoc
-        uses: solana-mobile/gha-commit-artifact-to-branch@v2
+        uses: solana-mobile/gha-commit-artifact-to-branch@4d6e4715d4d7eb83771e2e9d88bc11087c697682 # v2
         with:
           token: ${{ secrets.UPDATE_GITHUB_PAGES_TOKEN }}
           branch: gh-pages
@@ -204,19 +204,19 @@ jobs:
     if: ${{ github.event_name == 'release' && !github.event.repository.fork }}
 
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binaries
           path: binaries
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: clientlib-javadoc
           path: clientlib-javadoc
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: common-javadoc
           path: common-javadoc
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: walletlib-javadoc
           path: walletlib-javadoc

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -28,24 +28,24 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.PR_BOT_APP_ID }}
           private-key: ${{ secrets.PR_BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
 
       - name: set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           cache: true
           cache_dependency_path: 'js/pnpm-lock.yaml'
@@ -89,24 +89,24 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.PR_BOT_APP_ID }}
           private-key: ${{ secrets.PR_BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
 
       - name: set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           cache: true
           cache_dependency_path: 'js/pnpm-lock.yaml'
@@ -116,7 +116,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create Release PR or Publish to npm
-        uses: changesets/action@001cd79f0a536e733315164543a727bdf2d70aff # v1.5.1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           publish: pnpm publish-packages
           commit: "chore: version packages"

--- a/.github/workflows/example-ktx.yml
+++ b/.github/workflows/example-ktx.yml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
       # Setup
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/example-rn.yml
+++ b/.github/workflows/example-rn.yml
@@ -16,28 +16,28 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           cache: true
           cache_dependency_path: 'examples/example-react-native-*/pnpm-lock.yaml'
           package_json_file: 'js/package.json'
 
       - name: set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: 'Build Project'
         working-directory: 'js/'

--- a/.github/workflows/example-web.yml
+++ b/.github/workflows/example-web.yml
@@ -16,15 +16,15 @@ jobs:
       NEXT_PUBLIC_REFLECTOR_HOST_AUTHORITY:  ${{ secrets.URL_REFLECTOR_DEV }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           cache: true
           cache_dependency_path: 'examples/example-web-app/pnpm-lock.yaml'
@@ -47,7 +47,7 @@ jobs:
         working-directory: 'examples/example-web-app/'
         run: pnpm build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: example-web-app
           path: examples/example-web-app/out/*
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Update Example Web App
-        uses: solana-mobile/gha-commit-artifact-to-branch@v2
+        uses: solana-mobile/gha-commit-artifact-to-branch@4d6e4715d4d7eb83771e2e9d88bc11087c697682 # v2
         with:
           token: ${{ secrets.UPDATE_GITHUB_PAGES_TOKEN }}
           branch: gh-pages

--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -17,28 +17,28 @@ jobs:
         version: [ 52, 53, 54, latest]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           cache: true
           cache_dependency_path: 'js/pnpm-lock.yaml'
           package_json_file: 'js/package.json'
 
       - name: set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: 'Build Project'
         working-directory: 'js/'

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -16,15 +16,15 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           cache: true
           cache_dependency_path: 'js/pnpm-lock.yaml'

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -12,4 +12,4 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v4
+      - uses: dessant/label-actions@65225c179d3b2502f6eda7b3d15101a3f412366b # v5.0.3

--- a/.github/workflows/react-native.yml
+++ b/.github/workflows/react-native.yml
@@ -20,28 +20,28 @@ jobs:
         version: [ 74, 80, latest]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           cache: true
           cache_dependency_path: 'js/pnpm-lock.yaml'
           package_json_file: 'js/package.json'
 
       - name: set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: 'Build Project'
         working-directory: 'js/'

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -20,10 +20,10 @@ jobs:
       BUNDLE_WITHOUT: 'development'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: '3.1'
           bundler-cache: true
@@ -46,7 +46,7 @@ jobs:
         working-directory: spec
 
       # Upload spec jekyll site to workflow artifacts
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spec-jekyll-site
           path: spec/_site/*
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Update spec jekyll site
-        uses: solana-mobile/gha-commit-artifact-to-branch@v2
+        uses: solana-mobile/gha-commit-artifact-to-branch@4d6e4715d4d7eb83771e2e9d88bc11087c697682 # v2
         with:
           token: ${{ secrets.UPDATE_GITHUB_PAGES_TOKEN }}
           branch: gh-pages


### PR DESCRIPTION
Pin GitHub Actions workflow steps to explicit action SHAs with version comments across the repository CI workflows.

Update action versions used by the Android, JavaScript, example app, release, and documentation workflows.

This works well in line with our dependabot config that will now update hash + version tag.