### PR TITLE
fix: declare the react-native export condition before browser

### DIFF
--- a/js/.changeset/react-native-export-condition-order.md
+++ b/js/.changeset/react-native-export-condition-order.md
@@ -1,0 +1,16 @@
+---
+'@solana-mobile/mobile-wallet-adapter-protocol': patch
+'@solana-mobile/mobile-wallet-adapter-protocol-web3js': patch
+'@solana-mobile/mobile-wallet-adapter-protocol-kit': patch
+'@solana-mobile/mobile-wallet-adapter-walletlib': patch
+'@solana-mobile/wallet-adapter-mobile': patch
+'@solana-mobile/wallet-standard-mobile': patch
+---
+
+Declare the `react-native` export condition before `browser`, and `types` first.
+
+Conditional exports are matched in the order the package declares them, not in the order the bundler lists its conditions. Metro asserts `browser` alongside `react-native` when bundling a native app, so with `browser` declared first a React Native app resolved to `index.browser.js` instead of `index.native.js`. That build keeps the `assertSecureContext()` call the native fork exists to avoid, so `transact()` threw `The mobile wallet adapter protocol must be used in a secure context (https)` on device.
+
+This is why the failure appeared with Expo SDK 53 and React Native 0.79, which enabled package exports by default; before that Metro used the legacy top-level `react-native` field, which was already correct and still is.
+
+Only the key order changed — no target paths were added, removed or repointed. Resolution is unchanged for browser, node, workerd, edge-light and TypeScript consumers; the only resolutions that move are React Native ones, which now reach the native build they were always meant to.

--- a/js/.changeset/react-native-export-condition-order.md
+++ b/js/.changeset/react-native-export-condition-order.md
@@ -13,4 +13,6 @@ Conditional exports are matched in the order the package declares them, not in t
 
 This is why the failure appeared with Expo SDK 53 and React Native 0.79, which enabled package exports by default; before that Metro used the legacy top-level `react-native` field, which was already correct and still is.
 
-Only the key order changed — no target paths were added, removed or repointed. Resolution is unchanged for browser, node, workerd, edge-light and TypeScript consumers; the only resolutions that move are React Native ones, which now reach the native build they were always meant to.
+Only the key order changed — no target paths were added, removed or repointed. The only resolutions that move are React Native ones, which now reach the native build they were always meant to; browser, node, workerd and edge-light are unaffected.
+
+`types` also moves to the front. TypeScript matches conditions in declaration order too, so with `types` last a consumer that also asserts a runtime condition could match a JavaScript entry before reaching `./lib/types/index.d.ts`. Declaring it first is what TypeScript documents, and it means the declaration file is selected ahead of any runtime condition.

