### PR TITLE
fix(android): fix namespace collision in clientlib-ktx

### DIFF
--- a/android/clientlib-ktx/build.gradle
+++ b/android/clientlib-ktx/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.solana.mobilewalletadapter.clientlib"
+    namespace = "com.solana.mobilewalletadapter.clientlib.ktx"
 
     compileSdk 36
 


### PR DESCRIPTION
### Description
This PR resolves the Android Gradle Plugin build failure caused by a namespace collision between `clientlib` and `clientlib-ktx`. Both modules were using the exact same namespace, which is prohibited in AGP 8.0+.

Changed the namespace of `clientlib-ktx` to `com.solana.mobilewalletadapter.clientlib.ktx`.

### Related Issues
Closes #1530