### PR TITLE
fix: fakewallet account label derivation index and RPC submit error reporting

### DIFF
--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/MobileWalletAdapterViewModel.kt
@@ -137,22 +137,25 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
         viewModelScope.launch {
             if (authorized) {
                 val accounts = (0 until numAccounts).map {
-                    val publicKeyBytes = request.request.addresses?.get(it)?.let { address ->
+                    request.request.addresses?.getOrNull(it)?.let { address ->
                         val keypair = getApplication<FakeWalletApplication>().keyRepository
                             .getKeypair(Base64.decode(address)) ?: return@let null
                         val publicKey = keypair.public as Ed25519PublicKeyParameters
                         Log.d(TAG, "Reusing known keypair (pub=${publicKey.encoded.contentToString()}) for authorize request")
-                        publicKey.encoded
-                    } ?: run {
-                        val keypair = if (it == 0) {
-                            getKeypair()
-                        } else {
-                            generateKeypair()
-                        }
+                        buildAccount(publicKey.encoded, "fakewallet account $it")
+                    } ?: if (it == 0) {
+                        // getKeypair() derives from the stored seed's account index when a
+                        // seed is active; label with that derivation index, not the payload index
+                        val keypair = getKeypair()
                         val publicKey = keypair.public as Ed25519PublicKeyParameters
-                        publicKey.encoded
+                        val derivationIndex = getApplication<FakeWalletApplication>()
+                            .keyRepository.getSeed()?.accountIndex
+                        buildAccount(publicKey.encoded, "fakewallet account ${derivationIndex ?: it}")
+                    } else {
+                        val keypair = generateKeypair()
+                        val publicKey = keypair.public as Ed25519PublicKeyParameters
+                        buildAccount(publicKey.encoded, "fakewallet account $it")
                     }
-                    buildAccount(publicKeyBytes, "fakewallet account $it")
                 }
                 request.request.completeWithAuthorize(accounts.toTypedArray(), null,
                     request.sourceVerificationState.authorizationScope.encodeToByteArray(), null)
@@ -418,9 +421,14 @@ class MobileWalletAdapterViewModel(application: Application) : AndroidViewModel(
                 )
                 Log.d(TAG, "All transactions submitted via RPC")
                 request.request.completeWithSignatures(request.signatures)
-            } catch (e: SendTransactionsUseCase.InvalidTransactionsException) {
+            } catch (e: SendTransactionsUseCase.SubmitTransactionsException) {
+                // the payloads were valid and signed; only RPC submission failed, so report
+                // not-submitted (with signatures for any transactions that did land)
                 Log.e(TAG, "Failed submitting transactions via RPC", e)
-                request.request.completeWithInvalidSignatures(e.valid)
+                val notSubmittedSignatures = Array(request.signatures.size) { i ->
+                    if (e.submitted[i]) request.signatures[i] else null
+                }
+                request.request.completeWithNotSubmitted(notSubmittedSignatures)
             }
         }
     }

