### PR TITLE
fix: skip Local Network Access gate on loopback-origin dapps

### DIFF
--- a/js/.changeset/loopback-origin-lna-exempt.md
+++ b/js/.changeset/loopback-origin-lna-exempt.md
@@ -1,0 +1,5 @@
+---
+'@solana-mobile/wallet-standard-mobile': patch
+---
+
+Fix connection deadlock on loopback-origin dapps (localhost dev via `adb reverse`). Local Network Access only gates requests that cross into a more private address space, so a page served from `localhost`, `*.localhost`, `127.0.0.0/8`, or `[::1]` fetching loopback is exempt — the browser never shows the permission prompt and the permission state can never leave "prompt", which left the connection hanging until the association timeout. Loopback origins now skip the permission gate entirely and go straight to the association intent; non-loopback origins keep the existing prompt flow.

--- a/js/packages/wallet-standard-mobile/src/getIsSupported.ts
+++ b/js/packages/wallet-standard-mobile/src/getIsSupported.ts
@@ -52,8 +52,42 @@ export function getIsPwaLaunchedAsApp() {
     return isAndroidTwa || isStandalone || isFullscreen || isMinimalUI;
 }
 
+/**
+ * Returns true when a hostname is a loopback host per the URL spec: `localhost`,
+ * `*.localhost`, any 127.0.0.0/8 address, or `[::1]`. Hostnames from
+ * `location.hostname` are already lowercased and normalized by the browser's URL parser.
+ */
+export function isLoopbackHost(hostname: string): boolean {
+    return (
+        hostname === 'localhost' ||
+        hostname.endsWith('.localhost') ||
+        hostname === '[::1]' ||
+        /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)
+    );
+}
+
+/** Returns true when the current page is served from a loopback origin. */
+function isLoopbackOrigin(): boolean {
+    return typeof window !== 'undefined' && !!window.location && isLoopbackHost(window.location.hostname);
+}
+
+/**
+ * Returns true when a local websocket connection to the wallet can be attempted without
+ * going through the Local Network Access permission flow: inside the Solana Mobile Web
+ * Shell, on a loopback origin (exempt from LNA gating), or in browsers that don't
+ * implement the LNA permission. Returns false when the permission exists but has not
+ * been granted.
+ */
 export async function isLocalWebSocketAvailable(): Promise<boolean> {
     if (typeof navigator !== 'undefined' && isSolanaMobileWebShell(navigator.userAgent)) {
+        return true;
+    }
+    if (isLoopbackOrigin()) {
+        // Local Network Access only gates requests that cross into a more private
+        // address space. A page served from a loopback origin (e.g. localhost dev
+        // via `adb reverse`) fetching loopback is same-space and exempt, so the
+        // permission state can never leave "prompt" — the browser will never show
+        // its prompt. The permission is irrelevant here; connect directly.
         return true;
     }
     try {
@@ -72,6 +106,13 @@ export async function isLocalWebSocketAvailable(): Promise<boolean> {
     }
 }
 
+/**
+ * Ensures the Local Network Access permission is granted before local association,
+ * walking the user through the permission prompt flow when the state is "prompt".
+ * Resolves immediately when the permission is granted, irrelevant (Web Shell, loopback
+ * origins), or unsupported by the browser. Throws a SolanaMobileWalletAdapterError when
+ * the permission is denied or the user cancels.
+ */
 export async function checkLocalNetworkAccessPermission(): Promise<void> {
     if (typeof navigator !== 'undefined' && isSolanaMobileWebShell(navigator.userAgent)) {
         // Solana Mobile Web Shell runs inside an Android WebView hosted by a
@@ -80,6 +121,13 @@ export async function checkLocalNetworkAccessPermission(): Promise<void> {
         // check throws even though the shell can still proceed with local
         // association. Keep this bypass scoped to the explicit Web Shell user
         // agent marker so the normal browser permission flow remains unchanged.
+        return;
+    }
+
+    if (isLoopbackOrigin()) {
+        // See isLocalWebSocketAvailable: loopback-origin pages are exempt from
+        // Local Network Access gating, so there is nothing to prompt for. Showing
+        // the permission modal here would deadlock — the state never changes.
         return;
     }
 

--- a/js/packages/wallet-standard-mobile/test/getIsSupported.loopback.test.ts
+++ b/js/packages/wallet-standard-mobile/test/getIsSupported.loopback.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url": "http://localhost:5173/"}
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { checkLocalNetworkAccessPermission, isLocalWebSocketAvailable } from '../src/getIsSupported.js';
+
+const ANDROID_BROWSER_USER_AGENT =
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Mobile Safari/537.36';
+
+// A page served from a loopback origin (the standard `adb reverse` localhost dev
+// workflow) is exempt from Local Network Access gating: the browser never shows a
+// prompt, so the permission state can never leave "prompt". Both gates must bypass
+// the permission query entirely or the connection flow deadlocks until timeout.
+describe('getIsSupported on a loopback origin', () => {
+    let permissionQuery: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        permissionQuery = vi.fn().mockResolvedValue({ onchange: null, state: 'prompt' });
+        Object.defineProperty(navigator, 'permissions', {
+            configurable: true,
+            value: { query: permissionQuery },
+        });
+        Object.defineProperty(navigator, 'userAgent', {
+            configurable: true,
+            value: ANDROID_BROWSER_USER_AGENT,
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('skips the local network access permission check without querying permissions', async () => {
+        expect(window.location.hostname).toBe('localhost');
+
+        await expect(checkLocalNetworkAccessPermission()).resolves.toBeUndefined();
+        expect(permissionQuery).not.toHaveBeenCalled();
+    });
+
+    it('treats the local web socket as available without querying permissions', async () => {
+        await expect(isLocalWebSocketAvailable()).resolves.toBe(true);
+        expect(permissionQuery).not.toHaveBeenCalled();
+    });
+});

--- a/js/packages/wallet-standard-mobile/test/getIsSupported.test.ts
+++ b/js/packages/wallet-standard-mobile/test/getIsSupported.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+// @vitest-environment-options {"url": "https://dapp.example.com/"}
 import {
     SolanaMobileWalletAdapterError,
     SolanaMobileWalletAdapterErrorCode,
@@ -107,6 +108,7 @@ import {
     getIsLocalAssociationSupported,
     getIsPwaLaunchedAsApp,
     getIsRemoteAssociationSupported,
+    isLoopbackHost,
     isSolanaMobileWebShell,
     isWebView,
 } from '../src/getIsSupported.js';
@@ -327,6 +329,19 @@ describe('getIsSupported helpers', () => {
 
         installBrowserGlobals({ isSecureContext: true, userAgent: ANDROID_BROWSER_USER_AGENT });
         expect(getIsRemoteAssociationSupported()).toBe(false);
+    });
+
+    it('recognizes loopback hosts', () => {
+        expect(isLoopbackHost('127.0.0.1')).toBe(true);
+        expect(isLoopbackHost('127.255.255.254')).toBe(true);
+        expect(isLoopbackHost('[::1]')).toBe(true);
+        expect(isLoopbackHost('app.localhost')).toBe(true);
+        expect(isLoopbackHost('localhost')).toBe(true);
+
+        expect(isLoopbackHost('128.0.0.1')).toBe(false);
+        expect(isLoopbackHost('192.168.1.1')).toBe(false);
+        expect(isLoopbackHost('dapp.example.com')).toBe(false);
+        expect(isLoopbackHost('notlocalhost')).toBe(false);
     });
 
     it('recognizes WebView user agents', () => {

--- a/js/packages/wallet-standard-mobile/test/wallet.test.ts
+++ b/js/packages/wallet-standard-mobile/test/wallet.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+// @vitest-environment-options {"url": "https://dapp.example.com/"}
 import { SOLANA_MAINNET_CHAIN } from '@solana/wallet-standard-chains';
 import {
     SolanaSignAndSendTransaction,


### PR DESCRIPTION
Per the LNA spec only requests crossing into a more private address space are gated, so a page served from a loopback origin (localhost dev via adb reverse) fetching loopback is exempt: the browser never shows the permission prompt, the permission state can never leave "prompt", and the connection deadlocked until the association timeout.

`isLocalWebSocketAvailable()` and `checkLocalNetworkAccessPermission()` now early-return on loopback origins (`localhost`, `*.localhost`, `127.0.0.0/8`, `[::1]`) before any `permissions.query` call, going straight to the association intent. Non-loopback origins keep the existing prompt flow.

Existing permission-flow tests are pinned to a non-loopback jsdom URL (the root vitest environmentOptions were not inherited by the per-package projects, so they were silently running on localhost) and a new loopback test file covers the bypass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wallet association for apps running on loopback addresses, including `localhost`, IPv4 loopback, and IPv6 loopback.
  - Local network permission prompts are now bypassed for loopback origins, allowing association to proceed directly.
  - Local WebSocket availability checks now work without prompting on loopback origins.
  - Existing permission flows remain unchanged for non-loopback websites.

- **Tests**
  - Added coverage for supported loopback host formats and permission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
