### PR TITLE
fix: stop MWA web installs from pulling in the React Native toolchain

### DIFF
--- a/js/.changeset/mobile-wallet-adapter-protocol-optional-react-native-peer.md
+++ b/js/.changeset/mobile-wallet-adapter-protocol-optional-react-native-peer.md
@@ -1,0 +1,9 @@
+---
+'@solana-mobile/mobile-wallet-adapter-protocol': minor
+---
+
+Declare `react-native` as an optional peer dependency.
+
+It was previously a required peer dependency, which npm 7 and later install automatically, so browser-only consumers were pulling the entire React Native toolchain into `node_modules` — roughly 32 MB of `react-native` itself, plus `metro` and the transitive advisories it carries — even though no browser code path imports it. React Native is reached only through the `react-native` export condition, so nothing about which code runs where has changed; only the manifest was wrong.
+
+React Native consumers are unaffected: they already depend on `react-native` directly, and an optional peer dependency resolves identically for them.

--- a/js/.changeset/wallet-adapter-mobile-optional-react-native-peers.md
+++ b/js/.changeset/wallet-adapter-mobile-optional-react-native-peers.md
@@ -1,0 +1,9 @@
+---
+'@solana-mobile/wallet-adapter-mobile': minor
+---
+
+Declare `react-native` and `@react-native-async-storage/async-storage` as optional peer dependencies, moving async-storage out of `optionalDependencies` and widening its accepted range to `^1.17.7 || ^2.0.0`, and load async-storage lazily.
+
+`react-native` was a required peer dependency and async-storage sat in `optionalDependencies`, both of which package managers install by default, so browser-only consumers were pulling the entire React Native toolchain — including `metro` and the transitive advisories it carries — into `node_modules`. Both packages are reached only through the `react-native` export condition, so which code runs where is unchanged; a browser-only install no longer contains `react-native`, `metro`, or async-storage.
+
+**Action required for React Native consumers that use the default authorization result cache.** If you call `createDefaultAuthorizationResultCache()`, add `@react-native-async-storage/async-storage` to your own app dependencies — it is no longer installed transitively. The release also adds runtime validation: async-storage is now resolved lazily, on first use, and `createDefaultAuthorizationResultCache()` throws a descriptive error when it is missing or unusable (such as when its native module has not been linked) instead of failing silently into an inert cache. Apps that pass their own `authorizationResultCache` never load async-storage and do not need it installed; the lazy `require` sits inside a `try` block, which Metro's default `allowOptionalDependencies` configuration treats as an optional dependency, so their builds keep working without it.

--- a/js/.changeset/wallet-standard-mobile-optional-async-storage-peer.md
+++ b/js/.changeset/wallet-standard-mobile-optional-async-storage-peer.md
@@ -1,0 +1,9 @@
+---
+'@solana-mobile/wallet-standard-mobile': minor
+---
+
+Move `@react-native-async-storage/async-storage` from `optionalDependencies` to an optional peer dependency, widen the accepted range to `^1.17.7 || ^2.0.0`, and load it lazily.
+
+`optionalDependencies` are installed by default by every package manager — "optional" means only that a failed install is tolerated, not that the package is skipped — so browser-only consumers were pulling async-storage and, through its own peer dependency on `react-native`, the entire React Native toolchain into `node_modules`. Together with the matching fix in `@solana-mobile/mobile-wallet-adapter-protocol`, a browser-only install of this package drops from about 207 MB to about 42 MB and from 334 packages to 93, and the seven high-severity `metro` advisories it used to surface in `npm audit` go away entirely. Downstream lockfiles will shrink substantially on the next update; that is this change taking effect, not packages going missing.
+
+**Action required for React Native consumers that use the default authorization cache.** If you call `createDefaultAuthorizationCache()`, add `@react-native-async-storage/async-storage` to your own app dependencies — it is no longer installed transitively. The release also adds runtime validation: async-storage is now resolved lazily, on first use, and `createDefaultAuthorizationCache()` throws a descriptive error when it is missing or unusable (such as when its native module has not been linked) instead of failing silently into an inert cache. Apps that pass their own `authorizationCache` never load async-storage and do not need it installed; the lazy `require` sits inside a `try` block, which Metro's default `allowOptionalDependencies` configuration treats as an optional dependency, so their builds keep working without it.

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -98,6 +98,11 @@
     "peerDependencies": {
         "react-native": ">0.74"
     },
