### PR TITLE
Support localnet sign-and-send in fakewallet

### DIFF
--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -493,6 +493,9 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
             ProtocolContract.CHAIN_SOLANA_TESTNET,
             ProtocolContract.CLUSTER_TESTNET ->
                 Uri.parse("https://api.testnet.solana.com")
+            // reaches a test validator on the host via `adb reverse tcp:8899 tcp:8899`
+            CHAIN_SOLANA_LOCALNET, CLUSTER_LOCALNET ->
+                Uri.parse("http://localhost:8899")
             else -> throw IllegalArgumentException("Unsupported chain/cluster: $chainOrCluster")
         }
     }
@@ -701,6 +704,8 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
 
     companion object {
         private val TAG = MobileWalletAdapterViewModel::class.simpleName
+        private const val CHAIN_SOLANA_LOCALNET = "solana:localnet"
+        private const val CLUSTER_LOCALNET = "localnet"
         private const val SOURCE_VERIFICATION_TIMEOUT_MS = 3000L
         private const val LOW_POWER_NO_CONNECTION_TIMEOUT_MS = 3000L
     }

--- a/android/fakewallet/src/main/res/xml/network_security_config.xml
+++ b/android/fakewallet/src/main/res/xml/network_security_config.xml
@@ -7,4 +7,8 @@
                 tools:ignore="AcceptsUserCertificates" />
         </trust-anchors>
     </base-config>
+    <!-- cleartext HTTP for localnet test validators -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
Map the solana:localnet chain identifier (and legacy localnet cluster
name) to http://localhost:8899 when handling signAndSendTransactions,
and permit cleartext HTTP to localhost in the network security config.

localhost reaches a test validator running on the development host via
adb reverse tcp:8899 tcp:8899, so dapps can now exercise the full
sign-and-send flow against a local validator with fakewallet.
