### PR TITLE
chore(changesets): fix kit version to protocol group and use calculated canary versions

### DIFF
--- a/js/.changeset/align-protocol-kit-version.md
+++ b/js/.changeset/align-protocol-kit-version.md
@@ -1,0 +1,5 @@
+---
+'@solana-mobile/mobile-wallet-adapter-protocol-kit': minor
+---
+
+Align the package version with `@solana-mobile/mobile-wallet-adapter-protocol` and `@solana-mobile/mobile-wallet-adapter-protocol-web3js`. The three protocol packages are now released together as a fixed group, so from this release onward they always share the same version number. This is a versioning change only; there are no code or API changes in this package beyond those listed separately.

--- a/js/.changeset/config.json
+++ b/js/.changeset/config.json
@@ -3,11 +3,19 @@
     "changelog": "@changesets/cli/changelog",
     "commit": false,
     "fixed": [
-        ["@solana-mobile/mobile-wallet-adapter-protocol", "@solana-mobile/mobile-wallet-adapter-protocol-web3js"]
+        [
+            "@solana-mobile/mobile-wallet-adapter-protocol",
+            "@solana-mobile/mobile-wallet-adapter-protocol-web3js",
+            "@solana-mobile/mobile-wallet-adapter-protocol-kit"
+        ]
     ],
     "linked": [],
     "access": "public",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": []
+    "ignore": [],
+    "snapshot": {
+        "useCalculatedVersion": true,
+        "prereleaseTemplate": "{tag}-{datetime}"
+    }
 }


### PR DESCRIPTION
## Summary

Two changes to `js/.changeset/config.json`:

- **Add `@solana-mobile/mobile-wallet-adapter-protocol-kit` to the existing `fixed` group** with `mobile-wallet-adapter-protocol` and `mobile-wallet-adapter-protocol-web3js`, so all three protocol packages release under the same version number. Changesets versions a fixed group from its highest current version, so with the pending changesets the kit package moves from `0.4.0` to `2.4.0` alongside the other two. A changeset (`align-protocol-kit-version.md`) documents the jump in the kit changelog.
- **Enable `snapshot.useCalculatedVersion`** (with an explicit `{tag}-{datetime}` prerelease template) so canary publishes are versioned from the version the next release will publish, instead of the `0.0.0-` prefix.

No workflow changes are needed. The `publish-canary` job already runs `changeset version --snapshot canary` and picks up the new config.

Once this merges, the changesets action will regenerate the release PR (#1642) with the kit package at `2.4.0`.

## Verification

Dry-run of `changeset version` with this config on current `main`:

| Package | Release | Canary |
| --- | --- | --- |
| `mobile-wallet-adapter-protocol` | `2.4.0` | `2.4.0-canary-20260909015632` |
| `mobile-wallet-adapter-protocol-web3js` | `2.4.0` | `2.4.0-canary-20260909015632` |
| `mobile-wallet-adapter-protocol-kit` | `2.4.0` | `2.4.0-canary-20260909015632` |
| `wallet-adapter-mobile` | `2.4.0` | `2.4.0-canary-20260909015632` |
| `wallet-standard-mobile` | `0.7.0` | `0.7.0-canary-20260909015632` |

`pnpm format:check` and `pnpm changeset:check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package release configuration to keep related wallet adapter packages on synchronized versions.
  - Added support for snapshot releases with calculated version numbers and timestamped prerelease labels.
  - Scheduled a minor release for the mobile wallet adapter protocol kit package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->