### PR TITLE
chore(ci): parallelize smoke app builds

### DIFF
--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -9,11 +9,19 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.example.name }} (${{ matrix.version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
+        example:
+          - name: App
+            package_name: mobile-wallet-adapter-protocol
+            suffix: app
+          - name: Wallet
+            package_name: mobile-wallet-adapter-walletlib
+            suffix: wallet
         version: [ 52, 53, 54, latest]
 
     steps:
@@ -46,46 +54,24 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
 
-      - name: 'Setup Expo App'
+      - name: 'Setup Expo ${{ matrix.example.name }}'
         working-directory: 'js/'
         run: |
           if [ "${{ matrix.version }}" = "latest" ]; then
-            npx -y create-expo-app expo-${{ matrix.version }}-app --template blank
+            npx -y create-expo-app expo-${{ matrix.version }}-${{ matrix.example.suffix }} --template blank
           else
-            npx -y create-expo-app expo-${{ matrix.version }}-app --template blank@sdk-${{ matrix.version }}
+            npx -y create-expo-app expo-${{ matrix.version }}-${{ matrix.example.suffix }} --template blank@sdk-${{ matrix.version }}
           fi
 
-      - name: 'Install mobile-wallet-adapter-protocol'
+      - name: 'Install ${{ matrix.example.package_name }}'
         working-directory: 'js/'
         run: |
-          cd expo-${{ matrix.version }}-app
-          npm install file:../packages/mobile-wallet-adapter-protocol
+          cd expo-${{ matrix.version }}-${{ matrix.example.suffix }}
+          npm install file:../packages/${{ matrix.example.package_name }}
 
-      - name: 'Build Expo App'
+      - name: 'Build Expo ${{ matrix.example.name }}'
         working-directory: 'js/'
         run: |
-          cd expo-${{ matrix.version }}-app
-          npx expo prebuild --no-install
-          cd android && ./gradlew assembleDebug --no-daemon --stacktrace
-
-      - name: 'Setup Expo Wallet'
-        working-directory: 'js/'
-        run: |
-          if [ "${{ matrix.version }}" = "latest" ]; then
-            npx -y create-expo-app expo-${{ matrix.version }}-wallet --template blank
-          else
-            npx -y create-expo-app expo-${{ matrix.version }}-wallet --template blank@sdk-${{ matrix.version }}
-          fi
-
-      - name: 'Install mobile-wallet-adapter-walletlib'
-        working-directory: 'js/'
-        run: |
-          cd expo-${{ matrix.version }}-wallet
-          npm install file:../packages/mobile-wallet-adapter-walletlib
-
-      - name: 'Build Expo Wallet'
-        working-directory: 'js/'
-        run: |
-          cd expo-${{ matrix.version }}-wallet
+          cd expo-${{ matrix.version }}-${{ matrix.example.suffix }}
           npx expo prebuild --no-install
           cd android && ./gradlew assembleDebug --no-daemon --stacktrace

--- a/.github/workflows/react-native.yml
+++ b/.github/workflows/react-native.yml
@@ -12,11 +12,19 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.example.name }} (${{ matrix.version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
+        example:
+          - name: App
+            package_name: mobile-wallet-adapter-protocol
+            suffix: App
+          - name: Wallet
+            package_name: mobile-wallet-adapter-walletlib
+            suffix: Wallet
         version: [ 74, 80, latest]
 
     steps:
@@ -49,44 +57,23 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
 
-      - name: 'Setup React Native App'
+      - name: 'Setup React Native ${{ matrix.example.name }}'
         working-directory: 'js/'
         run: |
           if [ "${{ matrix.version }}" = "latest" ]; then
-            npx @react-native-community/cli@latest init React${{ matrix.version }}App
+            npx @react-native-community/cli@latest init React${{ matrix.version }}${{ matrix.example.suffix }}
           else
-            npx @react-native-community/cli@latest init React${{ matrix.version }}App --version 0.${{ matrix.version }}.0
+            npx @react-native-community/cli@latest init React${{ matrix.version }}${{ matrix.example.suffix }} --version 0.${{ matrix.version }}.0
           fi
 
-      - name: 'Install mobile-wallet-adapter-protocol'
+      - name: 'Install ${{ matrix.example.package_name }}'
         working-directory: 'js/'
         run: |
-          cd React${{ matrix.version }}App
-          npm install file:../packages/mobile-wallet-adapter-protocol
-          
-      - name: 'Build React Native App'
-        working-directory: 'js/'
-        run: |
-          cd React${{ matrix.version }}App/android
-          ./gradlew assembleDebug --no-daemon --stacktrace
+          cd React${{ matrix.version }}${{ matrix.example.suffix }}
+          npm install file:../packages/${{ matrix.example.package_name }}
 
-      - name: 'Setup React Native Wallet'
+      - name: 'Build React Native ${{ matrix.example.name }}'
         working-directory: 'js/'
         run: |
-          if [ "${{ matrix.version }}" = "latest" ]; then
-            npx @react-native-community/cli@latest init React${{ matrix.version }}Wallet
-          else
-            npx @react-native-community/cli@latest init React${{ matrix.version }}Wallet --version 0.${{ matrix.version }}.0
-          fi
-
-      - name: 'Install mobile-wallet-adapter-walletlib'
-        working-directory: 'js/'
-        run: |
-          cd React${{ matrix.version }}Wallet
-          npm install file:../packages/mobile-wallet-adapter-walletlib
-          
-      - name: 'Build React Native Wallet'
-        working-directory: 'js/'
-        run: |
-          cd React${{ matrix.version }}Wallet/android
+          cd React${{ matrix.version }}${{ matrix.example.suffix }}/android
           ./gradlew assembleDebug --no-daemon --stacktrace


### PR DESCRIPTION
Fan out Expo and React Native smoke workflows by app type so app and wallet builds run as separate matrix jobs for each version.

Keep the shared setup and project build steps in each matrix entry before installing and building the package under test.