### PR TITLE
chore(deps): configure JS dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,14 @@ updates:
     schedule:
       interval: "weekly"
 
+  # Mobile Wallet Adapter JavaScript SDK and TypeScript examples
+  - cooldown:
+      default-days: 5
+    directories:
+      - "/examples/example-react-native-app"
+      - "/examples/example-react-native-wallet"
+      - "/examples/example-web-app"
+      - "/js"
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"

--- a/examples/example-react-native-app/pnpm-workspace.yaml
+++ b/examples/example-react-native-app/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 7200

--- a/examples/example-react-native-wallet/pnpm-workspace.yaml
+++ b/examples/example-react-native-wallet/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 7200

--- a/examples/example-web-app/pnpm-workspace.yaml
+++ b/examples/example-web-app/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 7200

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
+minimumReleaseAge: 7200
 packages:
     - 'packages/*'


### PR DESCRIPTION
Add weekly Dependabot npm updates for the JS SDK and TypeScript example projects.

Set pnpm minimumReleaseAge to five days across the independent pnpm project roots so local installs follow the same release-age window.