### PR TITLE
fix(walletlib): stop advertising a CommonJS build that is never produced

### DIFF
--- a/js/.changeset/walletlib-drop-phantom-cjs-export.md
+++ b/js/.changeset/walletlib-drop-phantom-cjs-export.md
@@ -1,0 +1,9 @@
+---
+'@solana-mobile/mobile-wallet-adapter-walletlib': patch
+---
+
+Stop advertising a CommonJS build that is never produced.
+
+The `node` condition declared `"require": "./lib/cjs/index.js"`, but this package builds ESM only — `tsdown.config.ts` emits `format: 'esm'` into `lib/esm`, and `postbuild` writes only the `lib/esm` type marker. Nothing has produced `lib/cjs` since the build moved to tsdown, so the file was absent from the published tarball and `require('@solana-mobile/mobile-wallet-adapter-walletlib')` failed with `MODULE_NOT_FOUND` naming a path that had never existed.
+
+The `node` condition now points at the ESM build that is actually shipped. Importers are unaffected; `require` callers on Node 22.12 and later load it through `require(esm)`, and on older versions get a plain "cannot require an ES module" error instead of a missing-file one.

--- a/js/packages/mobile-wallet-adapter-walletlib/package.json
+++ b/js/packages/mobile-wallet-adapter-walletlib/package.json
@@ -6,10 +6,7 @@
     "repository": "https://github.com/solana-mobile/mobile-wallet-adapter",
     "license": "Apache-2.0",
     "exports": {
-        "node": {
-            "import": "./lib/esm/index.js",
-            "require": "./lib/cjs/index.js"
-        },
+        "node": "./lib/esm/index.js",
         "react-native": "./lib/esm/index.native.js",
         "types": "./lib/types/index.d.ts"
     },

--- a/js/packages/mobile-wallet-adapter-walletlib/test/packageExportsTargets.test.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/test/packageExportsTargets.test.ts
@@ -21,6 +21,17 @@ type ExportsNode = string | null | ExportsNode[] | { [condition: string]: Export
 
 const manifest: { exports?: ExportsNode } = JSON.parse(readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8'));
 
+/**
+ * Walks an exports field and collects every relative target it can resolve to.
+ *
+ * Targets can sit at any depth — nested condition maps, and fallback arrays — so the whole tree has
+ * to be walked rather than just its top level. Bare specifiers such as `react-native` are skipped;
+ * only `./`-prefixed paths point at files this package ships.
+ *
+ * @param node The `exports` field, or a node within it.
+ * @param found Accumulator, for the recursive calls.
+ * @returns Every relative target found, in declaration order and possibly with duplicates.
+ */
 function collectTargets(node: ExportsNode, found: string[] = []): string[] {
     if (typeof node === 'string') {
         if (node.startsWith('./')) {

--- a/js/packages/mobile-wallet-adapter-walletlib/test/packageExportsTargets.test.ts
+++ b/js/packages/mobile-wallet-adapter-walletlib/test/packageExportsTargets.test.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * This package builds ESM only — see `tsdown.config.ts`, which emits `format: 'esm'` into
+ * `lib/esm`. The manifest previously advertised a `require` target of `./lib/cjs/index.js`,
+ * which no build step produces and which was therefore absent from the published tarball, so
+ * `require('@solana-mobile/mobile-wallet-adapter-walletlib')` failed with MODULE_NOT_FOUND
+ * pointing at a file that had never existed.
+ *
+ * Guard against a manifest advertising output the build does not produce. CI builds before it
+ * tests, so the on-disk assertions run there; locally they are skipped until `pnpm build` has
+ * been run at least once.
+ */
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+
+type ExportsNode = string | null | ExportsNode[] | { [condition: string]: ExportsNode };
+
+const manifest: { exports?: ExportsNode } = JSON.parse(readFileSync(path.join(PACKAGE_ROOT, 'package.json'), 'utf8'));
+
+function collectTargets(node: ExportsNode, found: string[] = []): string[] {
+    if (typeof node === 'string') {
+        if (node.startsWith('./')) {
+            found.push(node);
+        }
+    } else if (Array.isArray(node)) {
+        for (const child of node) {
+            collectTargets(child, found);
+        }
+    } else if (node != null && typeof node === 'object') {
+        for (const child of Object.values(node)) {
+            collectTargets(child, found);
+        }
+    }
+    return found;
+}
+
+const targets = Array.from(new Set(collectTargets(manifest.exports ?? null)));
+const hasBeenBuilt = existsSync(path.join(PACKAGE_ROOT, 'lib'));
+
+describe('package.json exports targets', () => {
+    it('declares at least one target', () => {
+        expect(targets.length).toBeGreaterThan(0);
+    });
+
+    it('does not reference a CommonJS build this package does not emit', () => {
+        expect(targets.filter((target) => target.includes('/cjs/'))).toEqual([]);
+    });
+
+    it.runIf(hasBeenBuilt).each(targets)('%s exists on disk', (target) => {
+        expect(existsSync(path.join(PACKAGE_ROOT, target))).toBe(true);
+    });
+});


### PR DESCRIPTION
`require('@solana-mobile/mobile-wallet-adapter-walletlib')` fails:

```
Error: Cannot find module '.../node_modules/@solana-mobile/mobile-wallet-adapter-walletlib/lib/cjs/index.js'
    code: 'MODULE_NOT_FOUND'
```

The `node` condition declares `"require": "./lib/cjs/index.js"`, but this package builds ESM only. `tsdown.config.ts` emits `format: 'esm'` into `lib/esm`, and `postbuild` writes only the `lib/esm` type marker — compare the other packages, whose `postbuild` writes both `lib/cjs/package.json` and `lib/esm/package.json`. Nothing has produced `lib/cjs` since the build moved to tsdown, so the target has simply never existed.

I checked it two ways. The published 1.4.5 tarball contains `lib/esm` and `lib/types` and no cjs output whatsoever, and a local `turbo run build` emits the same two directories. I also walked the exports map of all six JS packages against their published tarballs — this is the only phantom target in the workspace, the other five are clean.

This points the `node` condition at the ESM build that actually ships. Importers are unaffected. `require` callers on Node 22.12+ load it through `require(esm)`, and on older versions get a plain "cannot require an ES module" error rather than a missing-file one.

If you would rather keep a real CJS entry, the alternative is adding a cjs format to this package's `tsdown.config.ts` and restoring the `lib/cjs` marker in `postbuild` — happy to do that version instead, just say which you prefer.

The test asserts every target in the exports map exists on disk after a build, and that the manifest does not reference a cjs directory this package does not emit. CI builds before it tests so the on-disk checks run there; they skip locally until `pnpm build` has been run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package loading for Node.js consumers using `require()`.
  * Updated package exports to point to the available ESM build, preventing missing-module errors.
  * Improved compatibility for supported Node.js versions while preserving clear errors on versions that cannot load ESM through `require()`.

* **Tests**
  * Added validation to ensure all published export targets exist and do not reference unavailable CommonJS builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->