--- a/js/packages/mobile-wallet-adapter-protocol-kit/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-kit/package.json
@@ -9,6 +9,8 @@
     },
     "license": "Apache-2.0",
     "exports": {
+        "types": "./lib/types/index.d.ts",
+        "react-native": "./lib/cjs/index.native.js",
         "edge-light": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
@@ -24,9 +26,7 @@
         "node": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
-        },
-        "react-native": "./lib/cjs/index.native.js",
-        "types": "./lib/types/index.d.ts"
+        }
     },
     "browser": {
         "./lib/cjs/index.js": "./lib/cjs/index.browser.js",

--- a/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol-web3js/package.json
@@ -9,6 +9,8 @@
     },
     "license": "Apache-2.0",
     "exports": {
+        "types": "./lib/types/index.d.ts",
+        "react-native": "./lib/cjs/index.native.js",
         "edge-light": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
@@ -24,9 +26,7 @@
         "node": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
-        },
-        "react-native": "./lib/cjs/index.native.js",
-        "types": "./lib/types/index.d.ts"
+        }
     },
     "browser": {
         "./lib/cjs/index.js": "./lib/cjs/index.browser.js",

--- a/js/packages/mobile-wallet-adapter-protocol/package.json
+++ b/js/packages/mobile-wallet-adapter-protocol/package.json
@@ -10,6 +10,8 @@
     "license": "Apache-2.0",
     "exports": {
         ".": {
+            "types": "./lib/types/index.d.ts",
+            "react-native": "./lib/cjs/index.native.js",
             "edge-light": {
                 "import": "./lib/esm/index.js",
                 "require": "./lib/cjs/index.js"
@@ -25,11 +27,11 @@
             "node": {
                 "import": "./lib/esm/index.js",
                 "require": "./lib/cjs/index.js"
-            },
-            "react-native": "./lib/cjs/index.native.js",
-            "types": "./lib/types/index.d.ts"
+            }
         },
         "./encoding": {
+            "types": "./lib/types/encoding.d.ts",
+            "react-native": "./lib/cjs/encoding.native.js",
             "edge-light": {
                 "import": "./lib/esm/encoding.js",
                 "require": "./lib/cjs/encoding.js"
@@ -45,9 +47,7 @@
             "node": {
                 "import": "./lib/esm/encoding.js",
                 "require": "./lib/cjs/encoding.js"
-            },
-            "react-native": "./lib/cjs/encoding.native.js",
-            "types": "./lib/types/encoding.d.ts"
+            }
         }
     },
     "browser": {

--- a/js/packages/mobile-wallet-adapter-protocol/test/packageExportsConditionOrder.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/packageExportsConditionOrder.test.ts
@@ -19,15 +19,36 @@ const PACKAGES_DIR = path.resolve(__dirname, '..', '..');
 type ExportsNode = string | null | ExportsNode[] | { [condition: string]: ExportsNode };
 type ConditionMap = Record<string, ExportsNode>;
 
+/**
+ * Reads a sibling workspace package's manifest.
+ *
+ * @param packageName Directory name of the package under `js/packages`.
+ * @returns The parsed manifest, of which only `exports` is of interest here.
+ */
 function readManifest(packageName: string): { exports?: ExportsNode } {
     return JSON.parse(readFileSync(path.join(PACKAGES_DIR, packageName, 'package.json'), 'utf8'));
 }
 
+/**
+ * Narrows an exports node to a condition map, excluding strings, `null` and fallback arrays.
+ *
+ * @param node A node from an `exports` field.
+ * @returns `true` when the node maps condition names to further nodes.
+ */
 function isConditionMap(node: ExportsNode | undefined): node is ConditionMap {
     return node != null && typeof node === 'object' && !Array.isArray(node);
 }
 
-/** Every subpath in an exports field, as `[subpath, conditions]` pairs. */
+/**
+ * Every subpath in an exports field, as `[subpath, conditions]` pairs.
+ *
+ * A manifest either maps subpaths (`"."`, `"./encoding"`) to condition maps, or is itself a single
+ * condition map for the root. Both shapes are in use across these packages, and each subpath carries
+ * its own ordering, so every one has to be checked rather than just `.`.
+ *
+ * @param exportsField The manifest's `exports` field.
+ * @returns One entry per subpath that declares conditions; empty when there are none.
+ */
 function conditionMapsBySubpath(exportsField: ExportsNode | undefined): [string, ConditionMap][] {
     if (!isConditionMap(exportsField)) {
         return [];
@@ -41,7 +62,17 @@ function conditionMapsBySubpath(exportsField: ExportsNode | undefined): [string,
         .filter((entry): entry is [string, ConditionMap] => isConditionMap(entry[1]));
 }
 
-/** Node's condition matching: first declared key that is asserted, or `default`, wins. */
+/**
+ * Node's condition matching: the first declared key that is asserted, or `default`, wins.
+ *
+ * Implemented here rather than pulled from a resolver library so the asserted conditions are exactly
+ * the ones named by the caller. Resolver libraries inject conditions of their own, which makes it
+ * look as though more environments are affected than actually are.
+ *
+ * @param node The condition map, or a target, to resolve.
+ * @param conditions The condition names the consuming bundler asserts.
+ * @returns The matched target, or `undefined` when nothing matches.
+ */
 function resolveWithConditions(node: ExportsNode, conditions: Set<string>): string | undefined {
     if (typeof node === 'string') {
         return node;

--- a/js/packages/mobile-wallet-adapter-protocol/test/packageExportsConditionOrder.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/packageExportsConditionOrder.test.ts
@@ -10,25 +10,35 @@ import { describe, expect, it } from 'vitest';
  * bundle. For these packages that means `transact` keeps its `assertSecureContext()` call, which
  * throws `The mobile wallet adapter protocol must be used in a secure context (https)` on a
  * device. See #1179 and #1302, which are the same defect reported twice.
+ *
+ * Every subpath is checked, not just `.`, since each one carries its own condition map.
  */
 
 const PACKAGES_DIR = path.resolve(__dirname, '..', '..');
 
 type ExportsNode = string | null | ExportsNode[] | { [condition: string]: ExportsNode };
+type ConditionMap = Record<string, ExportsNode>;
 
 function readManifest(packageName: string): { exports?: ExportsNode } {
     return JSON.parse(readFileSync(path.join(PACKAGES_DIR, packageName, 'package.json'), 'utf8'));
 }
 
-function rootConditions(exportsField: ExportsNode | undefined): Record<string, ExportsNode> | undefined {
-    if (exportsField == null || typeof exportsField !== 'object' || Array.isArray(exportsField)) {
-        return undefined;
+function isConditionMap(node: ExportsNode | undefined): node is ConditionMap {
+    return node != null && typeof node === 'object' && !Array.isArray(node);
+}
+
+/** Every subpath in an exports field, as `[subpath, conditions]` pairs. */
+function conditionMapsBySubpath(exportsField: ExportsNode | undefined): [string, ConditionMap][] {
+    if (!isConditionMap(exportsField)) {
+        return [];
     }
-    const hasSubpaths = Object.keys(exportsField).some((key) => key.startsWith('.'));
-    const root = hasSubpaths ? exportsField['.'] : exportsField;
-    return root != null && typeof root === 'object' && !Array.isArray(root)
-        ? (root as Record<string, ExportsNode>)
-        : undefined;
+    const subpaths = Object.keys(exportsField).filter((key) => key.startsWith('.'));
+    if (subpaths.length === 0) {
+        return [['.', exportsField]];
+    }
+    return subpaths
+        .map((subpath): [string, ExportsNode] => [subpath, exportsField[subpath]])
+        .filter((entry): entry is [string, ConditionMap] => isConditionMap(entry[1]));
 }
 
 /** Node's condition matching: first declared key that is asserted, or `default`, wins. */
@@ -59,21 +69,23 @@ function resolveWithConditions(node: ExportsNode, conditions: Set<string>): stri
     return undefined;
 }
 
-const packageNames = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+const cases = readdirSync(PACKAGES_DIR, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .filter((name) => {
+    .flatMap((entry) => {
+        let exportsField: ExportsNode | undefined;
         try {
-            return rootConditions(readManifest(name).exports) !== undefined;
+            exportsField = readManifest(entry.name).exports;
         } catch {
-            return false;
+            return [];
         }
+        return conditionMapsBySubpath(exportsField).map(([subpath, conditions]) => ({
+            conditions,
+            declared: Object.keys(conditions),
+            label: `${entry.name} ${subpath}`,
+        }));
     });
 
-describe.each(packageNames)('%s package.json exports', (packageName) => {
-    const conditions = rootConditions(readManifest(packageName).exports)!;
-    const declared = Object.keys(conditions);
-
+describe.each(cases)('$label exports conditions', ({ conditions, declared }) => {
     it.runIf(declared.includes('react-native') && declared.includes('browser'))(
         'declares `react-native` before `browser`',
         () => {

--- a/js/packages/mobile-wallet-adapter-protocol/test/packageExportsConditionOrder.test.ts
+++ b/js/packages/mobile-wallet-adapter-protocol/test/packageExportsConditionOrder.test.ts
@@ -1,0 +1,97 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Conditional exports are matched in the order the package declares them, not in the order the
+ * bundler lists its conditions. Metro asserts `browser` alongside `react-native` for native
+ * builds, so if `browser` is declared first a React Native app silently receives the browser
+ * bundle. For these packages that means `transact` keeps its `assertSecureContext()` call, which
+ * throws `The mobile wallet adapter protocol must be used in a secure context (https)` on a
+ * device. See #1179 and #1302, which are the same defect reported twice.
+ */
+
+const PACKAGES_DIR = path.resolve(__dirname, '..', '..');
+
+type ExportsNode = string | null | ExportsNode[] | { [condition: string]: ExportsNode };
+
+function readManifest(packageName: string): { exports?: ExportsNode } {
+    return JSON.parse(readFileSync(path.join(PACKAGES_DIR, packageName, 'package.json'), 'utf8'));
+}
+
+function rootConditions(exportsField: ExportsNode | undefined): Record<string, ExportsNode> | undefined {
+    if (exportsField == null || typeof exportsField !== 'object' || Array.isArray(exportsField)) {
+        return undefined;
+    }
+    const hasSubpaths = Object.keys(exportsField).some((key) => key.startsWith('.'));
+    const root = hasSubpaths ? exportsField['.'] : exportsField;
+    return root != null && typeof root === 'object' && !Array.isArray(root)
+        ? (root as Record<string, ExportsNode>)
+        : undefined;
+}
+
+/** Node's condition matching: first declared key that is asserted, or `default`, wins. */
+function resolveWithConditions(node: ExportsNode, conditions: Set<string>): string | undefined {
+    if (typeof node === 'string') {
+        return node;
+    }
+    if (node == null) {
+        return undefined;
+    }
+    if (Array.isArray(node)) {
+        for (const candidate of node) {
+            const resolved = resolveWithConditions(candidate, conditions);
+            if (resolved !== undefined) {
+                return resolved;
+            }
+        }
+        return undefined;
+    }
+    for (const condition of Object.keys(node)) {
+        if (condition === 'default' || conditions.has(condition)) {
+            const resolved = resolveWithConditions(node[condition], conditions);
+            if (resolved !== undefined) {
+                return resolved;
+            }
+        }
+    }
+    return undefined;
+}
+
+const packageNames = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => {
+        try {
+            return rootConditions(readManifest(name).exports) !== undefined;
+        } catch {
+            return false;
+        }
+    });
+
+describe.each(packageNames)('%s package.json exports', (packageName) => {
+    const conditions = rootConditions(readManifest(packageName).exports)!;
+    const declared = Object.keys(conditions);
+
+    it.runIf(declared.includes('react-native') && declared.includes('browser'))(
+        'declares `react-native` before `browser`',
+        () => {
+            expect(declared.indexOf('react-native')).toBeLessThan(declared.indexOf('browser'));
+        },
+    );
+
+    it.runIf(declared.includes('types'))('declares `types` first', () => {
+        expect(declared[0]).toBe('types');
+    });
+
+    it.runIf(declared.includes('react-native'))('resolves a React Native bundle to the native build', () => {
+        // The condition set Metro asserts for a native bundle once package exports are enabled,
+        // which React Native 0.79 and Expo SDK 53 turned on by default.
+        const resolved = resolveWithConditions(conditions, new Set(['react-native', 'browser', 'require']));
+
+        expect(resolved).toBeDefined();
+        expect(resolved).toContain('native');
+        expect(resolved).not.toContain('browser');
+    });
+});

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -6,12 +6,12 @@
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",
     "exports": {
+        "types": "./lib/types/index.d.ts",
+        "react-native": "./lib/esm/index.native.js",
         "node": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
-        },
-        "react-native": "./lib/esm/index.native.js",
-        "types": "./lib/types/index.d.ts"
+        }
     },
     "main": "lib/esm/index",
     "module": "lib/esm/index",

--- a/js/packages/wallet-adapter-mobile/package.json
+++ b/js/packages/wallet-adapter-mobile/package.json
@@ -9,6 +9,8 @@
     },
     "license": "Apache-2.0",
     "exports": {
+        "types": "./lib/types/index.d.ts",
+        "react-native": "./lib/cjs/index.native.js",
         "edge-light": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
@@ -24,9 +26,7 @@
         "node": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
-        },
-        "react-native": "./lib/cjs/index.native.js",
-        "types": "./lib/types/index.d.ts"
+        }
     },
     "browser": {
         "./lib/cjs/index.js": "./lib/cjs/index.browser.js",

--- a/js/packages/wallet-standard-mobile/package.json
+++ b/js/packages/wallet-standard-mobile/package.json
@@ -6,6 +6,8 @@
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",
     "exports": {
+        "types": "./lib/types/index.d.ts",
+        "react-native": "./lib/cjs/index.native.js",
         "edge-light": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
@@ -21,9 +23,7 @@
         "node": {
             "import": "./lib/esm/index.js",
             "require": "./lib/cjs/index.js"
-        },
-        "react-native": "./lib/cjs/index.native.js",
-        "types": "./lib/types/index.d.ts"
+        }
     },
     "browser": {
         "./lib/cjs/index.js": "./lib/cjs/index.browser.js",


### PR DESCRIPTION
Fixes #1302, and #1179 before it.

Conditional exports are matched in the order the package declares them, not the order the bundler lists its conditions. Metro asserts `browser` alongside `react-native` when it bundles a native app, so with `browser` declared first a React Native app resolves to `index.browser.js` and never reaches `index.native.js`. The browser build still calls `assertSecureContext()`, which is exactly what the `react-native` fork of `transact.ts` exists to avoid, so `transact()` throws ``The mobile wallet adapter protocol must be used in a secure context (`https`)`` on a device where `window.isSecureContext` is not true.

That is why this only started showing up with Expo SDK 53 and React Native 0.79. They enabled package exports by default; before that Metro read the legacy top-level `react-native` field, which was already correct and still is, and it had been quietly covering for the exports map.

`mobile-wallet-adapter-walletlib` is a useful control here. It is the only package that declares no `browser` condition, and it is the only one that already resolved correctly.

This also matters for #1639. That change moved `react-native` and async-storage to optional peers on the reasoning that both are reached only through the `react-native` export condition, which is only true if that condition is the one that actually matches.

The change is key order and nothing else. No target was added, removed or repointed — the manifests are content-identical if you ignore ordering. I checked resolution before and after against an exact implementation of Node's condition matching rather than a bundler, so no defaults get injected: five resolutions move, all of them React Native going from `index.browser.js` to `index.native.js`, and 49 others are untouched, including browser, node, workerd, edge-light and TypeScript. `types` also moves to the front, which TypeScript wants so it matches ahead of the runtime conditions.

`test/packageExportsConditionOrder.test.ts` walks every package that ships an exports map and asserts the ordering plus the resolution a Metro condition set produces. Against `main` as it stands it fails 16 times; with this change it passes. This is the same bug reported twice already, so the test is the part that actually matters.

One thing I left out on purpose: none of these maps declare a `default` condition, so a resolver that matches none of the declared ones resolves nothing at all. That looks like a real second bug, but it changes behaviour rather than ordering, so it seemed wrong to fold into this. Happy to do it separately if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed package resolution for React Native applications so native builds are selected consistently.
  - Prevented secure-context errors that could occur when using wallet functionality in Expo SDK 53 and React Native 0.79.
  - Improved TypeScript package resolution while preserving existing browser, Node.js, and other platform behavior.
  - Added validation to ensure package conditions resolve to the appropriate platform-specific targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->