### PR TITLE
fix: accept @solana/kit v8 alongside v7 in protocol packages

### DIFF
--- a/js/.changeset/widen-solana-kit-ranges.md
+++ b/js/.changeset/widen-solana-kit-ranges.md
@@ -1,0 +1,8 @@
+---
+'@solana-mobile/mobile-wallet-adapter-protocol': patch
+'@solana-mobile/mobile-wallet-adapter-protocol-kit': patch
+---
+
+Accept `@solana/kit` v8 alongside v7.
+
+`mobile-wallet-adapter-protocol-kit` widens its `@solana/kit` peer dependency and its `@solana/transaction-messages` / `@solana/transactions` dependencies to `^7.0.0 || ^8.0.0`, and `mobile-wallet-adapter-protocol` widens its `@solana/kit` dependency the same way. Apps on kit 8 previously ended up with a duplicate kit 7 tree in `node_modules` (and a peer-dependency conflict on `@solana/kit`); with the widened ranges everything dedupes against the app's kit tree, whichever major it uses. Every kit API these packages touch is unchanged between v7 and v8, so no code changes were needed.

--- a/js/packages/mobile-wallet-adapter-protocol-kit/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-kit/package.json
@@ -54,12 +54,12 @@
         "prepublishOnly": "agadoo"
     },
     "peerDependencies": {
-        "@solana/kit": "^7.0.0"
+        "@solana/kit": "^7.0.0 || ^8.0.0"
     },
     "dependencies": {
         "@solana-mobile/mobile-wallet-adapter-protocol": "workspace:^",
-        "@solana/transaction-messages": "^7.0.0",
-        "@solana/transactions": "^7.0.0"
+        "@solana/transaction-messages": "^7.0.0 || ^8.0.0",
+        "@solana/transactions": "^7.0.0 || ^8.0.0"
     },
     "devDependencies": {
         "@solana/keys": "^7.0.0",

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -83,7 +83,7 @@
     "dependencies": {
         "@noble/curves": "^2.2.0",
         "@noble/hashes": "^2.2.0",
-        "@solana/kit": "^7.0.0",
+        "@solana/kit": "^7.0.0 || ^8.0.0",
         "@solana/wallet-standard-features": "^1.3.0",
         "@solana/wallet-standard-util": "^1.1.2",
         "@wallet-standard/core": "^1.1.1"

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         specifier: ^2.2.0
         version: 2.3.0
       '@solana/kit':
-        specifier: ^7.0.0
+        specifier: ^7.0.0 || ^8.0.0
         version: 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/wallet-standard-features':
         specifier: ^1.3.0
@@ -103,13 +103,13 @@ importers:
         specifier: workspace:^
         version: link:../mobile-wallet-adapter-protocol
       '@solana/kit':
-        specifier: ^7.0.0
+        specifier: ^7.0.0 || ^8.0.0
         version: 7.0.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/transaction-messages':
-        specifier: ^7.0.0
+        specifier: ^7.0.0 || ^8.0.0
         version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions':
-        specifier: ^7.0.0
+        specifier: ^7.0.0 || ^8.0.0
         version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
     devDependencies:
       '@solana/keys':


### PR DESCRIPTION
## Summary

Apps that have upgraded to `@solana/kit` v8 currently get a duplicate kit 7 tree in `node_modules` when they install `@solana-mobile/mobile-wallet-adapter-protocol-kit`, plus an unresolvable peer-dependency conflict on `@solana/kit`. This PR widens the relevant ranges to `^7.0.0 || ^8.0.0` so installs dedupe against the app's kit tree, whichever major it uses:

- `mobile-wallet-adapter-protocol-kit`: `@solana/kit` peer dependency, and `@solana/transaction-messages` / `@solana/transactions` dependencies
- `mobile-wallet-adapter-protocol`: `@solana/kit` dependency (protocol-kit depends on this package, so without it every install would still drag in a kit 7 tree)

No code changes — every kit API these packages touch is identical in v7 and v8:

- `@solana/transactions`: `compileTransaction`, `getBase64EncodedWireTransaction`, `getTransactionDecoder`, `Transaction`
- `@solana/transaction-messages`: `TransactionMessage`, `TransactionMessageWithFeePayer`, `TransactionMessageWithLifetime` (types only)
- `@solana/keys`: `SignatureBytes` (type only)
- `@solana/kit` (in `mobile-wallet-adapter-protocol`): `getBase58Decoder`/`Encoder`, `getBase64Decoder`/`Encoder`, `getUtf8Decoder`/`Encoder`

The committed lockfile keeps resolving v7 (the existing resolutions satisfy the widened ranges), so CI continues to exercise the v7 combination while consumers are free to resolve v8.

## Verification

- With a temporary pnpm override forcing `@solana/kit` / `@solana/keys` / `@solana/transaction-messages` / `@solana/transactions` to `^8.0.0` (resolved to 8.1.0): `build` and `check-types` pass for both packages, and the protocol-kit vitest suite passes 8/8. The override was reverted before committing.
- Against the committed (v7) lockfile: `check-types`, `format:check`, and `changeset:check` all pass.

A patch changeset is included for both packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Added support for Solana Kit version 8 alongside version 7.
  - Updated compatibility for related transaction packages across the mobile wallet adapter packages.

- **Documentation**
  - Recorded patch releases for the updated package compatibility ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->