+    "peerDependenciesMeta": {
+        "react-native": {
+            "optional": true
+        }
+    },
     "codegenConfig": {
         "name": "SolanaMobileWalletAdapter",
         "type": "all",

--- a/js/packages/wallet-adapter-mobile/package.json
+++ b/js/packages/wallet-adapter-mobile/package.json
@@ -54,8 +54,17 @@
         "prepublishOnly": "agadoo"
     },
     "peerDependencies": {
+        "@react-native-async-storage/async-storage": "^1.17.7 || ^2.0.0",
         "@solana/web3.js": "^1.98.4",
         "react-native": ">0.74"
+    },
+    "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+            "optional": true
+        },
+        "react-native": {
+            "optional": true
+        }
     },
     "dependencies": {
         "@solana-mobile/mobile-wallet-adapter-protocol": "workspace:^",
@@ -65,9 +74,6 @@
         "@solana/wallet-standard-features": "^1.3.0",
         "@wallet-standard/core": "^1.1.1",
         "tslib": "^2.8.1"
-    },
-    "optionalDependencies": {
-        "@react-native-async-storage/async-storage": "^1.17.7"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.98.4",

--- a/js/packages/wallet-adapter-mobile/src/__forks__/react-native/createDefaultAuthorizationResultCache.ts
+++ b/js/packages/wallet-adapter-mobile/src/__forks__/react-native/createDefaultAuthorizationResultCache.ts
@@ -1,29 +1,38 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AuthorizationResult } from '@solana-mobile/mobile-wallet-adapter-protocol';
 
 import { AuthorizationResultCache } from '../../adapter.js';
+import { getAsyncStorage } from './getAsyncStorage.js';
 
 const CACHE_KEY = 'SolanaMobileWalletAdapterDefaultAuthorizationCache';
 
