### PR TITLE
fix(wallet-adapter-mobile): await underlying connection in connect methods

### DIFF
--- a/js/.changeset/wallet-adapter-mobile-connect-promise.md
+++ b/js/.changeset/wallet-adapter-mobile-connect-promise.md
@@ -1,0 +1,5 @@
+---
+'@solana-mobile/wallet-adapter-mobile': patch
+---
+
+Wait for `connect()` and `autoConnect()` to complete their underlying wallet connection and propagate connection failures to callers.

--- a/js/packages/wallet-adapter-mobile/src/adapter.ts
+++ b/js/packages/wallet-adapter-mobile/src/adapter.ts
@@ -197,11 +197,11 @@ abstract class BaseSolanaMobileWalletAdapter extends BaseSignInMessageSignerWall
     }
 
     async autoConnect(): Promise<void> {
-        this.#connect(true);
+        return await this.#connect(true);
     }
 
     async connect(): Promise<void> {
-        this.#connect();
+        return await this.#connect();
     }
 
     async #connect(autoConnect: boolean = false): Promise<void> {

--- a/js/packages/wallet-adapter-mobile/test/adapter.test.ts
+++ b/js/packages/wallet-adapter-mobile/test/adapter.test.ts
@@ -335,13 +335,54 @@ describe('adapter', () => {
 
         const firstConnect = adapter.connect();
         const secondConnect = adapter.connect();
+        let firstConnectSettled = false;
+        firstConnect.then(
+            () => {
+                firstConnectSettled = true;
+            },
+            () => {
+                firstConnectSettled = true;
+            },
+        );
         await flushPromises();
 
         expect(wallet.connectImpl).toHaveBeenCalledTimes(1);
+        expect(firstConnectSettled).toBe(false);
+        await expect(secondConnect).resolves.toBeUndefined();
 
         pendingConnect.resolve();
         await expect(firstConnect).resolves.toBeUndefined();
-        await expect(secondConnect).resolves.toBeUndefined();
+    });
+
+    it('wraps connection failures in WalletConnectionError', async () => {
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.connectImpl.mockRejectedValue('rejected');
+
+        await expect(adapter.connect()).rejects.toBeInstanceOf(WalletConnectionError);
+    });
+
+    it('waits for the underlying connection during autoConnect', async () => {
+        const pendingConnect = createDeferred<void>();
+        const { adapter, wallet } = createLocalAdapter();
+
+        wallet.connectImpl.mockImplementation(async () => pendingConnect.promise);
+
+        const autoConnect = adapter.autoConnect();
+        let autoConnectSettled = false;
+        autoConnect.then(
+            () => {
+                autoConnectSettled = true;
+            },
+            () => {
+                autoConnectSettled = true;
+            },
+        );
+        await flushPromises();
+
+        expect(autoConnectSettled).toBe(false);
+        pendingConnect.resolve();
+        await expect(autoConnect).resolves.toBeUndefined();
     });
 
     it('passes a silent connect request during autoConnect', async () => {


### PR DESCRIPTION


`connect()` and `autoConnect()` previously started `#connect()` without returning its promise. As a result, callers could observe the public method resolving before the Wallet Standard connection completed, and connection failures could be lost as unhandled promise rejections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Connection requests now wait for the underlying wallet connection to finish before completing.
  - Connection failures are now correctly reported to callers through `connect()` and `autoConnect()`.
  - Starting another connection while one is pending continues to behave predictably, without incorrectly resolving the first request early.

- **Tests**
  - Added coverage for pending connections, delayed auto-connect completion, and connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->