--- a/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/usecase/SendTransactionsUseCase.kt
+++ b/android/fakewallet/src/main/java/com/solana/mobilewalletadapter/fakewallet/usecase/SendTransactionsUseCase.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -36,44 +37,49 @@ object SendTransactionsUseCase {
                 val transactionBase64 = Base64.encodeToString(transaction, Base64.NO_WRAP)
                 Log.d(TAG, "Sending transaction: '$transactionBase64' with minContextSlot=$minContextSlot")
 
-                val conn = URL(rpcUri.toString()).openConnection() as HttpURLConnection
-                conn.requestMethod = "POST"
-                conn.setRequestProperty("Content-Type", "application/json")
-                conn.readTimeout = TIMEOUT_MS
-                conn.connectTimeout = TIMEOUT_MS
-                conn.doOutput = true
-                conn.outputStream.use { outputStream ->
-                    outputStream.write(
-                        createSendTransactionRequest(
-                            transactionBase64,
-                            minContextSlot,
-                            commitment,
-                            skipPreflight,
-                            maxRetries
-                        ).encodeToByteArray()
-                    )
-                }
-                conn.connect()
-                signatures[i] = if (conn.responseCode == HttpURLConnection.HTTP_OK) {
-                    val result = conn.inputStream.use { inputStream ->
-                        inputStream.readBytes()
+                signatures[i] = try {
+                    val conn = URL(rpcUri.toString()).openConnection() as HttpURLConnection
+                    conn.requestMethod = "POST"
+                    conn.setRequestProperty("Content-Type", "application/json")
+                    conn.readTimeout = TIMEOUT_MS
+                    conn.connectTimeout = TIMEOUT_MS
+                    conn.doOutput = true
+                    conn.outputStream.use { outputStream ->
+                        outputStream.write(
+                            createSendTransactionRequest(
+                                transactionBase64,
+                                minContextSlot,
+                                commitment,
+                                skipPreflight,
+                                maxRetries
+                            ).encodeToByteArray()
+                        )
                     }
-                    try {
-                        parseSendTransactionResult(result)
-                    } catch (e: IllegalArgumentException) {
-                        Log.e(TAG, "sendTransaction did not return a signature, response=${String(result)}")
+                    conn.connect()
+                    if (conn.responseCode == HttpURLConnection.HTTP_OK) {
+                        val result = conn.inputStream.use { inputStream ->
+                            inputStream.readBytes()
+                        }
+                        try {
+                            parseSendTransactionResult(result)
+                        } catch (e: IllegalArgumentException) {
+                            Log.e(TAG, "sendTransaction did not return a signature, response=${String(result)}")
+                            null
+                        }
+                    } else {
+                        Log.e(TAG, "Failed sending transaction, response code=${conn.responseCode}")
                         null
                     }
-                } else {
-                    Log.e(TAG, "Failed sending transaction, response code=${conn.responseCode}")
+                } catch (e: IOException) {
+                    Log.e(TAG, "Failed sending transaction via RPC", e)
                     null
                 }
             }
 
             // Ensure all transactions were submitted successfully
-            val valid = signatures.map { signature -> signature != null }
-            if (valid.any { !it }) {
-                throw InvalidTransactionsException(valid.toBooleanArray())
+            val submitted = signatures.map { signature -> signature != null }
+            if (submitted.any { !it }) {
+                throw SubmitTransactionsException(submitted.toBooleanArray())
             }
         }
     }
@@ -129,5 +135,5 @@ object SendTransactionsUseCase {
     private val TAG = SendTransactionsUseCase::class.simpleName
     private const val TIMEOUT_MS = 20000
 
-    class InvalidTransactionsException(val valid: BooleanArray, message: String? = null, cause: Throwable? = null) : RuntimeException(message, cause)
+    class SubmitTransactionsException(val submitted: BooleanArray, message: String? = null, cause: Throwable? = null) : RuntimeException(message, cause)
 }


### PR DESCRIPTION
## Summary

Two fakewallet fixes:

- **Account label ignores derivation index**: `authorizeDapp` labeled accounts with the authorize-request payload index (always 0 for single-account auth), so with a stored seed on derivation index 1 dapps still saw "fakewallet account 0". The primary account is now labeled with the seed's derivation index when a seed is active. Reused-address and extra generated accounts keep the payload-index label, and the requested-address lookup is bounds-safe (`getOrNull`) so authorizing more accounts than the dapp requested falls back to generation instead of throwing.
- **RPC submit failures reported as "payloads invalid for signing"**: any RPC submission failure in `signAndSendTransactionsSend` (e.g. a `BlockhashNotFound` error) completed with `completeWithInvalidSignatures`, so the dapp got `-2/payloads invalid for signing` even though the payloads were fine and correctly signed. Submission failures — including transport-level `IOException`s, which previously left the request hanging — now complete with `completeWithNotSubmitted` (`-4`, keeping signatures for any transactions that did land), and `SendTransactionsUseCase.InvalidTransactionsException` is renamed to `SubmitTransactionsException` to match its meaning. Actual signing/parse failures still report invalid signatures from the signing step.

## Verification

- `./gradlew :fakewallet:test` passes; `:fakewallet:assembleDebug` builds both flavors.
- E2E on an emulator with fakewallet (v1) + fakedapp: generated a seed, set derivation index 1, authorized — the dapp's account spinner shows "fakewallet account 1". Sign-and-send on testnet hit a real `BlockhashNotFound` RPC error and the dapp received `NotSubmittedException: -4/transactions not submitted` instead of the old `-2/payloads invalid`.