+/**
+ * Creates the default {@link AuthorizationResultCache}, backed by
+ * `@react-native-async-storage/async-storage`. That package is an optional peer dependency and is
+ * resolved here, at creation: this throws a descriptive error when it is not installed or not
+ * usable (such as when its native module has not been linked). Apps that cannot provide it should
+ * supply their own `authorizationResultCache` instead.
+ */
 export function createDefaultAuthorizationResultCache(): AuthorizationResultCache {
+    // Resolved outside the try/catch blocks below, which would otherwise swallow the diagnostic.
+    const asyncStorage = getAsyncStorage('createDefaultAuthorizationResultCache');
     return {
         async clear() {
             try {
-                await AsyncStorage.removeItem(CACHE_KEY);
+                await asyncStorage.removeItem(CACHE_KEY);
                 // eslint-disable-next-line no-empty
             } catch {}
         },
         async get() {
             try {
                 return (
-                    (JSON.parse((await AsyncStorage.getItem(CACHE_KEY)) as string) as AuthorizationResult) || undefined
+                    (JSON.parse((await asyncStorage.getItem(CACHE_KEY)) as string) as AuthorizationResult) || undefined
                 );
                 // eslint-disable-next-line no-empty
             } catch {}
         },
         async set(authorizationResult: AuthorizationResult) {
             try {
-                await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(authorizationResult));
+                await asyncStorage.setItem(CACHE_KEY, JSON.stringify(authorizationResult));
                 // eslint-disable-next-line no-empty
             } catch {}
         },

--- a/js/packages/wallet-adapter-mobile/src/__forks__/react-native/getAsyncStorage.ts
+++ b/js/packages/wallet-adapter-mobile/src/__forks__/react-native/getAsyncStorage.ts
@@ -1,0 +1,64 @@
+// Declared structurally so the return type does not drift between the v1 and v2 `AsyncStorage`
+// declarations, both of which the optional peer range accepts.
+export type AsyncStorageLike = {
+    getItem(key: string): Promise<string | null>;
+    removeItem(key: string): Promise<void>;
+    setItem(key: string, value: string): Promise<void>;
+};
+
+/**
+ * Narrows a candidate to the {@link AsyncStorageLike} surface the caches call: `getItem`,
+ * `removeItem`, and `setItem` must all be functions.
+ */
+function isUsable(value: unknown): value is AsyncStorageLike {
+    if (value == null) {
+        return false;
+    }
+    const candidate = value as AsyncStorageLike;
+    return (
+        typeof candidate.getItem === 'function' &&
+        typeof candidate.removeItem === 'function' &&
+        typeof candidate.setItem === 'function'
+    );
+}
+
+/**
+ * Resolves the optional peer dependency, returning `undefined` when it cannot be loaded. The
+ * `require` must sit directly inside the `try` block: Metro's default configuration
+ * (`transformer.allowOptionalDependencies`) treats exactly that shape as an optional dependency,
+ * so apps that never call this keep building without the package installed.
+ */
+function loadAsyncStorageModule(): unknown {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        return require('@react-native-async-storage/async-storage');
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * `@react-native-async-storage/async-storage` is an optional peer dependency, so it is resolved
+ * lazily, on first use: apps that supply their own authorization cache never load it and do not
+ * need it installed. When it is missing or unusable - not installed, or its native module not
+ * linked - this throws a descriptive error instead of degrading into a silently inert cache.
+ *
+ * The package is CommonJS with a default export, so depending on the resolver the usable instance
+ * arrives under `.default` or as the module itself. Both shapes are accepted.
+ *
+ * @param caller Name of the public function requiring `AsyncStorage`, used in the error message.
+ * @param load Test seam for supplying module shapes. Defaults to requiring the real package.
+ */
+export function getAsyncStorage(caller: string, load: () => unknown = loadAsyncStorageModule): AsyncStorageLike {
+    const asyncStorageModule = load();
+    const defaultExport = (asyncStorageModule as { default?: unknown } | undefined)?.default;
+    const asyncStorage = [defaultExport, asyncStorageModule].find(isUsable);
+    if (asyncStorage === undefined) {
+        throw new Error(
+            `\`${caller}()\` requires \`@react-native-async-storage/async-storage\`, which could not be resolved ` +
+                'or is not usable. Check that it is installed and, on bare React Native, that its native module is ' +
+                'linked. Otherwise, supply your own authorization cache instead.',
+        );
+    }
+    return asyncStorage;
+}

--- a/js/packages/wallet-adapter-mobile/test/__forks__react-native-createDefaultAuthorizationResultCache.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/__forks__react-native-createDefaultAuthorizationResultCache.test.ts
@@ -21,8 +21,8 @@ const { asyncStorage, resetAsyncStorage } = vi.hoisted(() => {
     };
 });
 
-vi.mock('@react-native-async-storage/async-storage', () => ({
-    default: asyncStorage,
+vi.mock('../src/__forks__/react-native/getAsyncStorage.js', () => ({
+    getAsyncStorage: () => asyncStorage,
 }));
 
 import { createDefaultAuthorizationResultCache } from '../src/__forks__/react-native/createDefaultAuthorizationResultCache.js';

--- a/js/packages/wallet-standard-mobile/package.json
+++ b/js/packages/wallet-standard-mobile/package.json
@@ -60,8 +60,13 @@
         "qrcode": "^1.5.4",
         "tslib": "^2.8.1"
     },
-    "optionalDependencies": {
-        "@react-native-async-storage/async-storage": "^1.17.7"
+    "peerDependencies": {
+        "@react-native-async-storage/async-storage": "^1.17.7 || ^2.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@types/qrcode": "^1.5.5",

--- a/js/packages/wallet-standard-mobile/src/__forks__/react-native/createDefaultAuthorizationCache.ts
+++ b/js/packages/wallet-standard-mobile/src/__forks__/react-native/createDefaultAuthorizationCache.ts
@@ -1,21 +1,30 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { base58ToUint8Array } from '@solana-mobile/mobile-wallet-adapter-protocol/encoding';
 
 import { Authorization, AuthorizationCache } from '../../wallet.js';
+import { getAsyncStorage } from './getAsyncStorage.js';
 
 const CACHE_KEY = 'SolanaMobileWalletAdapterWalletStandardDefaultAuthorizationCache';
 
+/**
+ * Creates the default {@link AuthorizationCache}, backed by
+ * `@react-native-async-storage/async-storage`. That package is an optional peer dependency and is
+ * resolved here, at creation: this throws a descriptive error when it is not installed or not
+ * usable (such as when its native module has not been linked). Apps that cannot provide it should
+ * supply their own `authorizationCache` instead.
+ */
 export function createDefaultAuthorizationCache(): AuthorizationCache {
+    // Resolved outside the try/catch blocks below, which would otherwise swallow the diagnostic.
+    const asyncStorage = getAsyncStorage('createDefaultAuthorizationCache');
     return {
         async clear() {
             try {
-                await AsyncStorage.removeItem(CACHE_KEY);
+                await asyncStorage.removeItem(CACHE_KEY);
                 // eslint-disable-next-line no-empty
             } catch {}
         },
         async get() {
             try {
-                const parsed = JSON.parse((await AsyncStorage.getItem(CACHE_KEY)) as string) as Authorization;
+                const parsed = JSON.parse((await asyncStorage.getItem(CACHE_KEY)) as string) as Authorization;
                 if (parsed && parsed.accounts) {
                     const parsedAccounts = parsed.accounts.map((account) => {
                         return {
@@ -33,7 +42,7 @@ export function createDefaultAuthorizationCache(): AuthorizationCache {
         },
         async set(authorizationResult: Authorization) {
             try {
-                await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(authorizationResult));
+                await asyncStorage.setItem(CACHE_KEY, JSON.stringify(authorizationResult));
                 // eslint-disable-next-line no-empty
             } catch {}
         },

--- a/js/packages/wallet-standard-mobile/src/__forks__/react-native/getAsyncStorage.ts
+++ b/js/packages/wallet-standard-mobile/src/__forks__/react-native/getAsyncStorage.ts
@@ -1,0 +1,64 @@
+// Declared structurally so the return type does not drift between the v1 and v2 `AsyncStorage`
+// declarations, both of which the optional peer range accepts.
+export type AsyncStorageLike = {
+    getItem(key: string): Promise<string | null>;
+    removeItem(key: string): Promise<void>;
+    setItem(key: string, value: string): Promise<void>;
+};
+
+/**
+ * Narrows a candidate to the {@link AsyncStorageLike} surface the caches call: `getItem`,
+ * `removeItem`, and `setItem` must all be functions.
+ */
+function isUsable(value: unknown): value is AsyncStorageLike {
+    if (value == null) {
+        return false;
+    }
+    const candidate = value as AsyncStorageLike;
+    return (
+        typeof candidate.getItem === 'function' &&
+        typeof candidate.removeItem === 'function' &&
+        typeof candidate.setItem === 'function'
+    );
+}
+
+/**
+ * Resolves the optional peer dependency, returning `undefined` when it cannot be loaded. The
+ * `require` must sit directly inside the `try` block: Metro's default configuration
+ * (`transformer.allowOptionalDependencies`) treats exactly that shape as an optional dependency,
+ * so apps that never call this keep building without the package installed.
+ */
+function loadAsyncStorageModule(): unknown {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        return require('@react-native-async-storage/async-storage');
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * `@react-native-async-storage/async-storage` is an optional peer dependency, so it is resolved
+ * lazily, on first use: apps that supply their own authorization cache never load it and do not
+ * need it installed. When it is missing or unusable - not installed, or its native module not
+ * linked - this throws a descriptive error instead of degrading into a silently inert cache.
+ *
+ * The package is CommonJS with a default export, so depending on the resolver the usable instance
+ * arrives under `.default` or as the module itself. Both shapes are accepted.
+ *
+ * @param caller Name of the public function requiring `AsyncStorage`, used in the error message.
+ * @param load Test seam for supplying module shapes. Defaults to requiring the real package.
+ */
+export function getAsyncStorage(caller: string, load: () => unknown = loadAsyncStorageModule): AsyncStorageLike {
+    const asyncStorageModule = load();
+    const defaultExport = (asyncStorageModule as { default?: unknown } | undefined)?.default;
+    const asyncStorage = [defaultExport, asyncStorageModule].find(isUsable);
+    if (asyncStorage === undefined) {
+        throw new Error(
+            `\`${caller}()\` requires \`@react-native-async-storage/async-storage\`, which could not be resolved ` +
+                'or is not usable. Check that it is installed and, on bare React Native, that its native module is ' +
+                'linked. Otherwise, supply your own authorization cache instead.',
+        );
+    }
+    return asyncStorage;
+}

--- a/js/packages/wallet-standard-mobile/test/createDefaultAuthorizationCache.react-native.test.ts
+++ b/js/packages/wallet-standard-mobile/test/createDefaultAuthorizationCache.react-native.test.ts
@@ -33,8 +33,8 @@ const { asyncStorage, resetAsyncStorage } = vi.hoisted(() => {
     };
 });
 
-vi.mock('@react-native-async-storage/async-storage', () => ({
-    default: asyncStorage,
+vi.mock('../src/__forks__/react-native/getAsyncStorage.js', () => ({
+    getAsyncStorage: () => asyncStorage,
 }));
 
 import { createDefaultAuthorizationCache } from '../src/__forks__/react-native/createDefaultAuthorizationCache.js';

--- a/js/packages/wallet-standard-mobile/test/getAsyncStorage.react-native.test.ts
+++ b/js/packages/wallet-standard-mobile/test/getAsyncStorage.react-native.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getAsyncStorage } from '../src/__forks__/react-native/getAsyncStorage.js';
+
+const CALLER = 'createDefaultAuthorizationCache';
+const EXPECTED_ERROR = /`createDefaultAuthorizationCache\(\)` requires `@react-native-async-storage\/async-storage`/;
+
+function createAsyncStorage() {
+    return {
+        getItem: vi.fn(async () => null),
+        removeItem: vi.fn(async () => {}),
+        setItem: vi.fn(async () => {}),
+    };
+}
+
+describe('react-native getAsyncStorage fork', () => {
+    it('accepts a module whose default export is usable', () => {
+        const asyncStorage = createAsyncStorage();
+
+        expect(getAsyncStorage(CALLER, () => ({ default: asyncStorage }))).toBe(asyncStorage);
+    });
+
+    it('accepts a module that is itself usable', () => {
+        const asyncStorage = createAsyncStorage();
+
+        expect(getAsyncStorage(CALLER, () => asyncStorage)).toBe(asyncStorage);
+    });
+
+    // The loader returns `undefined` when the optional peer cannot be resolved; Metro's optional
+    // dependency handling defers that failure from build time to this call.
+    it('throws an error naming the caller when the module cannot be resolved', () => {
+        expect(() => getAsyncStorage(CALLER, () => undefined)).toThrow(EXPECTED_ERROR);
+    });
+
+    it('throws an error naming the caller when the module resolves but is unusable', () => {
+        expect(() => getAsyncStorage(CALLER, () => ({ default: {} }))).toThrow(EXPECTED_ERROR);
+    });
+
+    // The cache calls all three methods, so a partially usable export must be rejected too.
+    it('rejects a default export that is missing removeItem and setItem', () => {
+        expect(() => getAsyncStorage(CALLER, () => ({ default: { getItem: async () => null } }))).toThrow(
+            EXPECTED_ERROR,
+        );
+    });
+});

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
 
   packages/wallet-adapter-mobile:
     dependencies:
+      '@react-native-async-storage/async-storage':
+        specifier: ^1.17.7 || ^2.0.0
+        version: 2.2.0(react-native@0.84.0(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@5.0.10))
       '@solana-mobile/mobile-wallet-adapter-protocol':
         specifier: workspace:^
         version: link:../mobile-wallet-adapter-protocol
@@ -214,13 +217,12 @@ importers:
       shx:
         specifier: ^0.4.0
         version: 0.4.0
-    optionalDependencies:
-      '@react-native-async-storage/async-storage':
-        specifier: ^1.17.7
-        version: 1.24.0(react-native@0.84.0(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@5.0.10))
 
   packages/wallet-standard-mobile:
     dependencies:
+      '@react-native-async-storage/async-storage':
+        specifier: ^1.17.7 || ^2.0.0
+        version: 2.2.0(react-native@0.84.0(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@5.0.10))
       '@solana-mobile/mobile-wallet-adapter-protocol':
         specifier: workspace:^
         version: link:../mobile-wallet-adapter-protocol
@@ -258,10 +260,6 @@ importers:
       shx:
         specifier: ^0.4.0
         version: 0.4.0
-    optionalDependencies:
-      '@react-native-async-storage/async-storage':
-        specifier: ^1.17.7
-        version: 1.24.0(react-native@0.84.0(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@5.0.10))
 
 packages:
 
@@ -894,10 +892,10 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@react-native-async-storage/async-storage@1.24.0':
-    resolution: {integrity: sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==}
+  '@react-native-async-storage/async-storage@2.2.0':
+    resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
-      react-native: ^0.0.0-0 || >=0.60 <1.0
+      react-native: ^0.0.0-0 || >=0.65 <1.0
 
   '@react-native/assets-registry@0.84.0':
     resolution: {integrity: sha512-YiU9h1IN0pvvZsHbd03MaD7mE2q+ySaKMlE9tWK+3iiwtbEaMQOsMUuSJ1er2LU6ERMWfhfvCYgWpKRGOMeN8A==}
@@ -4848,11 +4846,10 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@react-native-async-storage/async-storage@1.24.0(react-native@0.84.0(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@5.0.10))':
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.84.0(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@5.0.10))':
     dependencies:
       merge-options: 3.0.4
       react-native: 0.84.0(@babel/core@7.29.7)(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(utf-8-validate@5.0.10)
-    optional: true
 
   '@react-native/assets-registry@0.84.0': {}
 
@@ -6865,8 +6862,7 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-plain-obj@2.1.0:
-    optional: true
+  is-plain-obj@2.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -7127,7 +7123,6 @@ snapshots:
   merge-options@3.0.4:
     dependencies:
       is-plain-obj: 2.1.0
-    optional: true
 
   merge-stream@2.0.0: {}
 


### PR DESCRIPTION
Browser-only consumers of @solana-mobile/wallet-standard-mobile and @solana-mobile/wallet-adapter-mobile were installing react-native, metro, and async-storage into node_modules (~207 MB, 334 packages, 7 high-severity metro audit findings) even though no browser code path imports them. Two manifest bugs caused this: mobile-wallet-adapter-protocol declared react-native as a required peer dependency, which npm 7+ auto-installs, and wallet-standard-mobile plus wallet-adapter-mobile listed @react-native-async-storage/async-storage in optionalDependencies, which every package manager installs by default.

Declare react-native as an optional peer dependency in mobile-wallet-adapter-protocol and wallet-adapter-mobile, and move async-storage to an optional peer dependency in wallet-standard-mobile and wallet-adapter-mobile with the range widened to ^1.17.7 || ^2.0.0 — as a peer the range now constrains the consumer's tree, and a v1-only range would hard-fail installation for apps already on async-storage v2. Both packages are reached only through the react-native export condition, so no code path moves; a browser-only install drops to ~42 MB, 93 packages, and zero audit findings.

Since async-storage is no longer installed transitively, resolve it lazily in a getAsyncStorage module next to each React Native fork: the require sits directly inside a try block, which Metro's default allowOptionalDependencies configuration treats as an optional dependency, so apps that supply their own authorization cache build and run without the package installed. When the default cache is created, the loader validates that getItem, setItem, and removeItem are all functions and throws a descriptive error when the package is missing or unusable (typically an unlinked native module) instead of degrading into a silently inert cache. Unit tests cover the accepted and rejected module shapes, and the behavior is verified end to end with Metro bundles built with and without async-storage installed.

Changesets included for all three packages; downstream lockfiles will shrink substantially on the next update.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * React Native and Async Storage are now optional peer dependencies where supported.
  * Added support for Async Storage versions `^1.17.7` and `^2.0.0`.
  * Default authorization caches validate storage availability and provide clear setup guidance when unavailable.
  * Improved compatibility with direct and CommonJS-wrapped module exports.

* **Bug Fixes**
  * Storage-resolution errors are no longer hidden during cache operations.

* **Tests**
  * Added coverage for supported storage formats and unavailable-storage errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->