### PR TITLE
fix: sign_messages payloads encoding typo (base64url vs base64)

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -915,7 +915,7 @@ sign_messages
 where:
 
 - `addresses`: one or more base64-encoded addresses of the accounts which should be used to sign `message`. These should be a subset of the addresses returned by [`authorize`](#authorize) for the current session's authorization.
-- `payloads`: one or more base64url-encoded message payloads to sign
+- `payloads`: one or more base64-encoded message payloads to sign
 
 ###### Result
 {: .no_toc }


### PR DESCRIPTION
Fixes a typo in the MWA spec: `sign_messages` request `payloads` entry specified base64***url*** encoding when it should be just `base64`. All clients implement the correct base64 encoding - this is just a typo in the sepc that thankfully has not been implemented as defined in the spec so its save to update here without a compatibility patch.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that message payloads for `sign_messages` must use standard Base64 encoding rather than Base64URL encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->